### PR TITLE
Support tax year 2026 deductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Japan Take-Home Pay Calculator will be documented in this file.
 
+## 2026-04-02
+
+### Updated
+
+- Support 2026 tax deduction changes to income tax basic deduction, employment income, and spouse/dependent deduction income threshold.
+
+- Updated National Pension contribution amount for FY2026.
+
 ## 2026-03-30
 
 ### Updated

--- a/src/__tests__/adjustment-credit.test.ts
+++ b/src/__tests__/adjustment-credit.test.ts
@@ -604,7 +604,7 @@ describe('Specific Relative Special Deduction (特定親族特別控除)', () =>
       isCohabiting: false,
       disability: 'none',
       income: {
-        grossEmploymentIncome: 1_300_000, // Net = 750,000 (qualifies for specific relative special)
+        grossEmploymentIncome: 1_490_000, // Net = 750,000 (qualifies for specific relative special)
         otherNetIncome: 0,
       },
     }

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -10,23 +10,23 @@ import { DEDUCTION_TYPES, type Dependent } from '../types/dependents'
 
 // --- Helper functions to test internal logic via public API ---
 
-function isEligibleForDependentDeduction(dependent: Dependent): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000);
+function isEligibleForDependentDeduction(dependent: Dependent, year?: number): boolean {
+  const result = calculateDependentDeductions([dependent], 5000000, year);
   return result.nationalTax.dependentDeduction > 0;
 }
 
-function isEligibleForSpouseDeduction(dependent: Dependent): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000);
+function isEligibleForSpouseDeduction(dependent: Dependent, year?: number): boolean {
+  const result = calculateDependentDeductions([dependent], 5000000, year);
   return result.nationalTax.spouseDeduction > 0;
 }
 
-function isEligibleForSpouseSpecialDeduction(dependent: Dependent): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000);
+function isEligibleForSpouseSpecialDeduction(dependent: Dependent, year?: number): boolean {
+  const result = calculateDependentDeductions([dependent], 5000000, year);
   return result.nationalTax.spouseSpecialDeduction > 0;
 }
 
-function isEligibleForSpecificRelativeSpecialDeduction(dependent: Dependent): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000);
+function isEligibleForSpecificRelativeSpecialDeduction(dependent: Dependent, year?: number): boolean {
+  const result = calculateDependentDeductions([dependent], 5000000, year);
   return result.nationalTax.specificRelativeDeduction > 0;
 }
 
@@ -42,7 +42,7 @@ function isElderlyDependent(dependent: Dependent): boolean {
   return result.nationalTax.dependentDeduction === 480000 || result.nationalTax.dependentDeduction === 580000;
 }
 
-function getSpouseSpecialDeduction(spouseNetIncome: number, taxpayerNetIncome: number) {
+function getSpouseSpecialDeduction(spouseNetIncome: number, taxpayerNetIncome: number, year?: number) {
   const spouse: Dependent = {
     id: 'test-spouse',
     relationship: 'spouse',
@@ -54,14 +54,14 @@ function getSpouseSpecialDeduction(spouseNetIncome: number, taxpayerNetIncome: n
       otherNetIncome: spouseNetIncome,
     },
   };
-  const result = calculateDependentDeductions([spouse], taxpayerNetIncome);
+  const result = calculateDependentDeductions([spouse], taxpayerNetIncome, year);
   return {
     national: result.nationalTax.spouseSpecialDeduction,
     residence: result.residenceTax.spouseSpecialDeduction
   };
 }
 
-function getSpecificRelativeDeduction(dependentNetIncome: number) {
+function getSpecificRelativeDeduction(dependentNetIncome: number, year?: number) {
   const dependent: Dependent = {
     id: 'test-child',
     relationship: 'child',
@@ -73,7 +73,7 @@ function getSpecificRelativeDeduction(dependentNetIncome: number) {
       otherNetIncome: dependentNetIncome,
     },
   };
-  const result = calculateDependentDeductions([dependent], 5000000);
+  const result = calculateDependentDeductions([dependent], 5000000, year);
   return {
     national: result.nationalTax.specificRelativeDeduction,
     residence: result.residenceTax.specificRelativeDeduction
@@ -106,11 +106,11 @@ function getSpouseDeduction(isElderly: boolean, taxpayerNetIncome: number) {
 /**
  * Tests for dependent deduction eligibility and calculations
  * 
- * These tests verify the 2025 tax reform thresholds are correctly applied:
- * - Dependent deduction: income ≤ 58万円 (changed from 48万円)
- * - Spouse deduction: income ≤ 58万円 (changed from 48万円)
- * - Spouse special deduction: 58万円 < income ≤ 133万円 (lower bound changed from 48万円)
- * - Specific relative deduction: 58万円 < income ≤ 123万円 (lower bound changed from 48万円, upper limit 123万円)
+ * These tests verify the 2026 tax reform thresholds are correctly applied:
+ * - Dependent deduction: income ≤ 62万円 (changed from 58万円 in R8)
+ * - Spouse deduction: income ≤ 62万円 (changed from 58万円 in R8)
+ * - Spouse special deduction: 62万円 < income ≤ 133万円 (lower bound changed from 58万円 in R8)
+ * - Specific relative deduction: 62万円 < income ≤ 123万円 (lower bound changed from 58万円 in R8)
  * 
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1191.htm
@@ -119,8 +119,8 @@ function getSpouseDeduction(isElderly: boolean, taxpayerNetIncome: number) {
  */
 
 describe('Dependent Deduction Eligibility (扶養控除)', () => {
-  describe('At 58万円 threshold (2025 reform)', () => {
-    it('qualifies with income at exactly 580,000 yen', () => {
+  describe('At 62万円 threshold (2026 reform)', () => {
+    it('qualifies with income at exactly 620,000 yen', () => {
       const dependent: Dependent = {
         id: '1',
         relationship: 'child',
@@ -128,14 +128,14 @@ describe('Dependent Deduction Eligibility (扶養控除)', () => {
         isCohabiting: false,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_000, // Net = 580,000
+          grossEmploymentIncome: 1_360_000, // Net = 620,000
           otherNetIncome: 0,
         },
       }
       expect(isEligibleForDependentDeduction(dependent)).toBe(true)
     })
 
-    it('does not qualify with income at 580,001 yen', () => {
+    it('does not qualify with income at 620,001 yen', () => {
       const dependent: Dependent = {
         id: '1',
         relationship: 'child',
@@ -143,14 +143,14 @@ describe('Dependent Deduction Eligibility (扶養控除)', () => {
         isCohabiting: false,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_001, // Net = 580,001
+          grossEmploymentIncome: 1_360_001, // Net = 620,001
           otherNetIncome: 0,
         },
       }
       expect(isEligibleForDependentDeduction(dependent)).toBe(false)
     })
 
-    it('qualifies with income at 579,999 yen', () => {
+    it('qualifies with income at 619,999 yen', () => {
       const dependent: Dependent = {
         id: '1',
         relationship: 'child',
@@ -158,7 +158,7 @@ describe('Dependent Deduction Eligibility (扶養控除)', () => {
         isCohabiting: false,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_229_999, // Net = 579,999
+          grossEmploymentIncome: 1_359_999, // Net = 619,999
           otherNetIncome: 0,
         },
       }
@@ -232,8 +232,8 @@ describe('Dependent Deduction Eligibility (扶養控除)', () => {
 })
 
 describe('Spouse Deduction Eligibility (配偶者控除)', () => {
-  describe('At 58万円 threshold (2025 reform)', () => {
-    it('qualifies with income at exactly 580,000 yen', () => {
+  describe('At 62万円 threshold (2026 reform)', () => {
+    it('qualifies with income at exactly 620,000 yen', () => {
       const spouse: Dependent = {
         id: '1',
         relationship: 'spouse',
@@ -241,14 +241,14 @@ describe('Spouse Deduction Eligibility (配偶者控除)', () => {
         isCohabiting: true,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_000, // Net = 580,000
+          grossEmploymentIncome: 1_360_000, // Net = 620,000
           otherNetIncome: 0,
         },
       }
       expect(isEligibleForSpouseDeduction(spouse)).toBe(true)
     })
 
-    it('does not qualify with income at 580,001 yen', () => {
+    it('does not qualify with income at 620,001 yen', () => {
       const spouse: Dependent = {
         id: '1',
         relationship: 'spouse',
@@ -256,7 +256,7 @@ describe('Spouse Deduction Eligibility (配偶者控除)', () => {
         isCohabiting: true,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_001, // Net = 580,001
+          grossEmploymentIncome: 1_360_001, // Net = 620,001
           otherNetIncome: 0,
         },
       }
@@ -315,8 +315,8 @@ describe('Spouse Deduction Eligibility (配偶者控除)', () => {
 })
 
 describe('Spouse Special Deduction Eligibility (配偶者特別控除)', () => {
-  describe('At lower threshold boundary (58万円)', () => {
-    it('does not qualify at exactly 580,000 yen (must be above)', () => {
+  describe('At lower threshold boundary (62万円)', () => {
+    it('does not qualify at exactly 620,000 yen (must be above)', () => {
       const spouse: Dependent = {
         id: '1',
         relationship: 'spouse',
@@ -324,14 +324,14 @@ describe('Spouse Special Deduction Eligibility (配偶者特別控除)', () => {
         isCohabiting: true,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_000, // Net = 580,000
+          grossEmploymentIncome: 1_360_000, // Net = 620,000
           otherNetIncome: 0,
         },
       }
       expect(isEligibleForSpouseSpecialDeduction(spouse)).toBe(false)
     })
 
-    it('qualifies at 580,001 yen', () => {
+    it('qualifies at 620,001 yen', () => {
       const spouse: Dependent = {
         id: '1',
         relationship: 'spouse',
@@ -339,7 +339,7 @@ describe('Spouse Special Deduction Eligibility (配偶者特別控除)', () => {
         isCohabiting: true,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_001, // Net = 580,001
+          grossEmploymentIncome: 1_360_001, // Net = 620,001
           otherNetIncome: 0,
         },
       }
@@ -399,7 +399,7 @@ describe('Spouse Special Deduction Eligibility (配偶者特別控除)', () => {
   })
 
   describe('Middle range values', () => {
-    it('qualifies at 600,000 yen', () => {
+    it('qualifies at 650,000 yen', () => {
       const spouse: Dependent = {
         id: '1',
         relationship: 'spouse',
@@ -407,7 +407,7 @@ describe('Spouse Special Deduction Eligibility (配偶者特別控除)', () => {
         isCohabiting: true,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_250_000, // Net = 600,000
+          grossEmploymentIncome: 1_390_000, // Net = 650,000
           otherNetIncome: 0,
         },
       }
@@ -434,14 +434,14 @@ describe('Spouse Special Deduction Eligibility (配偶者特別控除)', () => {
 describe('Spouse Special Deduction Amounts (with low taxpayer income)', () => {
   const taxpayerIncome = 5_000_000 // Below phase-out threshold
 
-  describe('First bracket (58万円超～95万円以下)', () => {
-    it('returns correct national tax amount at 580,001 yen', () => {
-      expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).national).toBe(380_000)
+  describe('First bracket (62万円超～95万円以下)', () => {
+    it('returns correct national tax amount at 620,001 yen', () => {
+      expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).national).toBe(380_000)
     })
 
-    it('returns correct residence tax amount at 580,001 yen', () => {
-      expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).residence).toBe(330_000)
-      expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).residence).toBe(330_000)
+    it('returns correct residence tax amount at 620,001 yen', () => {
+      expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).residence).toBe(330_000)
+      expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).residence).toBe(330_000)
     })
 
     it('returns correct amount at 950,000 yen (upper bound)', () => {
@@ -511,7 +511,7 @@ describe('Spouse Special Deduction Amounts (with low taxpayer income)', () => {
 
 describe('Specific Relative Special Deduction Eligibility (特定親族特別控除)', () => {
   describe('Age 19-22 at threshold boundaries', () => {
-    it('does not qualify at exactly 580,000 yen (must be above)', () => {
+    it('does not qualify at exactly 620,000 yen (must be above)', () => {
       const dependent: Dependent = {
         id: '1',
         relationship: 'child',
@@ -519,7 +519,7 @@ describe('Specific Relative Special Deduction Eligibility (特定親族特別控
         isCohabiting: false,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_000, // Net = 580,000
+          grossEmploymentIncome: 1_360_000, // Net = 620,000
           otherNetIncome: 0,
         },
       }
@@ -528,7 +528,7 @@ describe('Specific Relative Special Deduction Eligibility (特定親族特別控
       expect(isEligibleForDependentDeduction(dependent)).toBe(true)
     })
 
-    it('qualifies at 580,001 yen', () => {
+    it('qualifies at 620,001 yen', () => {
       const dependent: Dependent = {
         id: '1',
         relationship: 'child',
@@ -536,7 +536,7 @@ describe('Specific Relative Special Deduction Eligibility (特定親族特別控
         isCohabiting: false,
         disability: 'none',
         income: {
-          grossEmploymentIncome: 1_230_001, // Net = 580,001
+          grossEmploymentIncome: 1_360_001, // Net = 620,001
           otherNetIncome: 0,
         },
       }
@@ -641,13 +641,13 @@ describe('Specific Relative Special Deduction Eligibility (特定親族特別控
 })
 
 describe('Specific Relative Special Deduction Amounts', () => {
-  describe('First bracket (58万円超～85万円以下)', () => {
-    it('returns correct national tax amount at 580,001 yen', () => {
-      expect(getSpecificRelativeDeduction(580_001).national).toBe(630_000)
+  describe('First bracket (62万円超～85万円以下)', () => {
+    it('returns correct national tax amount at 620,001 yen', () => {
+      expect(getSpecificRelativeDeduction(620_001).national).toBe(630_000)
     })
 
-    it('returns correct residence tax amount at 580,001 yen', () => {
-      expect(getSpecificRelativeDeduction(580_001).residence).toBe(450_000)
+    it('returns correct residence tax amount at 620,001 yen', () => {
+      expect(getSpecificRelativeDeduction(620_001).residence).toBe(450_000)
     })
 
     it('returns correct amount at 850,000 yen (upper bound)', () => {
@@ -704,8 +704,8 @@ describe('Specific Relative Special Deduction Amounts', () => {
 
   describe('Bracket boundaries (residence tax)', () => {
     it('first three brackets all return 45万円', () => {
-      // 58万円超～85万円以下
-      expect(getSpecificRelativeDeduction(580_001).residence).toBe(450_000)
+      // 62万円超～85万円以下
+      expect(getSpecificRelativeDeduction(620_001).residence).toBe(450_000)
       expect(getSpecificRelativeDeduction(850_000).residence).toBe(450_000)
       
       // 85万円超～90万円以下
@@ -782,7 +782,7 @@ describe('Special Dependent (特定扶養親族) Classification', () => {
     expect(isSpecialDependent(dependent)).toBe(true)
   })
 
-  it('age 19-22 with income > 58万円 is not special dependent', () => {
+  it('age 19-22 with income > 62万円 is not special dependent', () => {
     const dependent: Dependent = {
       id: '1',
       relationship: 'child',
@@ -790,7 +790,7 @@ describe('Special Dependent (特定扶養親族) Classification', () => {
       isCohabiting: false,
       disability: 'none',
       income: {
-        grossEmploymentIncome: 1_230_001, // Net = 580,001
+        grossEmploymentIncome: 1_360_001, // Net = 620,001
         otherNetIncome: 0,
       },
     }
@@ -814,7 +814,7 @@ describe('Elderly Dependent Classification', () => {
     expect(isElderlyDependent(dependent)).toBe(true)
   })
 
-  it('age 70+ with income > 58万円 is not elderly dependent', () => {
+  it('age 70+ with income > 62万円 is not elderly dependent', () => {
     const dependent: Dependent = {
       id: '1',
       relationship: 'parent',
@@ -822,7 +822,7 @@ describe('Elderly Dependent Classification', () => {
       isCohabiting: false,
       disability: 'none',
       income: {
-        grossEmploymentIncome: 1_230_001, // Net = 580,001
+        grossEmploymentIncome: 1_360_001, // Net = 620,001
         otherNetIncome: 0,
       },
     }
@@ -833,10 +833,10 @@ describe('Elderly Dependent Classification', () => {
 describe('Total Net Income Calculation with Other Income', () => {
   it('combines employment income and other net income correctly', () => {
     const income = {
-      grossEmploymentIncome: 1_000_000, // Net = 350,000
+      grossEmploymentIncome: 1_000_000, // Net = 260,000
       otherNetIncome: 200_000,
     }
-    expect(calculateDependentTotalNetIncome(income)).toBe(550_000)
+    expect(calculateDependentTotalNetIncome(income)).toBe(460_000)
   })
 
   it('threshold applies to total net income (employment + other)', () => {
@@ -847,14 +847,14 @@ describe('Total Net Income Calculation with Other Income', () => {
       isCohabiting: false,
       disability: 'none',
       income: {
-        grossEmploymentIncome: 1_000_000, // Net = 350,000
-        otherNetIncome: 230_000, // Total = 580,000
+        grossEmploymentIncome: 1_000_000, // Net = 260,000
+        otherNetIncome: 360_000, // Total = 620,000
       },
     }
     expect(isEligibleForDependentDeduction(dependent)).toBe(true)
   })
 
-  it('total net income of 580,001 exceeds threshold', () => {
+  it('total net income of 620,001 exceeds threshold', () => {
     const dependent: Dependent = {
       id: '1',
       relationship: 'child',
@@ -862,8 +862,8 @@ describe('Total Net Income Calculation with Other Income', () => {
       isCohabiting: false,
       disability: 'none',
       income: {
-        grossEmploymentIncome: 1_000_000, // Net = 350,000
-        otherNetIncome: 230_001, // Total = 580,001
+        grossEmploymentIncome: 1_000_000, // Net = 260,000
+        otherNetIncome: 360_001, // Total = 620,001
       },
     }
     expect(isEligibleForDependentDeduction(dependent)).toBe(false)
@@ -953,8 +953,8 @@ describe('Taxpayer Income Effects on Spouse Special Deduction (配偶者特別�
     const taxpayerIncome = 8_000_000
 
     describe('National tax - all brackets', () => {
-      it('58万円超～95万円以下: 380,000', () => {
-        expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).national).toBe(380_000)
+      it('62万円超～95万円以下: 380,000', () => {
+        expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).national).toBe(380_000)
         expect(getSpouseSpecialDeduction(950_000, taxpayerIncome).national).toBe(380_000)
       })
 
@@ -1000,8 +1000,8 @@ describe('Taxpayer Income Effects on Spouse Special Deduction (配偶者特別�
     })
 
     describe('Residence tax - all brackets', () => {
-      it('58万円超～100万円以下: 330,000', () => {
-        expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).residence).toBe(330_000)
+      it('62万円超～100万円以下: 330,000', () => {
+        expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).residence).toBe(330_000)
         expect(getSpouseSpecialDeduction(1_000_000, taxpayerIncome).residence).toBe(330_000)
       })
 
@@ -1046,8 +1046,8 @@ describe('Taxpayer Income Effects on Spouse Special Deduction (配偶者特別�
     const taxpayerIncome = 9_200_000
 
     describe('National tax - all brackets', () => {
-      it('58万円超～95万円以下: 260,000', () => {
-        expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).national).toBe(260_000)
+      it('62万円超～95万円以下: 260,000', () => {
+        expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).national).toBe(260_000)
         expect(getSpouseSpecialDeduction(950_000, taxpayerIncome).national).toBe(260_000)
       })
 
@@ -1093,8 +1093,8 @@ describe('Taxpayer Income Effects on Spouse Special Deduction (配偶者特別�
     })
 
     describe('Residence tax - all brackets', () => {
-      it('58万円超～100万円以下: 220,000', () => {
-        expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).residence).toBe(220_000)
+      it('62万円超～100万円以下: 220,000', () => {
+        expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).residence).toBe(220_000)
         expect(getSpouseSpecialDeduction(1_000_000, taxpayerIncome).residence).toBe(220_000)
       })
 
@@ -1139,8 +1139,8 @@ describe('Taxpayer Income Effects on Spouse Special Deduction (配偶者特別�
     const taxpayerIncome = 9_700_000
 
     describe('National tax - all brackets', () => {
-      it('58万円超～95万円以下: 130,000', () => {
-        expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).national).toBe(130_000)
+      it('62万円超～95万円以下: 130,000', () => {
+        expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).national).toBe(130_000)
         expect(getSpouseSpecialDeduction(950_000, taxpayerIncome).national).toBe(130_000)
       })
 
@@ -1186,8 +1186,8 @@ describe('Taxpayer Income Effects on Spouse Special Deduction (配偶者特別�
     })
 
     describe('Residence tax - all brackets', () => {
-      it('58万円超～100万円以下: 110,000', () => {
-        expect(getSpouseSpecialDeduction(580_001, taxpayerIncome).residence).toBe(110_000)
+      it('62万円超～100万円以下: 110,000', () => {
+        expect(getSpouseSpecialDeduction(620_001, taxpayerIncome).residence).toBe(110_000)
         expect(getSpouseSpecialDeduction(1_000_000, taxpayerIncome).residence).toBe(110_000)
       })
 
@@ -1294,7 +1294,7 @@ describe('Integration: calculateDependentDeductions with Taxpayer Income', () =>
       isCohabiting: false,
       disability: 'none',
       income: {
-        grossEmploymentIncome: 1_600_001, // Net = 950,001 (95万円超～100万円 bracket)
+        grossEmploymentIncome: 1_690_001, // Net = 950,001 (95万円超～100万円 bracket)
         otherNetIncome: 0,
       },
     }
@@ -1439,4 +1439,115 @@ describe('Dependent Deductions - Under 16', () => {
     expect(result.breakdown).toHaveLength(1)
     expect(result.breakdown[0]!.deductionType).toBe(DEDUCTION_TYPES.DISABILITY)
   })
+})
+
+describe('2025 income year (R7) — 58万円 threshold', () => {
+  const year = 2025;
+
+  function makeDependentWithNetIncome(netIncome: number): Dependent {
+    return {
+      id: 'test',
+      relationship: 'child',
+      ageCategory: '16to18',
+      isCohabiting: false,
+      disability: 'none',
+      income: { grossEmploymentIncome: 0, otherNetIncome: netIncome },
+    };
+  }
+
+  function makeSpouseWithNetIncome(netIncome: number): Dependent {
+    return {
+      id: 'test-spouse',
+      relationship: 'spouse',
+      ageCategory: 'under70',
+      isCohabiting: true,
+      disability: 'none',
+      income: { grossEmploymentIncome: 0, otherNetIncome: netIncome },
+    };
+  }
+
+  describe('Dependent deduction eligibility', () => {
+    it('qualifies at exactly 580,000 yen', () => {
+      expect(isEligibleForDependentDeduction(makeDependentWithNetIncome(580_000), year)).toBe(true);
+    });
+
+    it('does not qualify at 580,001 yen', () => {
+      expect(isEligibleForDependentDeduction(makeDependentWithNetIncome(580_001), year)).toBe(false);
+    });
+
+    it('income between 58万 and 62万: eligible in 2026 but not 2025', () => {
+      const dependent = makeDependentWithNetIncome(600_000);
+      expect(isEligibleForDependentDeduction(dependent, 2025)).toBe(false);
+      expect(isEligibleForDependentDeduction(dependent, 2026)).toBe(true);
+    });
+  });
+
+  describe('Spouse deduction eligibility', () => {
+    it('qualifies at exactly 580,000 yen', () => {
+      expect(isEligibleForSpouseDeduction(makeSpouseWithNetIncome(580_000), year)).toBe(true);
+    });
+
+    it('does not qualify at 580,001 yen', () => {
+      expect(isEligibleForSpouseDeduction(makeSpouseWithNetIncome(580_001), year)).toBe(false);
+    });
+  });
+
+  describe('Spouse special deduction starts at 58万超', () => {
+    it('not eligible at 580,000 (qualifies for regular spouse deduction instead)', () => {
+      expect(isEligibleForSpouseSpecialDeduction(makeSpouseWithNetIncome(580_000), year)).toBe(false);
+    });
+
+    it('eligible at 580,001', () => {
+      expect(isEligibleForSpouseSpecialDeduction(makeSpouseWithNetIncome(580_001), year)).toBe(true);
+    });
+
+    it('first bracket gives correct deduction amount', () => {
+      const deduction = getSpouseSpecialDeduction(600_000, 5_000_000, year);
+      expect(deduction.national).toBe(380_000);
+      expect(deduction.residence).toBe(330_000);
+    });
+
+    it('income between 58万 and 62万: spouse special in 2025, regular spouse in 2026', () => {
+      const spouse = makeSpouseWithNetIncome(600_000);
+      expect(isEligibleForSpouseSpecialDeduction(spouse, 2025)).toBe(true);
+      expect(isEligibleForSpouseDeduction(spouse, 2026)).toBe(true);
+    });
+  });
+
+  describe('Specific relative special deduction starts at 58万超', () => {
+    it('not eligible at 580,000 (qualifies for dependent deduction instead)', () => {
+      const dependent: Dependent = {
+        id: 'test', relationship: 'child', ageCategory: '19to22',
+        isCohabiting: false, disability: 'none',
+        income: { grossEmploymentIncome: 0, otherNetIncome: 580_000 },
+      };
+      expect(isEligibleForSpecificRelativeSpecialDeduction(dependent, year)).toBe(false);
+      expect(isEligibleForDependentDeduction(dependent, year)).toBe(true);
+    });
+
+    it('eligible at 580,001', () => {
+      const dependent: Dependent = {
+        id: 'test', relationship: 'child', ageCategory: '19to22',
+        isCohabiting: false, disability: 'none',
+        income: { grossEmploymentIncome: 0, otherNetIncome: 580_001 },
+      };
+      expect(isEligibleForSpecificRelativeSpecialDeduction(dependent, year)).toBe(true);
+    });
+
+    it('first bracket gives correct deduction amount', () => {
+      const deduction = getSpecificRelativeDeduction(600_000, year);
+      expect(deduction.national).toBe(630_000);
+      expect(deduction.residence).toBe(450_000);
+    });
+
+    it('income between 58万 and 62万: specific relative special in 2025, regular dependent in 2026', () => {
+      const dependent: Dependent = {
+        id: 'test', relationship: 'child', ageCategory: '19to22',
+        isCohabiting: false, disability: 'none',
+        income: { grossEmploymentIncome: 0, otherNetIncome: 600_000 },
+      };
+      expect(isEligibleForSpecificRelativeSpecialDeduction(dependent, 2025)).toBe(true);
+      expect(isEligibleForDependentDeduction(dependent, 2026)).toBe(true);
+    });
+  });
 })

--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -15,32 +15,32 @@ describe('calculateFurusatoNozeiLimit', () => {
   it('calculates furusato nozei for the default salary', () => {
     const fn = calculateFNForIncome(5_000_000);
     expect(fn.limit).toBe(61_000);
-    expect(fn.outOfPocketCost).toBe(2000);
-    expect(fn.incomeTaxReduction).toBe(6000);
+    expect(fn.outOfPocketCost).toBe(5_000);
+    expect(fn.incomeTaxReduction).toBe(3_000);
     expect(fn.residenceTaxReduction).toBe(53_000);
   });
 
   it('calculates furusato nozei for the salary with lower out-of-pocket cost', () => {
     const fn = calculateFNForIncome(6_000_000);
     expect(fn.limit).toBe(77_000);
-    expect(fn.outOfPocketCost).toBe(1800);
-    expect(fn.incomeTaxReduction).toBe(7700);
+    expect(fn.outOfPocketCost).toBe(1_900);
+    expect(fn.incomeTaxReduction).toBe(7_600);
     expect(fn.residenceTaxReduction).toBe(67_500);
   });
 
   it('calculates furusato nozei for the salary with slightly higher out-of-pocket cost', () => {
     const fn = calculateFNForIncome(8_800_000);
     expect(fn.limit).toBe(151_000);
-    expect(fn.outOfPocketCost).toBe(2100);
-    expect(fn.incomeTaxReduction).toBe(30_400);
+    expect(fn.outOfPocketCost).toBe(2_000);
+    expect(fn.incomeTaxReduction).toBe(30_500);
     expect(fn.residenceTaxReduction).toBe(118_500);
   });
 
   it('high-income salary, high out-of-pocket cost', () => {
     const fn = calculateFNForIncome(13_000_000);
-    expect(fn.outOfPocketCost).toBe(31_500);
+    expect(fn.outOfPocketCost).toBe(35_200);
     expect(fn.limit).toBe(327_000);
-    expect(fn.incomeTaxReduction).toBe(80_000);
+    expect(fn.incomeTaxReduction).toBe(76_300);
     expect(fn.residenceTaxReduction).toBe(215_500);
   });
 
@@ -48,7 +48,7 @@ describe('calculateFurusatoNozeiLimit', () => {
     const fn = calculateFNForIncome(6_500_000);
     expect(fn.limit).toBe(98_000);
     expect(fn.outOfPocketCost).toBe(11_800);
-    expect(fn.incomeTaxReduction).toBe(9800);
+    expect(fn.incomeTaxReduction).toBe(9_800);
     expect(fn.residenceTaxReduction).toBe(76_400);
   });
 
@@ -67,17 +67,18 @@ describe('calculateFurusatoNozeiLimit', () => {
       dcPlanContributions: 240_000, // 20,000 yen per month
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     }).furusatoNozei;
 
     const fnWithoutDC = calculateFNForIncome(5_000_000);
 
     expect(fn.limit).toBeLessThan(fnWithoutDC.limit);
     expect(fn.limit).toBe(55_000);
-    expect(fn.outOfPocketCost).toBe(4700);
+    expect(fn.outOfPocketCost).toBe(4_700);
   });
 
   it('furusato nozei limit is affected by manual social insurance override', () => {
-    // Standard calculation for 5M income has limit of 61,000
+    // Standard calculation for 5M income has limit of 60,000
     // If we increase social insurance deduction manually, taxable income decreases, so limit should decrease
     const fnWithHighSocialInsurance = calculateTaxes({
       incomeStreams: [{ id: 'test', type: 'salary', amount: 5_000_000, frequency: 'annual' }],
@@ -90,7 +91,7 @@ describe('calculateFurusatoNozeiLimit', () => {
       manualSocialInsuranceAmount: 1_000_000, // Higher than standard ~726k
     }).furusatoNozei;
 
-    expect(fnWithHighSocialInsurance.limit).toBeLessThan(61_000);
+    expect(fnWithHighSocialInsurance.limit).toBeLessThan(62_000);
 
     // If we decrease social insurance deduction manually, taxable income increases, so limit should increase
     const fnWithLowSocialInsurance = calculateTaxes({
@@ -104,7 +105,7 @@ describe('calculateFurusatoNozeiLimit', () => {
       manualSocialInsuranceAmount: 500_000, // Lower than standard ~726k
     }).furusatoNozei;
 
-    expect(fnWithLowSocialInsurance.limit).toBeGreaterThan(61_000);
+    expect(fnWithLowSocialInsurance.limit).toBeGreaterThan(62_000);
   });
 });
 
@@ -118,5 +119,6 @@ function calculateFNForIncome(income: number): FurusatoNozeiDetails {
     dcPlanContributions: 0,
     manualSocialInsuranceEntry: false,
     manualSocialInsuranceAmount: 0,
+    incomeYear: 2026,
   }).furusatoNozei;
 }

--- a/src/__tests__/pensionCalculator.test.ts
+++ b/src/__tests__/pensionCalculator.test.ts
@@ -13,19 +13,27 @@ describe('calculatePensionPremium', () => {
     expect(calculatePensionPremium(true, 10_000_000 / 12, true)).toBe(713_700) // Capped at 59,475 * 12
   })
 
-  it('calculates fixed national pension for non-employment income', () => {
-    expect(calculatePensionPremium(false, 5_000_000 / 12, true)).toBe(210_120) // 17,510 * 12 months
-    expect(calculatePensionPremium(false, 10_000_000 / 12, true)).toBe(210_120) // Same fixed amount regardless of income
+  it('calculates fixed national pension for non-employment income (2026)', () => {
+    // 3 months FY2025 (17,510) + 9 months FY2026 (17,920) = 52,530 + 161,280 = 213,810
+    expect(calculatePensionPremium(false, 5_000_000 / 12, true, [], 2026)).toBe(213_810)
+    expect(calculatePensionPremium(false, 10_000_000 / 12, true, [], 2026)).toBe(213_810) // Same fixed amount regardless of income
+  })
+
+  it('calculates fixed national pension for non-employment income (2025)', () => {
+    // 3 months FY2024 (16,980) + 9 months FY2025 (17,510) = 50,940 + 157,590 = 208,530
+    expect(calculatePensionPremium(false, 5_000_000 / 12, true, [], 2025)).toBe(208_530)
+    expect(calculatePensionPremium(false, 10_000_000 / 12, true, [], 2025)).toBe(208_530)
   })
 
   it('handles zero income correctly', () => {
     expect(calculatePensionPremium(true, 0, true)).toBe(96_624)
-    expect(calculatePensionPremium(false, 0, true)).toBe(210_120) // Still pays fixed amount
+    expect(calculatePensionPremium(false, 0, true, [], 2026)).toBe(213_810) // Fixed amount (2026)
+    expect(calculatePensionPremium(false, 0, true, [], 2025)).toBe(208_530) // Fixed amount (2025)
   })
 
   it('handles negative income correctly', () => {
-    expect(() => calculatePensionPremium(true, -1_000_000, true)).toThrowError('Monthly income must be a positive number')
-    expect(calculatePensionPremium(false, -1_000_000, true)).toBe(210_120) // Still pays fixed amount
+    expect(() => calculatePensionPremium(true, -1_000_000, true)).toThrow('Monthly income must be a positive number')
+    expect(calculatePensionPremium(false, -1_000_000, true, [], 2026)).toBe(213_810) // Still pays fixed amount
   })
 })
 

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -11,43 +11,83 @@ beforeAll(() => { vi.useFakeTimers({ now: new Date(2025, 5, 1) }) })
 afterAll(() => { vi.useRealTimers() })
 
 describe('calculateNetEmploymentIncome', () => {
-  it('deduction of 650,000 yen for income up to 1,900,000 yen', () => {
-    expect(calculateNetEmploymentIncome(1_500_000)).toBe(850_000)
-    expect(calculateNetEmploymentIncome(1_899_999)).toBe(1_249_999)
+  describe('2026 tiers (R8)', () => {
+    it('deduction of 740,000 yen for income up to 2,200,000 yen (R8 temporary provision)', () => {
+      expect(calculateNetEmploymentIncome(1_500_000, 2026)).toBe(760_000)
+      expect(calculateNetEmploymentIncome(1_899_999, 2026)).toBe(1_159_999)
+    })
+
+    it('between 2,200,000 and 6,600,000 yen, income is rounded down to the nearest 4000 yen', () => {
+      expect(calculateNetEmploymentIncome(2_200_000, 2026)).toBe(1_460_000)
+      expect(calculateNetEmploymentIncome(2_201_123, 2026)).toBe(1_460_000)
+      expect(calculateNetEmploymentIncome(2_203_333, 2026)).toBe(1_460_000)
+      expect(calculateNetEmploymentIncome(2_204_000, 2026)).toBe(1_462_800)
+
+      expect(calculateNetEmploymentIncome(3_600_000, 2026)).toBe(2_440_000)
+      expect(calculateNetEmploymentIncome(3_603_999, 2026)).toBe(2_440_000)
+      expect(calculateNetEmploymentIncome(3_604_000, 2026)).toBe(2_443_200)
+    })
+
+    it('calculates deduction correctly for income between 2,200,000 and 3,600,000 yen', () => {
+      expect(calculateNetEmploymentIncome(2_500_000, 2026)).toBe(2_500_000 - (2_500_000 * 0.3 + 80_000))
+    })
+
+    it('calculates deduction correctly for income between 3,600,001 and 6,600,000 yen', () => {
+      expect(calculateNetEmploymentIncome(5_000_000, 2026)).toBe(5_000_000 - (5_000_000 * 0.2 + 440_000))
+    })
+
+    it('calculates deduction correctly for income between 6,600,001 and 8,500,000 yen', () => {
+      expect(calculateNetEmploymentIncome(7_500_000, 2026)).toBe(7_500_000 - (7_500_000 * 0.1 + 1_100_000))
+    })
+
+    it('From 6.6 million yen, income is not rounded down to the nearest 4000 yen', () => {
+      expect(calculateNetEmploymentIncome(6_600_100, 2026)).toBe(Math.floor(6_600_100 * 0.9) - 1_100_000)
+      expect(calculateNetEmploymentIncome(6_600_123, 2026)).toBe((Math.floor(6_600_123 * 0.9) - 1_100_000))
+      expect(calculateNetEmploymentIncome(6_601_000, 2026)).not.toBe(calculateNetEmploymentIncome(6_600_100, 2026))
+    })
+
+    it('returns maximum deduction of 1,950,000 yen for income above 8,500,000 yen', () => {
+      expect(calculateNetEmploymentIncome(9_000_000, 2026)).toBe(9_000_000 - 1_950_000)
+      expect(calculateNetEmploymentIncome(10_000_000, 2026)).toBe(10_000_000 - 1_950_000)
+    })
   })
 
-  it('between 1,900,000 and 6,600,000 yen, income is rounded down to the nearest 4000 yen', () => {
-    expect(calculateNetEmploymentIncome(1_900_000)).toBe(1_250_000)
-    expect(calculateNetEmploymentIncome(1_901_123)).toBe(1_250_000)
-    expect(calculateNetEmploymentIncome(1_903_333)).toBe(1_250_000)
-    expect(calculateNetEmploymentIncome(1_904_000)).toBe(1_252_800)
+  describe('2025 tiers (R7)', () => {
+    it('returns 0 for income at or below 650,000 yen', () => {
+      expect(calculateNetEmploymentIncome(0, 2025)).toBe(0)
+      expect(calculateNetEmploymentIncome(650_000, 2025)).toBe(0)
+    })
 
-    expect(calculateNetEmploymentIncome(3_600_000)).toBe(2_440_000)
-    expect(calculateNetEmploymentIncome(3_603_999)).toBe(2_440_000)
-    expect(calculateNetEmploymentIncome(3_604_000)).toBe(2_443_200)
-  })
+    it('deduction of 650,000 yen for income up to 1,900,000 yen', () => {
+      expect(calculateNetEmploymentIncome(650_001, 2025)).toBe(1)
+      expect(calculateNetEmploymentIncome(1_500_000, 2025)).toBe(850_000)
+      expect(calculateNetEmploymentIncome(1_900_000, 2025)).toBe(1_250_000)
+    })
 
-  it('calculates deduction correctly for income between 1,900,001 and 3,600,000 yen', () => {
-    expect(calculateNetEmploymentIncome(2_500_000)).toBe(2_500_000 - (2_500_000 * 0.3 + 80_000))
-  })
+    it('smooth join at 1,900,000 yen: flat floor and standard formula give same result', () => {
+      // Floor formula: 1,900,000 - 650,000 = 1,250,000
+      // Standard formula: floor(1,900,000 / 4000) * 4000 * 0.7 - 80,000 = 1,900,000 * 0.7 - 80,000 = 1,250,000
+      expect(calculateNetEmploymentIncome(1_900_000, 2025)).toBe(1_250_000)
+      expect(calculateNetEmploymentIncome(1_900_001, 2025)).toBe(1_250_000) // rounds down to 1,900,000
+    })
 
-  it('calculates deduction correctly for income between 3,600,001 and 6,600,000 yen', () => {
-    expect(calculateNetEmploymentIncome(5_000_000)).toBe(5_000_000 - (5_000_000 * 0.2 + 440_000))
-  })
+    it('calculates deduction correctly for income between 1,900,001 and 3,600,000 yen', () => {
+      expect(calculateNetEmploymentIncome(2_200_000, 2025)).toBe(1_460_000) // 2,200,000 * 0.7 - 80,000
+      expect(calculateNetEmploymentIncome(2_500_000, 2025)).toBe(2_500_000 - (2_500_000 * 0.3 + 80_000))
+    })
 
-  it('calculates deduction correctly for income between 6,600,001 and 8,500,000 yen', () => {
-    expect(calculateNetEmploymentIncome(7_500_000)).toBe(7_500_000 - (7_500_000 * 0.1 + 1_100_000))
-  })
+    it('calculates deduction correctly for income between 3,600,001 and 6,600,000 yen', () => {
+      expect(calculateNetEmploymentIncome(5_000_000, 2025)).toBe(5_000_000 - (5_000_000 * 0.2 + 440_000))
+    })
 
-  it('From 6.6 million yen, income is not rounded down to the nearest 4000 yen', () => {
-    expect(calculateNetEmploymentIncome(6_600_100)).toBe(6_600_100 - (6_600_100 * 0.1 + 1_100_000))
-    expect(calculateNetEmploymentIncome(6_600_123)).toBe((Math.floor(6_600_123 * 0.9) - 1_100_000))
-    expect(calculateNetEmploymentIncome(6_601_000)).not.toBe(calculateNetEmploymentIncome(6_600_100))
-  })
+    it('calculates deduction correctly for income between 6,600,001 and 8,500,000 yen', () => {
+      expect(calculateNetEmploymentIncome(7_500_000, 2025)).toBe(7_500_000 - (7_500_000 * 0.1 + 1_100_000))
+    })
 
-  it('returns maximum deduction of 1,950,000 yen for income above 8,500,000 yen', () => {
-    expect(calculateNetEmploymentIncome(9_000_000)).toBe(9_000_000 - 1_950_000)
-    expect(calculateNetEmploymentIncome(10_000_000)).toBe(10_000_000 - 1_950_000)
+    it('returns maximum deduction of 1,950,000 yen for income above 8,500,000 yen', () => {
+      expect(calculateNetEmploymentIncome(9_000_000, 2025)).toBe(9_000_000 - 1_950_000)
+      expect(calculateNetEmploymentIncome(10_000_000, 2025)).toBe(10_000_000 - 1_950_000)
+    })
   })
 })
 
@@ -60,17 +100,18 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo", // Default for Kyokai Kenpo in tests
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(0)
-    expect(result.residenceTax.totalResidenceTax).toBe(22_200)
+    expect(result.residenceTax.totalResidenceTax).toBe(13_200)
     expect(result.healthInsurance).toBe(74_916)
     expect(result.pensionPayments).toBe(138_348)
     // 1,500,000 / 12 = 125,000 per month
     // 125,000 * 0.55% = 687.5 per month → 687 yen (exactly 0.5 yen → round down)
     // 687 * 12 = 8,244 yen annually
     expect(result.employmentInsurance).toBe(8_244)
-    expect(result.takeHomeIncome).toBe(1_256_292)
+    expect(result.takeHomeIncome).toBe(1_265_292)
   })
 
   it('calculates taxes correctly for income between 1,950,000 and 3,300,000 yen', () => {
@@ -80,9 +121,10 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
-    expect(result.nationalIncomeTax).toBe(22_300)
+    expect(result.nationalIncomeTax).toBe(14_100)
     expect(result.residenceTax.totalResidenceTax).toBe(91_100)
     expect(result.healthInsurance).toBe(118_920)
     expect(result.pensionPayments).toBe(219_600)
@@ -90,7 +132,7 @@ describe('calculateTaxes', () => {
     // 208,333.33 * 0.55% ≈ 1,145.83 per month → 1,146 yen (round up)
     // 1,146 * 12 = 13,752 yen annually
     expect(result.employmentInsurance).toBe(13_752)
-    expect(result.takeHomeIncome).toBe(2_034_328)
+    expect(result.takeHomeIncome).toBe(2_042_528)
   })
 
   it('calculates taxes correctly for income between 3,300,000 and 6,950,000 yen', () => {
@@ -100,9 +142,10 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
-    expect(result.nationalIncomeTax).toBe(120_700)
+    expect(result.nationalIncomeTax).toBe(91_700)
     expect(result.residenceTax.totalResidenceTax).toBe(243_200)
     expect(result.healthInsurance).toBe(243_780) // 410k * 4.955% = 20,315.5 -> 20,315 * 12
     expect(result.pensionPayments).toBe(450_180)
@@ -110,7 +153,7 @@ describe('calculateTaxes', () => {
     // 416,666.67 * 0.55% ≈ 2,291.67 per month → 2,292 yen (round up)
     // 2,292 * 12 = 27,504 yen annually
     expect(result.employmentInsurance).toBe(27_504)
-    expect(result.takeHomeIncome).toBe(3_914_636)
+    expect(result.takeHomeIncome).toBe(3_943_636)
   })
 
   // Test cases for high income brackets
@@ -121,10 +164,11 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
-    expect(result.nationalIncomeTax).toBe(16_345_400) // 50M - 1.95M (employment deduction) - 1.815194M (social insurance) - 0 (basic deduction) = 46.234806M, rounded to 46.234M, then 45% - 4.796M = 16.0093M, + 2.1% = 16.345495M, rounded down to 16.3454M
-    expect(result.residenceTax.totalResidenceTax).toBe(4_628_300) // (50M - 1.95M - 1.815194M - 0) = 46.234806M, rounded to 46.234M, then 6% city tax (2.774M) + 4% prefectural tax (1.8493M) + 5K 均等割
+    expect(result.nationalIncomeTax).toBe(16_345_400) // 50M - 1.95M (employment deduction) - 1.815192M (social insurance) - 0 (basic deduction, income > 25M)
+    expect(result.residenceTax.totalResidenceTax).toBe(4_628_300)
     expect(result.healthInsurance).toBe(826_488) // Capped at 68,874.5 -> 68,874 * 12
     expect(result.pensionPayments).toBe(713_700) // Capped at 59,475 * 12
     // 50,000,000 / 12 ≈ 4,166,666.67 per month
@@ -176,14 +220,15 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
-    expect(result.nationalIncomeTax).toBe(302_700)
-    expect(result.residenceTax.totalResidenceTax).toBe(384_500)
+    expect(result.nationalIncomeTax).toBe(293_700)
+    expect(result.residenceTax.totalResidenceTax).toBe(384_000)
     expect(result.healthInsurance).toBe(539_380)
-    expect(result.pensionPayments).toBe(210_120)
+    expect(result.pensionPayments).toBe(213_810)
     expect(result.employmentInsurance).toBe(0)
-    expect(result.takeHomeIncome).toBe(3_563_300)
+    expect(result.takeHomeIncome).toBe(3_569_110)
   })
 
   it('calculates taxes correctly for employment income with NHI', () => {
@@ -195,6 +240,7 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
       region: "Tokyo", // For NHI
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
 
@@ -206,16 +252,16 @@ describe('calculateTaxes', () => {
     expect(result.healthInsurance).toBe(389_620)
 
     // Should pay national pension (not employee pension, since they're on NHI)
-    expect(result.pensionPayments).toBe(210_120)
+    expect(result.pensionPayments).toBe(213_810)
 
     // Tax calculations should use employment income deduction
     expect(result.netEmploymentIncome).toBe(3_560_000)
-    expect(result.nationalIncomeTax).toBe(130_300)
-    expect(result.residenceTax.totalResidenceTax).toBe(252_600)
+    expect(result.nationalIncomeTax).toBe(96_400)
+    expect(result.residenceTax.totalResidenceTax).toBe(252_300)
 
     // Total take-home should reflect employment income with NHI and National Pension
     // NHI calculated on net employment income results in lower premiums and higher take-home
-    expect(result.takeHomeIncome).toBe(3_989_856)
+    expect(result.takeHomeIncome).toBe(4_020_366)
   })
 
   it('calculates taxes correctly with DC plan contributions', () => {
@@ -226,6 +272,7 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const resultWithoutIdeco = calculateTaxes(inputsWithoutDcPlan);
 
@@ -248,9 +295,9 @@ describe('calculateTaxes', () => {
     const incomeTaxSavings = resultWithoutIdeco.nationalIncomeTax - resultWithIdeco.nationalIncomeTax;
     const residenceTaxSavings = resultWithoutIdeco.residenceTax.totalResidenceTax - resultWithIdeco.residenceTax.totalResidenceTax;
 
-    // With 240,000 yen contribution at ~10% marginal tax rate, we expect around 24,000 yen in income tax savings
+    // With 240,000 yen contribution at ~5% marginal tax rate (basic deduction increase reduces taxable income into lower bracket)
     // and around 24,000 yen in residence tax savings (10% rate)
-    expect(incomeTaxSavings).equals(22_800); // less because it crosses into the 5% bracket
+    expect(incomeTaxSavings).equals(12_200);
     expect(residenceTaxSavings).equals(24_000);
   });
 
@@ -408,58 +455,105 @@ describe('calculateEmploymentInsurance', () => {
 })
 
 describe('calculateNationalIncomeTaxBasicDeduction', () => {
-  it('returns 950,000 yen for income up to 1,320,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(0)).toBe(950_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(1_000_000)).toBe(950_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(1_320_000)).toBe(950_000)
+  describe('2026 tiers (R8: 62万 base + temporary additions via Art. 41-16-2)', () => {
+    it('returns 1,040,000 yen for income up to 1,320,000 yen (62万 base + 42万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(0, 2026)).toBe(1_040_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(1_000_000, 2026)).toBe(1_040_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(1_320_000, 2026)).toBe(1_040_000)
+    })
+
+    it('returns 1,040,000 yen for income between 1,320,001 and 3,360,000 yen (62万 base + 42万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(1_320_001, 2026)).toBe(1_040_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(2_000_000, 2026)).toBe(1_040_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(3_360_000, 2026)).toBe(1_040_000)
+    })
+
+    it('returns 1,040,000 yen for income between 3,360,001 and 4,890,000 yen (62万 base + 42万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(3_360_001, 2026)).toBe(1_040_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(4_000_000, 2026)).toBe(1_040_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(4_890_000, 2026)).toBe(1_040_000)
+    })
+
+    it('returns 670,000 yen for income between 4,890,001 and 6,550,000 yen (62万 base + 5万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(4_890_001, 2026)).toBe(670_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(5_000_000, 2026)).toBe(670_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(6_550_000, 2026)).toBe(670_000)
+    })
+
+    it('returns 620,000 yen for income between 6,550,001 and 23,500,000 yen (62万 base)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(6_550_001, 2026)).toBe(620_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(10_000_000, 2026)).toBe(620_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(23_500_000, 2026)).toBe(620_000)
+    })
+
+    it('returns 480,000 yen for income between 23,500,001 and 24,000,000 yen', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(23_500_001, 2026)).toBe(480_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(24_000_000, 2026)).toBe(480_000)
+    })
+
+    it('returns 320,000 yen for income between 24,000,001 and 24,500,000 yen', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(24_000_001, 2026)).toBe(320_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(24_500_000, 2026)).toBe(320_000)
+    })
+
+    it('returns 160,000 yen for income between 24,500,001 and 25,000,000 yen', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(24_500_001, 2026)).toBe(160_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(25_000_000, 2026)).toBe(160_000)
+    })
+
+    it('returns 0 yen for income above 25,000,000 yen', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(25_000_001, 2026)).toBe(0)
+      expect(calculateNationalIncomeTaxBasicDeduction(30_000_000, 2026)).toBe(0)
+    })
+
+    it('handles negative income correctly', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(-1_000_000, 2026)).toBe(1_040_000)
+    })
   })
 
-  it('returns 880,000 yen for income between 1,320,001 and 3,360,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(1_320_001)).toBe(880_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(2_000_000)).toBe(880_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(3_360_000)).toBe(880_000)
-  })
+  describe('2025 tiers (R7: 58万 base + temporary additions via Art. 41-16-2)', () => {
+    it('returns 950,000 yen for income up to 1,320,000 yen (58万 base + 37万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(0, 2025)).toBe(950_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(1_000_000, 2025)).toBe(950_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(1_320_000, 2025)).toBe(950_000)
+    })
 
-  it('returns 680,000 yen for income between 3,360,001 and 4,890,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(3_360_001)).toBe(680_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(4_000_000)).toBe(680_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(4_890_000)).toBe(680_000)
-  })
+    it('returns 880,000 yen for income between 1,320,001 and 3,360,000 yen (58万 base + 30万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(1_320_001, 2025)).toBe(880_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(2_000_000, 2025)).toBe(880_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(3_360_000, 2025)).toBe(880_000)
+    })
 
-  it('returns 630,000 yen for income between 4,890,001 and 6,550,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(4_890_001)).toBe(630_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(5_000_000)).toBe(630_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(6_550_000)).toBe(630_000)
-  })
+    it('returns 680,000 yen for income between 3,360,001 and 4,890,000 yen (58万 base + 10万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(3_360_001, 2025)).toBe(680_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(4_000_000, 2025)).toBe(680_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(4_890_000, 2025)).toBe(680_000)
+    })
 
-  it('returns 580,000 yen for income between 6,550,001 and 23,500,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(6_550_001)).toBe(580_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(10_000_000)).toBe(580_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(23_500_000)).toBe(580_000)
-  })
+    it('returns 630,000 yen for income between 4,890,001 and 6,550,000 yen (58万 base + 5万 temp)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(4_890_001, 2025)).toBe(630_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(5_000_000, 2025)).toBe(630_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(6_550_000, 2025)).toBe(630_000)
+    })
 
-  it('returns 480,000 yen for income between 23,500,001 and 24,000,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(23_500_001)).toBe(480_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(24_000_000)).toBe(480_000)
-  })
+    it('returns 580,000 yen for income between 6,550,001 and 23,500,000 yen (58万 base)', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(6_550_001, 2025)).toBe(580_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(10_000_000, 2025)).toBe(580_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(23_500_000, 2025)).toBe(580_000)
+    })
 
-  it('returns 320,000 yen for income between 24,000,001 and 24,500,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(24_000_001)).toBe(320_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(24_500_000)).toBe(320_000)
-  })
+    it('returns 480,000 yen for income between 23,500,001 and 24,000,000 yen', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(23_500_001, 2025)).toBe(480_000)
+      expect(calculateNationalIncomeTaxBasicDeduction(24_000_000, 2025)).toBe(480_000)
+    })
 
-  it('returns 160,000 yen for income between 24,500,001 and 25,000,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(24_500_001)).toBe(160_000)
-    expect(calculateNationalIncomeTaxBasicDeduction(25_000_000)).toBe(160_000)
-  })
+    it('returns 0 yen for income above 25,000,000 yen', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(25_000_001, 2025)).toBe(0)
+    })
 
-  it('returns 0 yen for income above 25,000,000 yen', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(25_000_001)).toBe(0)
-    expect(calculateNationalIncomeTaxBasicDeduction(30_000_000)).toBe(0)
-  })
-
-  it('handles negative income correctly', () => {
-    expect(calculateNationalIncomeTaxBasicDeduction(-1_000_000)).toBe(950_000)
+    it('handles negative income correctly', () => {
+      expect(calculateNationalIncomeTaxBasicDeduction(-1_000_000, 2025)).toBe(950_000)
+    })
   })
 })
 
@@ -533,9 +627,9 @@ describe('calculateTaxes with Dependent Coverage', () => {
     expect(result.employmentInsurance).toBe(5_496)
 
     // Income tax and residence tax should still be calculated normally
-    // Net income: 1,000,000 - 650,000 = 350,000
+    // Net income: 1,000,000 - 740,000 = 260,000 (R8 minimum deduction)
     // Social insurance deduction: 0 + 0 + 5,496 = 5,496
-    // Taxable income: 350,000 - 5,496 - 950,000 = negative, so 0
+    // Taxable income: 260,000 - 5,496 - 1,040,000 = negative, so 0
     expect(result.nationalIncomeTax).toBe(0)
   })
 
@@ -671,6 +765,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
@@ -679,7 +774,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
     expect(result.annualIncome).toBe(4_000_000);
 
     // 2. Validate Net Employment Income
-    // Deduction for 3M: 3M * 30% + 80k = 980k; Net = 2.02M
+    // Deduction for 3M (R8): floor(3M * 0.7) - 80k = 2.1M - 80k = 2.02M
     expect(result.netEmploymentIncome).toBe(2_020_000);
 
     // 3. Validate Total Net Income (The base for NHI)
@@ -688,16 +783,16 @@ describe('calculateTaxes with Dependent Coverage', () => {
 
     // 4. Validate NHI Premium is calculated broadly correctly (non-zero)
     // Base = 3.02M - 430k = 2.59M
-    // Rough calc: 2.59M * ~10% = ~260k. 
+    // Rough calc: 2.59M * ~10% = ~260k.
     expect(result.healthInsurance).toBeGreaterThan(200_000);
   });
 })
 
 describe('calculateTotalNetIncome', () => {
   it('calculates total net income correctly for salary only', () => {
-    // Salary 5M -> Net Employment Income (5M - 1.44M deduction) = 3.56M
+    // Salary 5M -> Net Employment Income (R8: floor(5M * 0.8) - 440k = 4M - 440k = 3.56M)
     const incomeStreams = [{ type: 'salary' as const, amount: 5_000_000, frequency: 'annual' as const, id: 'test' }];
-    expect(calculateTotalNetIncome(incomeStreams)).toBe(3_560_000);
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(3_560_000);
   });
 
   it('calculates total net income correctly for business only', () => {
@@ -707,18 +802,18 @@ describe('calculateTotalNetIncome', () => {
   });
 
   it('calculates total net income correctly for mixed income', () => {
-    // Salary 3M -> Net Employment (3M - 980k) = 2.02M
+    // Salary 3M -> Net Employment (R8: floor(3M * 0.7) - 80k = 2.1M - 80k = 2.02M)
     // Business 1M -> Taxable Business = 1M
     // Total = 3.02M
     const incomeStreams = [
       { type: 'salary' as const, amount: 3_000_000, frequency: 'annual' as const, id: 's1' },
       { type: 'business' as const, amount: 1_000_000, blueFilerDeduction: 0, id: 'b1' }
     ];
-    expect(calculateTotalNetIncome(incomeStreams)).toBe(3_020_000);
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(3_020_000);
   });
 
   it('handles business income less than blue-filer deduction and misc income', () => {
-    // Salary 3M -> Net Employment (3M - 980k) = 2.02M
+    // Salary 3M -> Net Employment (R8: floor(3M * 0.7) - 80k = 2.02M)
     // Business 200k, Deduction 650k -> Net Business = 0 (Deduction limited to 200k)
     // Misc 100k -> Net Misc = 100k (Deduction does NOT apply to Misc)
     // Total Net = 2.02M + 0 + 100k = 2.12M
@@ -727,7 +822,7 @@ describe('calculateTotalNetIncome', () => {
       { type: 'business' as const, amount: 200_000, blueFilerDeduction: 650_000, id: 'b1' },
       { type: 'miscellaneous' as const, amount: 100_000, id: 'm1' }
     ];
-    expect(calculateTotalNetIncome(incomeStreams)).toBe(2_120_000);
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(2_120_000);
   });
 });
 
@@ -868,17 +963,17 @@ describe('RSU (Restricted Stock Unit) income', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
 
     // 1. RSU is employment income, so it goes through employment income deduction
-    // Gross EI = 2M (in 1.9M-3.6M range)
-    // Rounded: 2M, Net = 2M * 0.7 - 80k = 1.32M
-    expect(result.netEmploymentIncome).toBe(1_320_000);
+    // Gross EI = 2M (below 2.2M): Net = 2M - 740k = 1.26M
+    expect(result.netEmploymentIncome).toBe(1_260_000);
 
     // 2. RSU should be included in total net income
-    expect(result.totalNetIncome).toBe(1_320_000);
+    expect(result.totalNetIncome).toBe(1_260_000);
 
     // 3. RSU should NOT be in social insurance bases (no salary/bonus/commuting allowance)
     // With 0 salary income, health insurance base for SMR is 0
@@ -907,6 +1002,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
@@ -953,6 +1049,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
@@ -984,20 +1081,19 @@ describe('RSU (Restricted Stock Unit) income', () => {
       healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
 
-    // 1. Total net income: 2M - 1.32M deduction = not used for NHI, instead total income is
-    // For NHI with RSU only, the net income includes the full amount after deduction
-    // 2M in 1.9M-3.6M range: Net = 2M * 0.7 - 80k = 1.32M
-    expect(result.totalNetIncome).toBe(1_320_000);
+    // 1. Total net income: RSU 2M below 2.2M: Net = 2M - 740k = 1.26M
+    expect(result.totalNetIncome).toBe(1_260_000);
 
     // 2. NHI is based on total net income (including RSU)
     expect(result.healthInsurance).toBeGreaterThan(0);
 
-    // 3. Pension is National Pension (fixed)
-    expect(result.pensionPayments).toBe(210_120); // 17,510 * 12
+    // 3. Pension is National Pension (3 months FY2025 + 9 months FY2026)
+    expect(result.pensionPayments).toBe(213_810);
 
     // 4. No employment insurance for NHI (NHI people don't have employment insurance)
     expect(result.employmentInsurance).toBe(0);
@@ -1005,11 +1101,11 @@ describe('RSU (Restricted Stock Unit) income', () => {
 
   it('calculateTotalNetIncome includes RSU in employment income deduction', () => {
     // RSU 2M should receive employment income deduction
-    // 2M in 1.9M-3.6M range: Net = 2M * 0.7 - 80k = 1.32M
+    // 2M below 2.2M: Net = 2M - 740k = 1.26M
     const incomeStreams = [
       { type: 'stockCompensation' as const, amount: 2_000_000, issuerDomicile: 'foreign' as const, id: 'rsu1' }
     ];
-    expect(calculateTotalNetIncome(incomeStreams)).toBe(1_320_000);
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(1_260_000);
   });
 
   it('calculateTotalNetIncome includes RSU with salary correctly', () => {
@@ -1019,7 +1115,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
       { type: 'salary' as const, amount: 3_000_000, frequency: 'annual' as const, id: 's1' },
       { type: 'stockCompensation' as const, amount: 2_000_000, issuerDomicile: 'foreign' as const, id: 'rsu1' }
     ];
-    expect(calculateTotalNetIncome(incomeStreams)).toBe(3_560_000);
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(3_560_000);
   });
 
   it('supports multiple stock compensation streams and sums them in tax calculations', () => {
@@ -1036,6 +1132,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
@@ -1044,6 +1141,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
     expect(result.annualIncome).toBe(5_000_000);
 
     // Net employment income is based on salary + stock compensation (5M total)
+    // 5M in 3.6M-6.6M range: Net = 5M * 0.8 - 440k = 3.56M
     expect(result.netEmploymentIncome).toBe(3_560_000);
     expect(result.totalNetIncome).toBe(3_560_000);
 
@@ -1058,7 +1156,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
       { type: 'stockCompensation' as const, amount: 800_000, issuerDomicile: 'foreign' as const, id: 'sc2' },
     ];
 
-    // Combined 2M in 1.9M-3.6M range: net = 2M * 0.7 - 80k = 1.32M
-    expect(calculateTotalNetIncome(incomeStreams)).toBe(1_320_000);
+    // Combined 2M below 2.2M: net = 2M - 740k = 1.26M
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(1_260_000);
   });
 });

--- a/src/components/TakeHomeCalculator/tabs/EmploymentIncomeDeductionTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/EmploymentIncomeDeductionTooltip.tsx
@@ -4,83 +4,98 @@
 import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { getEmploymentIncomeDeductionPeriod } from '../../../data/employmentIncomeDeduction';
 
-const EmploymentIncomeDeductionTooltip: React.FC = () => (
-    <Box>
-        <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
-            Employment Income Deduction Table
-        </Typography>
-        <Box
-            component="table"
-            sx={{
-                borderCollapse: 'collapse',
-                width: '100%',
-                fontSize: '0.95em',
-                '& td': {
-                    padding: '2px 6px'
-                },
-                '& th': {
-                    borderBottom: '1px solid #ccc',
-                    padding: '2px 6px',
-                    textAlign: 'left'
-                }
-            }}
-        >
-            <thead>
-                <tr>
-                    <th>Gross Employment Income (¥)</th>
-                    <th>Deduction Amount</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Up to 1,900,000</td>
-                    <td>650,000</td>
-                </tr>
-                <tr>
-                    <td>1,900,001 – 3,600,000</td>
-                    <td>30% of income + 80,000</td>
-                </tr>
-                <tr>
-                    <td>3,600,001 – 6,600,000</td>
-                    <td>20% of income + 440,000</td>
-                </tr>
-                <tr>
-                    <td>6,600,001 – 8,500,000</td>
-                    <td>10% of income + 1,100,000</td>
-                </tr>
-                <tr>
-                    <td>8,500,001 and above</td>
-                    <td>1,950,000 (max)</td>
-                </tr>
-            </tbody>
+const fmtNum = (n: number) => n.toLocaleString('en');
+
+interface EmploymentIncomeDeductionTooltipProps {
+    year: number;
+}
+
+const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionTooltipProps> = ({ year }) => {
+    const period = getEmploymentIncomeDeductionPeriod(year);
+
+    // The effective upper boundary of the flat-floor region (including transition values).
+    // For R8: transitions end at 2,199,999 → standard starts at 2,200,000.
+    // For R7: no transitions → standard starts at flatFloorGrossMaxInclusive + 1.
+    const flatUpperBound = period.transitionValues.length > 0
+        ? period.transitionValues[period.transitionValues.length - 1]!.grossMaxInclusive + 1
+        : period.flatFloorGrossMaxInclusive;
+
+    // Build rows from standardTiers
+    const tierRows = period.standardTiers.map((tier, i) => {
+        const lower = (i === 0 ? flatUpperBound : period.standardTiers[i - 1]!.grossMaxInclusive) + 1;
+        const isCap = !isFinite(tier.grossMaxInclusive);
+        const deductionPct = Math.round((1 - tier.retentionRate) * 100);
+
+        const range = isCap
+            ? `${fmtNum(lower)} and above`
+            : `${fmtNum(lower)} – ${fmtNum(tier.grossMaxInclusive)}`;
+
+        const deduction = isCap
+            ? `${fmtNum(tier.offset)} (max)`
+            : `${deductionPct}% of income + ${fmtNum(tier.offset)}`;
+
+        return { range, deduction };
+    });
+
+    return (
+        <Box>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                Employment Income Deduction Table
+            </Typography>
+            <Box
+                component="table"
+                sx={{
+                    borderCollapse: 'collapse',
+                    width: '100%',
+                    fontSize: '0.95em',
+                    '& td': {
+                        padding: '2px 6px'
+                    },
+                    '& th': {
+                        borderBottom: '1px solid #ccc',
+                        padding: '2px 6px',
+                        textAlign: 'left'
+                    }
+                }}
+            >
+                <thead>
+                    <tr>
+                        <th>Gross Employment Income (¥)</th>
+                        <th>Deduction Amount</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Up to {fmtNum(flatUpperBound)}</td>
+                        <td>{fmtNum(period.flatFloorDeduction)}</td>
+                    </tr>
+                    {tierRows.map((row, i) => (
+                        <tr key={i}>
+                            <td>{row.range}</td>
+                            <td>{row.deduction}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </Box>
+            <Box sx={{ mt: 1 }}>
+                Official Sources:
+                <ul>
+                    <li>
+                        <a href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
+                            給与所得控除 - NTA
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://www.nta.go.jp/english/taxes/individual/12012.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
+                            Overview of deduction for employment income - NTA (English)
+                        </a>
+                    </li>
+                </ul>
+            </Box>
         </Box>
-        <Box sx={{ mt: 1 }}>
-            Official Sources:
-            <ul>
-                <li>
-                    <a href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
-                        給与所得控除 - NTA
-                    </a>
-                </li>
-                <li>
-                    <a href="https://www.nta.go.jp/english/taxes/individual/12012.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
-                        Overview of deduction for employment income - NTA (English)
-                    </a>
-                </li>
-                <li>
-                    <a href="https://www.nta.go.jp/users/gensen/2025kiso/index.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
-                        令和７年度税制改正による所得税の基礎控除の見直し等について - NTA
-                    </a>
-                </li>
-                <li>
-                    <a href="https://www.city.yokohama.lg.jp/kurashi/koseki-zei-hoken/zeikin/y-shizei/kojin-shiminzei-kenminzei/R7kaisei.html" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
-                        令和７年度税制改正（いわゆる年収の壁への対応）の概要 - Yokohama City
-                    </a>
-                </li>
-            </ul>
-        </Box>
-    </Box>
-);
+    );
+};
 
 export default EmploymentIncomeDeductionTooltip;

--- a/src/components/TakeHomeCalculator/tabs/NationalPensionTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NationalPensionTooltip.tsx
@@ -1,0 +1,90 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { getNationalPensionMonthlyContribution } from '../../../data/nationalPensionContribution';
+import { formatJPY } from '../../../utils/formatters';
+
+const formatMonthShort = (month: number): string =>
+    new Date(2000, month).toLocaleString('en', { month: 'short' });
+
+const cellStyle = { padding: '2px 8px 2px 0' } as const;
+const rightCellStyle = { ...cellStyle, textAlign: 'right' as const };
+const headerStyle = { ...cellStyle, borderBottom: '1px solid #ccc', fontWeight: 'normal' as const };
+const rightHeaderStyle = { ...rightCellStyle, borderBottom: '1px solid #ccc', fontWeight: 'normal' as const };
+const totalStyle = { ...rightCellStyle, borderTop: '1px solid #ccc', fontWeight: 600 };
+
+interface NationalPensionTooltipProps {
+    year: number;
+}
+
+const NationalPensionTooltip: React.FC<NationalPensionTooltipProps> = ({ year }) => {
+    const months = Array.from({ length: 12 }, (_, month) => ({
+        month,
+        contribution: getNationalPensionMonthlyContribution(year, month),
+    }));
+
+    const annualTotal = months.reduce((sum, m) => sum + m.contribution, 0);
+
+    // Group consecutive months with the same contribution amount
+    const groups: { startMonth: number; endMonth: number; contribution: number }[] = [];
+    for (const { month, contribution } of months) {
+        const last = groups[groups.length - 1];
+        if (last && last.contribution === contribution) {
+            last.endMonth = month;
+        } else {
+            groups.push({ startMonth: month, endMonth: month, contribution });
+        }
+    }
+
+    const allSame = groups.length === 1;
+
+    return (
+        <Box>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                National Pension (国民年金)
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 1, fontSize: '0.85rem' }}>
+                National pension contributions are a fixed amount regardless of income level.
+                {!allSame && ' The monthly amount changes in April with the fiscal year.'}
+            </Typography>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+                <thead>
+                    <tr>
+                        <th style={headerStyle}>Period</th>
+                        <th style={rightHeaderStyle}>Monthly</th>
+                        <th style={rightHeaderStyle}>Subtotal</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {groups.map((g, idx) => {
+                        const count = g.endMonth - g.startMonth + 1;
+                        const label = g.startMonth === g.endMonth
+                            ? formatMonthShort(g.startMonth)
+                            : `${formatMonthShort(g.startMonth)}–${formatMonthShort(g.endMonth)}`;
+                        return (
+                            <tr key={idx}>
+                                <td style={cellStyle}>{label}</td>
+                                <td style={rightCellStyle}>{formatJPY(g.contribution)}</td>
+                                <td style={rightCellStyle}>{formatJPY(g.contribution * count)}</td>
+                            </tr>
+                        );
+                    })}
+                    <tr>
+                        <td colSpan={2} style={totalStyle}>Annual Total</td>
+                        <td style={totalStyle}>{formatJPY(annualTotal)}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <Box sx={{ mt: 1, fontSize: '0.85rem' }}>
+                Source: <a href="https://www.nenkin.go.jp/service/kokunen/hokenryo/hokenryo.html#cms01" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}>
+                    国民年金保険料の金額 (Japan Pension Service)
+                </a>
+            </Box>
+        </Box>
+    );
+};
+
+export default NationalPensionTooltip;

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -18,6 +18,7 @@ import PensionPremiumTooltip from './PensionPremiumTooltip';
 import EmploymentIncomeDeductionTooltip from './EmploymentIncomeDeductionTooltip';
 import HealthInsuranceBonusTooltip from './HealthInsuranceBonusTooltip';
 import PensionBonusTooltip from './PensionBonusTooltip';
+import NationalPensionTooltip from './NationalPensionTooltip';
 import { calculatePensionBonusBreakdown, findPensionBracket } from '../../../utils/pensionCalculator';
 import { calculateEmployeesHealthInsuranceBonusBreakdown } from '../../../utils/healthInsuranceCalculator';
 import type { BonusIncomeStream } from '../../../types/tax';
@@ -204,7 +205,7 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
                           </tr>
                         </tbody>
                       </table>
-                      <EmploymentIncomeDeductionTooltip />
+                      <EmploymentIncomeDeductionTooltip year={inputs.incomeYear ?? new Date().getFullYear()} />
                     </Box>
                   </DetailedTooltip>
                 </span>
@@ -438,17 +439,7 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
                 title="Pension Contribution"
                 icon={SIMPLE_TOOLTIP_ICON}
               >
-                <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
-                  National Pension (国民年金)
-                </Typography>
-                <Typography variant="body2" sx={{ mb: 1, fontSize: '0.85rem' }}>
-                  National pension contributions are a fixed amount regardless of income level.
-                </Typography>
-                <Box sx={{ mt: 1 }}>
-                  Source:<a href="https://www.nenkin.go.jp/service/kokunen/hokenryo/hokenryo.html#cms01" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
-                    国民年金保険料の金額 (Japan Pension Service)
-                  </a>
-                </Box >
+                <NationalPensionTooltip year={inputs.incomeYear ?? new Date().getFullYear()} />
               </DetailedTooltip>
             )}
           </Typography>

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -22,6 +22,7 @@ import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import { DetailedTooltip } from '../../ui/Tooltips';
 import { ResultRow } from '../ResultRow';
 import EmploymentIncomeDeductionTooltip from './EmploymentIncomeDeductionTooltip';
+import { getNationalBasicDeductionTiers } from '../../../data/nationalBasicDeduction';
 
 interface TaxesTabProps {
   results: TakeHomeResults;
@@ -109,6 +110,8 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
   // Almost taxable income but before applying the basic deduction
   const subtotalIncome = (results.totalNetIncome ?? results.annualIncome) - totalSocialInsurance - (results.dcPlanContributions ?? 0);
   const totalTaxes = results.nationalIncomeTax + results.residenceTax.totalResidenceTax;
+  const incomeYear = inputs.incomeYear ?? new Date().getFullYear();
+  const basicDeductionTiers = getNationalBasicDeductionTiers(incomeYear);
 
   // Calculate separated gross income
   const grossEmploymentIncome = inputs.incomeStreams
@@ -169,7 +172,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                         </Box>
                       </tbody>
                     </table>
-                    <EmploymentIncomeDeductionTooltip />
+                    <EmploymentIncomeDeductionTooltip year={incomeYear} />
                   </Box>
                 </DetailedTooltip>
               </span>
@@ -325,40 +328,17 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                       </tr>
                     </thead>
                     <tbody>
+                      {/* Deduplicate consecutive tiers with the same deduction */}
+                      {basicDeductionTiers
+                        .filter((tier, i, arr) => i === arr.length - 1 || tier.deduction !== arr[i + 1]!.deduction)
+                        .map((tier, i) => (
+                          <tr key={i}>
+                            <td>Up to {tier.maxIncomeInclusive.toLocaleString('en')}</td>
+                            <td>{tier.deduction.toLocaleString('en')}</td>
+                          </tr>
+                        ))}
                       <tr>
-                        <td>Up to 1,320,000</td>
-                        <td>950,000</td>
-                      </tr>
-                      <tr>
-                        <td>Up to 3,360,000</td>
-                        <td>880,000</td>
-                      </tr>
-                      <tr>
-                        <td>Up to 4,890,000</td>
-                        <td>680,000</td>
-                      </tr>
-                      <tr>
-                        <td>Up to 6,550,000</td>
-                        <td>630,000</td>
-                      </tr>
-                      <tr>
-                        <td>Up to 23,500,000</td>
-                        <td>580,000</td>
-                      </tr>
-                      <tr>
-                        <td>Up to 24,000,000</td>
-                        <td>480,000</td>
-                      </tr>
-                      <tr>
-                        <td>Up to 24,500,000</td>
-                        <td>320,000</td>
-                      </tr>
-                      <tr>
-                        <td>Up to 25,000,000</td>
-                        <td>160,000</td>
-                      </tr>
-                      <tr>
-                        <td>Over 25,000,000</td>
+                        <td>Over {basicDeductionTiers[basicDeductionTiers.length - 1]!.maxIncomeInclusive.toLocaleString('en')}</td>
                         <td>0</td>
                       </tr>
                     </tbody>

--- a/src/constants/taxThresholds.ts
+++ b/src/constants/taxThresholds.ts
@@ -2,26 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /**
- * National Income Tax Basic Deduction (基礎控除) tiers for 2025/2026
- * Source: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1199.htm
- * 2025 reform: https://www.nta.go.jp/users/gensen/2025kiso/index.htm#a-01
- *
- * Each tier is (income_max, deduction_amount). Applies to net income.
- */
-export const NATIONAL_BASIC_DEDUCTION_TIERS: ReadonlyArray<{ maxIncomeInclusive: number; deduction: number }> = [
-  { maxIncomeInclusive: 1_320_000,  deduction: 950_000 }, // Up from 480,000 in 2024
-  { maxIncomeInclusive: 3_360_000,  deduction: 880_000 }, // Will be 580,000 from 2027
-  { maxIncomeInclusive: 4_890_000,  deduction: 680_000 }, // Will be 580,000 from 2027
-  { maxIncomeInclusive: 6_550_000,  deduction: 630_000 }, // Will be 580,000 from 2027
-  { maxIncomeInclusive: 23_500_000, deduction: 580_000 }, // Up from 480,000 in 2024
-  { maxIncomeInclusive: 24_000_000, deduction: 480_000 }, // Unchanged for income > 23.5M
-  { maxIncomeInclusive: 24_500_000, deduction: 320_000 },
-  { maxIncomeInclusive: 25_000_000, deduction: 160_000 },
-  // Above 25,000,000: deduction = 0
-];
-
-/**
  * Cap on the non-taxable portion of commuting allowance (150,000 yen/month)
- * Source: https://www.nta.go.jp/taxes/shiraberu/taxanswer/gensen/2585.htm
+ * Source: https://www.nta.go.jp/taxes/shiraberu/taxanswer/gensen/2582.htm
  */
 export const COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP : number = 150_000 * 12;

--- a/src/data/dependentDeductionThresholds.ts
+++ b/src/data/dependentDeductionThresholds.ts
@@ -1,0 +1,61 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Dependent deduction income eligibility thresholds, indexed by income year.
+ *
+ * This threshold determines the maximum net income (合計所得金額) for a dependent
+ * (or spouse) to qualify for the dependent deduction (扶養控除) or spouse deduction (配偶者控除).
+ * It also serves as the lower bound for the spouse special deduction (配偶者特別控除)
+ * and specific relative special deduction (特定親族特別控除).
+ *
+ * The threshold tracks changes to the basic deduction (基礎控除) — when the basic
+ * deduction is raised, this threshold is raised by the same amount.
+ *
+ * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm — 扶養控除
+ * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1191.htm — 配偶者控除
+ */
+
+export interface DependentDeductionThresholdPeriod {
+    /** The income year (calendar year) from which this threshold applies (inclusive) */
+    effectiveYear: number;
+    /** Max net income (inclusive) for dependent/spouse deduction eligibility, in yen */
+    dependentEligibilityMax: number;
+}
+
+/**
+ * Time-series of dependent deduction eligibility thresholds, sorted newest-first.
+ */
+export const DEPENDENT_DEDUCTION_THRESHOLD_PERIODS: ReadonlyArray<DependentDeductionThresholdPeriod> = [
+    // R8 (2026): raised from 58万 to 62万 per 令和8年度税制改正
+    { effectiveYear: 2026, dependentEligibilityMax: 620_000 },
+    // R7 (2025): raised from 48万 to 58万 per 令和7年度税制改正
+    { effectiveYear: 2025, dependentEligibilityMax: 580_000 },
+];
+
+if (import.meta.env.DEV) {
+    for (let i = 1; i < DEPENDENT_DEDUCTION_THRESHOLD_PERIODS.length; i++) {
+        const prev = DEPENDENT_DEDUCTION_THRESHOLD_PERIODS[i - 1]!.effectiveYear;
+        const curr = DEPENDENT_DEDUCTION_THRESHOLD_PERIODS[i]!.effectiveYear;
+        if (prev <= curr) {
+            throw new Error(
+                `DEPENDENT_DEDUCTION_THRESHOLD_PERIODS must be sorted newest-first, ` +
+                `but entry ${i - 1} (year ${prev}) is not after entry ${i} (year ${curr})`
+            );
+        }
+    }
+}
+
+/**
+ * Returns the dependent/spouse deduction eligibility max for the given income year.
+ *
+ * @param year Income year (calendar year the income was earned)
+ */
+export const getDependentEligibilityMax = (year: number): number => {
+    for (const period of DEPENDENT_DEDUCTION_THRESHOLD_PERIODS) {
+        if (year >= period.effectiveYear) {
+            return period.dependentEligibilityMax;
+        }
+    }
+    return DEPENDENT_DEDUCTION_THRESHOLD_PERIODS[DEPENDENT_DEDUCTION_THRESHOLD_PERIODS.length - 1]!.dependentEligibilityMax;
+};

--- a/src/data/employmentIncomeDeduction.ts
+++ b/src/data/employmentIncomeDeduction.ts
@@ -1,0 +1,193 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Employment Income Deduction (給与所得控除) tables, indexed by income year.
+ *
+ * The deduction is determined by the taxpayer's gross employment income (給与等の収入金額).
+ * Each period defines the flat-floor region, any fixed transition values, and the standard
+ * percentage-formula tiers that apply for the given income year.
+ *
+ * Source: NTA overview: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm
+ */
+
+/** One tier in the standard percentage-formula region. */
+export interface EmploymentIncomeStandardTier {
+    /** Upper bound of gross salary (inclusive) for this tier. Use Infinity for the final cap tier. */
+    grossMaxInclusive: number;
+    /**
+     * Net retention rate applied to (optionally rounded) gross:
+     *   net = floor(base × retentionRate) − offset
+     * where base = roundTo4k ? floor(gross / 4000) × 4000 : gross
+     */
+    retentionRate: number;
+    /** Constant subtracted after applying the retention rate. */
+    offset: number;
+    /** Whether to round gross down to the nearest 4,000 yen before applying the rate. */
+    roundTo4k: boolean;
+}
+
+/**
+ * All parameters describing the employment income deduction for one income-year period.
+ * The compute logic is:
+ *  1. gross < flatFloorGrossMinInclusive  →  net = 0
+ *  2. flatFloorGrossMinInclusive ≤ gross ≤ flatFloorGrossMaxInclusive  →  net = gross − flatFloorDeduction
+ *  3. transitionValues (checked in order)  →  first matching grossMaxInclusive wins
+ *  4. standardTiers (checked in order)  →  first matching grossMaxInclusive wins
+ */
+export interface EmploymentIncomeDeductionPeriod {
+    /**
+     * The income year (calendar year) from which this period's rules apply (inclusive).
+     * Periods are sorted newest-first; the lookup returns the first period where year ≥ effectiveYear.
+     */
+    effectiveYear: number;
+
+    /**
+     * Minimum gross salary (inclusive) at which a positive net is possible.
+     * For gross < this value, net = 0.
+     *   R7 (2025): 650_001 — ITA Art 28(3) flat floor is 65万; gross ≤ 65万 → net ≤ 0
+     *   R8 (2026): 741_000 — STMA Art 29-4 para 2 item 1 explicitly sets net = 0 for 69.1万–74万
+     */
+    flatFloorGrossMinInclusive: number;
+
+    /**
+     * Flat deduction applied in the floor region:
+     *   net = gross − flatFloorDeduction
+     * for flatFloorGrossMinInclusive ≤ gross ≤ flatFloorGrossMaxInclusive.
+     */
+    flatFloorDeduction: number;
+
+    /**
+     * Maximum gross salary (inclusive) for the flat-floor region.
+     *   R7: 1_900_000 — ITA Art 28(3) item 1 applies up to 190万
+     *   R8: 2_190_999 — STMA Art 29-4 para 2 item 2: up to (but not incl.) 219万1千
+     */
+    flatFloorGrossMaxInclusive: number;
+
+    /**
+     * Fixed net-income values for specific gross ranges that sit between the flat-floor region
+     * and the standard formula region. Checked in order; first match (gross ≤ grossMaxInclusive) wins.
+     * Sorted by grossMaxInclusive ascending.
+     *   R7: empty — the 30% formula joins smoothly at 190万 with no special steps
+     *   R8: three steps spanning 219万1千–219万9999 (near the 220万 boundary)
+     */
+    transitionValues: ReadonlyArray<{ grossMaxInclusive: number; net: number }>;
+
+    /**
+     * Standard percentage-formula tiers for gross above the flat-floor and all transition values.
+     * Sorted by grossMaxInclusive ascending; the final tier must have grossMaxInclusive = Infinity
+     * to handle the deduction cap (e.g. 195万 or 199万).
+     */
+    standardTiers: ReadonlyArray<EmploymentIncomeStandardTier>;
+}
+
+/**
+ * Time-series of employment income deduction parameters, sorted newest-first.
+ * Each entry defines the rules in effect for the given income year onward.
+ */
+export const EMPLOYMENT_INCOME_DEDUCTION_PERIODS: ReadonlyArray<EmploymentIncomeDeductionPeriod> = [
+    // R8/R9 (令和8年・令和9年) — income years 2026–2027
+    // Permanent base: ITA Art 28(3) amended (floor 69万 for salary ≤ ~230万, cap 195万)
+    //   Only item 1's minimum changed (65万→69万); items 2–4 (tiers above 360万) are unchanged.
+    //   Effective December 1, 2026 (applies to all 2026 income)
+    //   Source: https://laws.e-gov.go.jp/law/340AC0000000033/20261201_508AC0000000012#Mp-Pa_2-Ch_2-Se_2-Ss_1-At_28
+    // Temporary +5万: STMA Art 29-4 (R8/R9) extends floor to 74万 for salary ≤ 220万
+    //   Source: https://laws.e-gov.go.jp/law/332AC0000000026/20261201_508AC0000000012#Mp-Ch_2-Se_3-At_29_4
+    {
+        effectiveYear: 2026,
+        flatFloorGrossMinInclusive: 741_000,  // STMA Art 29-4 para 2 item 2: net > 0 starts at 74万1千
+        flatFloorDeduction:         740_000,  // 74万 (69万 ITA permanent + 5万 STMA temporary)
+        flatFloorGrossMaxInclusive: 2_190_999, // Art 29-4 para 2 item 2: up to (not incl.) 219万1千
+        transitionValues: [
+            // STMA Art 29-4 para 2 items 3–5: fixed net values near the 220万 boundary
+            { grossMaxInclusive: 2_192_999, net: 1_451_000 }, // 219万1千–219万3千: net = 145万1千
+            { grossMaxInclusive: 2_195_999, net: 1_453_000 }, // 219万3千–219万6千: net = 145万3千
+            { grossMaxInclusive: 2_199_999, net: 1_456_000 }, // 219万6千–220万:   net = 145万6千
+        ],
+        standardTiers: [
+            // ITA Art 28(3) items 1–4 — standard tiers unchanged from R7
+            // Item 1: deduction = 8万 + gross×30% (min 69万) → net = gross×0.7 − 8万
+            // Items 2–4: unchanged offsets (116万, 176万, 195万 deductions)
+            { grossMaxInclusive: 3_600_000, retentionRate: 0.7, offset:    80_000, roundTo4k: true  },
+            { grossMaxInclusive: 6_600_000, retentionRate: 0.8, offset:   440_000, roundTo4k: true  },
+            { grossMaxInclusive: 8_500_000, retentionRate: 0.9, offset: 1_100_000, roundTo4k: false },
+            { grossMaxInclusive: Infinity,  retentionRate: 1.0, offset: 1_950_000, roundTo4k: false }, // 195万 cap
+        ],
+    },
+    // R7 (令和7年) — income year 2025
+    // Permanent base: ITA Art 28(3) amended (floor 65万 for salary ≤ 190万, cap 195万)
+    //   Effective December 1, 2025 (applies to all 2025 income)
+    //   Source: https://laws.e-gov.go.jp/law/340AC0000000033/20251201_507AC0000000013?occasion_date=20251201#Mp-Pa_2-Ch_2-Se_2-Ss_1-At_28
+    {
+        effectiveYear: 2025,
+        flatFloorGrossMinInclusive: 650_001,  // ITA Art 28(3) item 1: net > 0 starts at 65万+1円
+        flatFloorDeduction:         650_000,  // 65万
+        flatFloorGrossMaxInclusive: 1_900_000, // ITA Art 28(3) item 1: applies up to 190万 (inclusive)
+        transitionValues: [],                 // Smooth join: 30%-formula gives same value at exactly 190万
+        standardTiers: [
+            // ITA Art 28(3) items 2–5 (R7 amended constants), with 4000-yen rounding per Art 28(4)
+            { grossMaxInclusive: 3_600_000, retentionRate: 0.7, offset:    80_000, roundTo4k: true  },
+            { grossMaxInclusive: 6_600_000, retentionRate: 0.8, offset:   440_000, roundTo4k: true  },
+            { grossMaxInclusive: 8_500_000, retentionRate: 0.9, offset: 1_100_000, roundTo4k: false },
+            { grossMaxInclusive: Infinity,  retentionRate: 1.0, offset: 1_950_000, roundTo4k: false }, // 195万 cap
+        ],
+    },
+];
+
+if (import.meta.env.DEV) {
+    for (let i = 1; i < EMPLOYMENT_INCOME_DEDUCTION_PERIODS.length; i++) {
+        const prev = EMPLOYMENT_INCOME_DEDUCTION_PERIODS[i - 1]!.effectiveYear;
+        const curr = EMPLOYMENT_INCOME_DEDUCTION_PERIODS[i]!.effectiveYear;
+        if (prev <= curr) {
+            throw new Error(
+                `EMPLOYMENT_INCOME_DEDUCTION_PERIODS must be sorted newest-first, ` +
+                `but entry ${i - 1} (year ${prev}) is not after entry ${i} (year ${curr})`
+            );
+        }
+    }
+}
+
+/**
+ * Returns the employment income deduction period applicable for the given income year.
+ * Finds the most recent period whose effectiveYear is on or before the given year.
+ *
+ * @param year Income year (calendar year the income was earned)
+ */
+export const getEmploymentIncomeDeductionPeriod = (year: number): EmploymentIncomeDeductionPeriod => {
+    for (const period of EMPLOYMENT_INCOME_DEDUCTION_PERIODS) {
+        if (year >= period.effectiveYear) return period;
+    }
+    return EMPLOYMENT_INCOME_DEDUCTION_PERIODS[EMPLOYMENT_INCOME_DEDUCTION_PERIODS.length - 1]!;
+};
+
+/**
+ * Calculates net employment income (給与所得の金額) for a given period.
+ *
+ * @param grossEmploymentIncome  Gross employment income (給与等の収入金額) in yen
+ * @param period                 The deduction period parameters to apply
+ */
+export const calculateNetEmploymentIncomeForPeriod = (
+    grossEmploymentIncome: number,
+    period: EmploymentIncomeDeductionPeriod
+): number => {
+    if (grossEmploymentIncome < period.flatFloorGrossMinInclusive) return 0;
+
+    if (grossEmploymentIncome <= period.flatFloorGrossMaxInclusive) {
+        return grossEmploymentIncome - period.flatFloorDeduction;
+    }
+
+    for (const { grossMaxInclusive, net } of period.transitionValues) {
+        if (grossEmploymentIncome <= grossMaxInclusive) return net;
+    }
+
+    for (const tier of period.standardTiers) {
+        if (grossEmploymentIncome <= tier.grossMaxInclusive) {
+            const base = tier.roundTo4k
+                ? Math.floor(grossEmploymentIncome / 4000) * 4000
+                : grossEmploymentIncome;
+            return Math.floor(base * tier.retentionRate) - tier.offset;
+        }
+    }
+
+    return 0; // unreachable: final tier has grossMaxInclusive = Infinity
+};

--- a/src/data/nationalBasicDeduction.ts
+++ b/src/data/nationalBasicDeduction.ts
@@ -1,0 +1,108 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * National Income Tax Basic Deduction (基礎控除) tier tables, indexed by income year.
+ *
+ * The deduction is determined by the taxpayer's net income (合計所得金額).
+ * Each tier lists the maximum net income (inclusive) and the corresponding deduction amount.
+ *
+ * Source: NTA overview: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1199.htm
+ */
+
+export interface BasicDeductionTier {
+    /** Maximum net income (inclusive) for this tier, in yen */
+    maxIncomeInclusive: number;
+    /** Deduction amount in yen */
+    deduction: number;
+}
+
+export interface BasicDeductionTierPeriod {
+    /** The income year (calendar year) from which this tier set applies (inclusive) */
+    effectiveYear: number;
+    /** Tiers sorted by maxIncomeInclusive ascending; income above all tiers → deduction = 0 */
+    tiers: ReadonlyArray<BasicDeductionTier>;
+}
+
+/**
+ * Time-series of national basic deduction tier tables, sorted newest-first.
+ * Each entry defines the tiers in effect for the given income year onward.
+ */
+export const NATIONAL_BASIC_DEDUCTION_TIER_PERIODS: ReadonlyArray<BasicDeductionTierPeriod> = [
+    // R8 (令和8年) — income year 2026 onward
+    // Base deduction: Art. 86 raised from 58万 to 62万, effective December 1, 2026
+    //   Source: https://laws.e-gov.go.jp/law/340AC0000000033/20261201_508AC0000000012?occasion_date=20261201#Mp-Pa_2-Ch_2-Se_4-At_86
+    // Temporary additions: Special Tax Measures Act Art. 41-16-2 (December 1, 2026 version):
+    //   net income ≤ 489万: +42万 → combined 104万
+    //   489万 < net ≤ 655万: +5万 → combined 67万
+    //   net > 655万: 0 → combined 62万
+    //   Source: https://laws.e-gov.go.jp/law/332AC0000000026/20261201_508AC0000000012?occasion_date=20261201#Mp-Ch_2-Se_6-At_41_16_2
+    {
+        effectiveYear: 2026,
+        tiers: [
+            { maxIncomeInclusive:  1_320_000, deduction: 1_040_000 }, // 62万 base + 42万 temp = 104万
+            { maxIncomeInclusive:  3_360_000, deduction: 1_040_000 }, // 62万 base + 42万 temp = 104万
+            { maxIncomeInclusive:  4_890_000, deduction: 1_040_000 }, // 62万 base + 42万 temp = 104万
+            { maxIncomeInclusive:  6_550_000, deduction:   670_000 }, // 62万 base + 5万 temp = 67万
+            { maxIncomeInclusive: 23_500_000, deduction:   620_000 }, // 62万 base, no temp addition
+            { maxIncomeInclusive: 24_000_000, deduction:   480_000 }, // Phase-down (unchanged from R7)
+            { maxIncomeInclusive: 24_500_000, deduction:   320_000 },
+            { maxIncomeInclusive: 25_000_000, deduction:   160_000 },
+            // Above 25,000,000: deduction = 0
+        ],
+    },
+    // R7 (令和7年) — income year 2025
+    // Base deduction: Art. 86 raised from 48万 to 58万, effective June 1, 2025
+    //   Source: Income Tax Act Article 86: https://laws.e-gov.go.jp/law/340AC0000000033/20250601_504AC0000000068?occasion_date=20250601#Mp-Pa_2-Ch_2-Se_4-At_86
+    // Temporary additions: Special Tax Measures Act Art. 41-16-2 (December 1 2025 version):
+    //   net income ≤ 132万: +37万 → combined 95万
+    //   132万 < net ≤ 336万: +30万 → combined 88万
+    //   336万 < net ≤ 489万: +10万 → combined 68万
+    //   489万 < net ≤ 655万: +5万 → combined 63万
+    //   net > 655万: 0 → combined 58万
+    // Source: Special Tax Measures Act Article 41-16-2: https://laws.e-gov.go.jp/law/332AC0000000026/20251201_507AC0000000013?occasion_date=20251201#Mp-Ch_2-Se_6-At_41_16_2
+    {
+        effectiveYear: 2025,
+        tiers: [
+            { maxIncomeInclusive:  1_320_000, deduction:   950_000 }, // 58万 base + 37万 temp = 95万
+            { maxIncomeInclusive:  3_360_000, deduction:   880_000 }, // 58万 base + 30万 temp = 88万
+            { maxIncomeInclusive:  4_890_000, deduction:   680_000 }, // 58万 base + 10万 temp = 68万
+            { maxIncomeInclusive:  6_550_000, deduction:   630_000 }, // 58万 base + 5万 temp = 63万
+            { maxIncomeInclusive: 23_500_000, deduction:   580_000 }, // 58万 base, no temp addition
+            { maxIncomeInclusive: 24_000_000, deduction:   480_000 }, // Phase-down
+            { maxIncomeInclusive: 24_500_000, deduction:   320_000 },
+            { maxIncomeInclusive: 25_000_000, deduction:   160_000 },
+            // Above 25,000,000: deduction = 0
+        ],
+    },
+];
+
+if (import.meta.env.DEV) {
+    // Validate that the periods are sorted newest-first
+    for (let i = 1; i < NATIONAL_BASIC_DEDUCTION_TIER_PERIODS.length; i++) {
+        const prev = NATIONAL_BASIC_DEDUCTION_TIER_PERIODS[i - 1]!.effectiveYear;
+        const curr = NATIONAL_BASIC_DEDUCTION_TIER_PERIODS[i]!.effectiveYear;
+        if (prev <= curr) {
+            throw new Error(
+                `NATIONAL_BASIC_DEDUCTION_TIER_PERIODS must be sorted newest-first, ` +
+                `but entry ${i - 1} (year ${prev}) is not after entry ${i} (year ${curr})`
+            );
+        }
+    }
+}
+
+/**
+ * Returns the basic deduction tiers applicable for the given income year.
+ * Finds the most recent period whose effectiveYear is on or before the given year.
+ *
+ * @param year Income year (calendar year the income was earned)
+ */
+export const getNationalBasicDeductionTiers = (year: number): ReadonlyArray<BasicDeductionTier> => {
+    for (const period of NATIONAL_BASIC_DEDUCTION_TIER_PERIODS) {
+        if (year >= period.effectiveYear) {
+            return period.tiers;
+        }
+    }
+    // Fallback to the oldest known tiers
+    return NATIONAL_BASIC_DEDUCTION_TIER_PERIODS[NATIONAL_BASIC_DEDUCTION_TIER_PERIODS.length - 1]!.tiers;
+};

--- a/src/data/nationalPensionContribution.ts
+++ b/src/data/nationalPensionContribution.ts
@@ -1,0 +1,75 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * National pension (国民年金) monthly contribution amounts.
+ *
+ * The contribution is a fixed monthly amount set per fiscal year (April–March).
+ * Assumes monthly payment (毎月納付), the default payment method with no advance discount.
+ *
+ * Source: https://www.nenkin.go.jp/service/kokunen/hokenryo/hokenryo.html
+ * Historical rates: https://www.nenkin.go.jp/service/kokunen/hokenryo/hensen.html
+ */
+
+export interface NationalPensionContributionPeriod {
+    /** The date from which this rate applies (inclusive). Month is 0-indexed (0=Jan, 3=Apr). */
+    effectiveFrom: { year: number; month: number };
+    /** Monthly contribution in yen */
+    monthlyContribution: number;
+}
+
+/**
+ * Time-series of national pension contribution amounts, sorted newest-first.
+ * Each entry defines the monthly contribution starting from the given date.
+ */
+export const NATIONAL_PENSION_CONTRIBUTION_PERIODS: ReadonlyArray<NationalPensionContributionPeriod> = [
+    // FY2026 (令和8年度): April 2026 – March 2027
+    { effectiveFrom: { year: 2026, month: 3 }, monthlyContribution: 17_920 },
+    // FY2025 (令和7年度): April 2025 – March 2026
+    { effectiveFrom: { year: 2025, month: 3 }, monthlyContribution: 17_510 },
+    // FY2024 (令和6年度): April 2024 – March 2025
+    { effectiveFrom: { year: 2024, month: 3 }, monthlyContribution: 16_980 },
+];
+
+if (import.meta.env.DEV) {
+    for (let i = 1; i < NATIONAL_PENSION_CONTRIBUTION_PERIODS.length; i++) {
+        const prev = NATIONAL_PENSION_CONTRIBUTION_PERIODS[i - 1]!.effectiveFrom;
+        const curr = NATIONAL_PENSION_CONTRIBUTION_PERIODS[i]!.effectiveFrom;
+        if (prev.year < curr.year || (prev.year === curr.year && prev.month <= curr.month)) {
+            throw new Error(
+                `NATIONAL_PENSION_CONTRIBUTION_PERIODS must be sorted newest-first, ` +
+                `but entry ${i - 1} (${prev.year}-${prev.month}) is not after entry ${i} (${curr.year}-${curr.month})`
+            );
+        }
+    }
+}
+
+/**
+ * Returns the monthly national pension contribution for a given year and month.
+ *
+ * @param year Calendar year
+ * @param month 0-indexed month (0=Jan, 11=Dec)
+ */
+export const getNationalPensionMonthlyContribution = (year: number, month: number): number => {
+    for (const period of NATIONAL_PENSION_CONTRIBUTION_PERIODS) {
+        const { effectiveFrom } = period;
+        if (year > effectiveFrom.year || (year === effectiveFrom.year && month >= effectiveFrom.month)) {
+            return period.monthlyContribution;
+        }
+    }
+    return NATIONAL_PENSION_CONTRIBUTION_PERIODS[NATIONAL_PENSION_CONTRIBUTION_PERIODS.length - 1]!.monthlyContribution;
+};
+
+/**
+ * Returns the total annual national pension contribution for a given calendar year,
+ * summing the 12 monthly contributions (which may span two fiscal years).
+ *
+ * @param year Calendar year
+ */
+export const getNationalPensionAnnualTotal = (year: number): number => {
+    let total = 0;
+    for (let month = 0; month < 12; month++) {
+        total += getNationalPensionMonthlyContribution(year, month);
+    }
+    return total;
+};

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -72,6 +72,7 @@ export interface TakeHomeInputs {
   manualSocialInsuranceEntry: boolean;
   manualSocialInsuranceAmount: number;
   customEHIRates?: CustomEmployeesHealthInsuranceRates | undefined;
+  incomeYear?: number;
 }
 
 export interface CustomEmployeesHealthInsuranceRates {

--- a/src/utils/dependentDeductions.ts
+++ b/src/utils/dependentDeductions.ts
@@ -27,56 +27,33 @@ import type {
 } from '../types/dependents';
 import { DEDUCTION_TYPES } from '../types/dependents';
 import { calculateNetEmploymentIncome } from './taxCalculations';
+import { getDependentEligibilityMax } from '../data/dependentDeductionThresholds';
 
-/**
- * Income thresholds for dependent deductions (2025 tax year - 令和7年)
- * 
- * These thresholds determine eligibility for various dependent deductions.
- * The amounts are inclusive, meaning the dependent can have income up to and including these values.
- * Updated December 1, 2025 per 令和7年度税制改正.
- * 
- * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm - 扶養控除
- * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1191.htm - 配偶者控除  
- * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1195.htm - 配偶者特別控除
- * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1177.htm - 特定親族特別控除
+export { getDependentEligibilityMax };
+
+/** Maximum total net income (合計所得金額) for spouse special deduction eligibility (配偶者特別控除).
+ * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1195.htm
  */
-export const DEPENDENT_INCOME_THRESHOLDS = {
-  /**
-   * Maximum total net income for dependent deduction eligibility (扶養控除)
-   * Changed from 480,000 yen to 580,000 yen in 2025 tax reform
-   */
-  DEPENDENT_DEDUCTION_MAX: 580_000,
-  
-  /**
-   * Maximum total net income for spouse deduction eligibility (配偶者控除)
-   * Changed from 480,000 yen to 580,000 yen in 2025 tax reform
-   */
-  SPOUSE_DEDUCTION_MAX: 580_000,
-  
-  /**
-   * Maximum total net income for spouse special deduction eligibility (配偶者特別控除)
-   * Upper limit remains at 1,330,000 yen (no change in 2025)
-   */
-  SPOUSE_SPECIAL_DEDUCTION_MAX: 1_330_000,
-  
-  /**
-   * Maximum total net income for specific relative special deduction (特定親族特別控除)
-   * Upper limit is 1,230,000 yen (123万円)
-   * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1177.htm
-   */
-  SPECIFIC_RELATIVE_DEDUCTION_MAX: 1_230_000,
-} as const;
+const SPOUSE_SPECIAL_DEDUCTION_MAX_INCOME = 1_330_000;
+
+/** Maximum total net income (合計所得金額) for specific relative special deduction (特定親族特別控除).
+ * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1177.htm
+ */
+const SPECIFIC_RELATIVE_DEDUCTION_MAX_INCOME = 1_230_000;
 
 /**
  * Calculate total net income (合計所得金額) for a dependent
  * This is used to determine eligibility for various dependent deductions
+ *
+ * @param income  The dependent's income breakdown
+ * @param year    Income year for the employment income deduction lookup; defaults to current year
  */
-export function calculateDependentTotalNetIncome(income: DependentIncome): number {
+export function calculateDependentTotalNetIncome(income: DependentIncome, year: number = new Date().getFullYear()): number {
   const { grossEmploymentIncome, otherNetIncome } = income;
-  
+
   // Calculate net employment income using employment income deduction formula
-  const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome);
-  
+  const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, year);
+
   // Total net income = net employment income + other net income
   return netEmploymentIncome + otherNetIncome;
 }
@@ -85,7 +62,7 @@ export function calculateDependentTotalNetIncome(income: DependentIncome): numbe
  * Check if dependent is eligible for Dependent Deduction (扶養控除).
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm
  */
-function isEligibleForDependentDeduction(dependent: Dependent): boolean {
+function isEligibleForDependentDeduction(dependent: Dependent, year: number): boolean {
   if (dependent.relationship === 'spouse') {
     // Spouse is a special case because of the spouse deduction and spouse special deduction.
     return false;
@@ -98,8 +75,8 @@ function isEligibleForDependentDeduction(dependent: Dependent): boolean {
     return false;
   }
 
-  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
-  return totalNetIncome <= DEPENDENT_INCOME_THRESHOLDS.DEPENDENT_DEDUCTION_MAX;
+  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, year);
+  return totalNetIncome <= getDependentEligibilityMax(year);
 }
 
 /**
@@ -109,8 +86,8 @@ function isEligibleForDependentDeduction(dependent: Dependent): boolean {
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/yogo/senmon.htm#word9
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm
  */
-function isSpecialDependent(dependent: Dependent): boolean {
-  return isEligibleForDependentDeduction(dependent) && 
+function isSpecialDependent(dependent: Dependent, year: number): boolean {
+  return isEligibleForDependentDeduction(dependent, year) &&
          (dependent as OtherDependent).ageCategory === '19to22';
 }
 
@@ -121,8 +98,8 @@ function isSpecialDependent(dependent: Dependent): boolean {
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/yogo/senmon.htm#word10
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm
  */
-function isElderlyDependent(dependent: Dependent): boolean {
-  return isEligibleForDependentDeduction(dependent) &&
+function isElderlyDependent(dependent: Dependent, year: number): boolean {
+  return isEligibleForDependentDeduction(dependent, year) &&
          (dependent as OtherDependent).ageCategory === '70plus';
 }
 
@@ -130,25 +107,25 @@ function isElderlyDependent(dependent: Dependent): boolean {
  * Check if dependent is eligible for Spouse Deduction (配偶者控除).
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1191.htm
  */
-function isEligibleForSpouseDeduction(dependent: Dependent): boolean {
+function isEligibleForSpouseDeduction(dependent: Dependent, year: number): boolean {
   if (dependent.relationship !== 'spouse') {
     return false;
   }
-  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
-  return totalNetIncome <= DEPENDENT_INCOME_THRESHOLDS.SPOUSE_DEDUCTION_MAX;
+  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, year);
+  return totalNetIncome <= getDependentEligibilityMax(year);
 }
 
 /**
  * Check if dependent is eligible for Spouse Special Deduction (配偶者特別控除).
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1195.htm
  */
-function isEligibleForSpouseSpecialDeduction(dependent: Dependent): boolean {
+function isEligibleForSpouseSpecialDeduction(dependent: Dependent, year: number): boolean {
   if (dependent.relationship !== 'spouse') {
     return false;
   }
-  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
-  return totalNetIncome > DEPENDENT_INCOME_THRESHOLDS.SPOUSE_DEDUCTION_MAX && 
-         totalNetIncome <= DEPENDENT_INCOME_THRESHOLDS.SPOUSE_SPECIAL_DEDUCTION_MAX;
+  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, year);
+  return totalNetIncome > getDependentEligibilityMax(year) &&
+         totalNetIncome <= SPOUSE_SPECIAL_DEDUCTION_MAX_INCOME;
 }
 
 /**
@@ -156,21 +133,21 @@ function isEligibleForSpouseSpecialDeduction(dependent: Dependent): boolean {
  * Age 19-22 (19歳以上23歳未満) on December 31st, not spouse.
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1177.htm
  */
-function isEligibleForSpecificRelativeSpecialDeduction(dependent: Dependent): boolean {
+function isEligibleForSpecificRelativeSpecialDeduction(dependent: Dependent, year: number): boolean {
   if (dependent.relationship === 'spouse') {
     return false;
   }
   const otherDependent = dependent as OtherDependent;
   const ageCategory = otherDependent.ageCategory;
-  
+
   // Only age 19-22 are eligible (19歳以上23歳未満)
   if (ageCategory !== '19to22') {
     return false;
   }
-  
-  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
-  return totalNetIncome > DEPENDENT_INCOME_THRESHOLDS.DEPENDENT_DEDUCTION_MAX && 
-         totalNetIncome <= DEPENDENT_INCOME_THRESHOLDS.SPECIFIC_RELATIVE_DEDUCTION_MAX;
+
+  const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, year);
+  return totalNetIncome > getDependentEligibilityMax(year) &&
+         totalNetIncome <= SPECIFIC_RELATIVE_DEDUCTION_MAX_INCOME;
 }
 
 /**
@@ -347,32 +324,34 @@ const SPOUSE_DEDUCTION_PHASE_OUT = {
  * The deduction amounts are legislated values from the tax tables, not calculated ratios.
  * National tax and residence tax have different bracket structures and phase-out patterns.
  * 
- * Each entry specifies:
- * - minIncome: Lower bound of spouse income bracket (exclusive, in yen)
- * - maxIncome: Upper bound of spouse income bracket (inclusive, in yen)
- * - amounts: Deduction amounts for each taxpayer income level
+ * Brackets are ordered by maxIncome ascending. The lower bound of the first bracket is
+ * the year-dependent eligibility threshold (getDependentEligibilityMax); subsequent brackets
+ * are contiguous so only maxIncome is needed.
+ *
+ * Bracket structure is the same for R7 (2025) and R8 (2026) onward (令和7年分以降).
+ * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1195.htm
  */
 const SPOUSE_SPECIAL_DEDUCTION_TABLE = {
   NATIONAL: [
-    { minIncome: 580_000, maxIncome: 950_000, amounts: { under900: 380_000, bracket900_950: 260_000, bracket950_1000: 130_000 } },
-    { minIncome: 950_000, maxIncome: 1_000_000, amounts: { under900: 360_000, bracket900_950: 240_000, bracket950_1000: 120_000 } },
-    { minIncome: 1_000_000, maxIncome: 1_050_000, amounts: { under900: 310_000, bracket900_950: 210_000, bracket950_1000: 110_000 } },
-    { minIncome: 1_050_000, maxIncome: 1_100_000, amounts: { under900: 260_000, bracket900_950: 180_000, bracket950_1000: 90_000 } },
-    { minIncome: 1_100_000, maxIncome: 1_150_000, amounts: { under900: 210_000, bracket900_950: 140_000, bracket950_1000: 70_000 } },
-    { minIncome: 1_150_000, maxIncome: 1_200_000, amounts: { under900: 160_000, bracket900_950: 110_000, bracket950_1000: 60_000 } },
-    { minIncome: 1_200_000, maxIncome: 1_250_000, amounts: { under900: 110_000, bracket900_950: 80_000, bracket950_1000: 40_000 } },
-    { minIncome: 1_250_000, maxIncome: 1_300_000, amounts: { under900: 60_000, bracket900_950: 40_000, bracket950_1000: 20_000 } },
-    { minIncome: 1_300_000, maxIncome: 1_330_000, amounts: { under900: 30_000, bracket900_950: 20_000, bracket950_1000: 10_000 } },
+    { maxIncome:   950_000, amounts: { under900: 380_000, bracket900_950: 260_000, bracket950_1000: 130_000 } },
+    { maxIncome: 1_000_000, amounts: { under900: 360_000, bracket900_950: 240_000, bracket950_1000: 120_000 } },
+    { maxIncome: 1_050_000, amounts: { under900: 310_000, bracket900_950: 210_000, bracket950_1000: 110_000 } },
+    { maxIncome: 1_100_000, amounts: { under900: 260_000, bracket900_950: 180_000, bracket950_1000: 90_000 } },
+    { maxIncome: 1_150_000, amounts: { under900: 210_000, bracket900_950: 140_000, bracket950_1000: 70_000 } },
+    { maxIncome: 1_200_000, amounts: { under900: 160_000, bracket900_950: 110_000, bracket950_1000: 60_000 } },
+    { maxIncome: 1_250_000, amounts: { under900: 110_000, bracket900_950: 80_000, bracket950_1000: 40_000 } },
+    { maxIncome: 1_300_000, amounts: { under900: 60_000, bracket900_950: 40_000, bracket950_1000: 20_000 } },
+    { maxIncome: 1_330_000, amounts: { under900: 30_000, bracket900_950: 20_000, bracket950_1000: 10_000 } },
   ],
   RESIDENCE: [
-    { minIncome: 580_000, maxIncome: 1_000_000, amounts: { under900: 330_000, bracket900_950: 220_000, bracket950_1000: 110_000 } },
-    { minIncome: 1_000_000, maxIncome: 1_050_000, amounts: { under900: 310_000, bracket900_950: 210_000, bracket950_1000: 110_000 } },
-    { minIncome: 1_050_000, maxIncome: 1_100_000, amounts: { under900: 260_000, bracket900_950: 180_000, bracket950_1000: 90_000 } },
-    { minIncome: 1_100_000, maxIncome: 1_150_000, amounts: { under900: 210_000, bracket900_950: 140_000, bracket950_1000: 70_000 } },
-    { minIncome: 1_150_000, maxIncome: 1_200_000, amounts: { under900: 160_000, bracket900_950: 110_000, bracket950_1000: 60_000 } },
-    { minIncome: 1_200_000, maxIncome: 1_250_000, amounts: { under900: 110_000, bracket900_950: 80_000, bracket950_1000: 40_000 } },
-    { minIncome: 1_250_000, maxIncome: 1_300_000, amounts: { under900: 60_000, bracket900_950: 40_000, bracket950_1000: 20_000 } },
-    { minIncome: 1_300_000, maxIncome: 1_330_000, amounts: { under900: 30_000, bracket900_950: 20_000, bracket950_1000: 10_000 } },
+    { maxIncome: 1_000_000, amounts: { under900: 330_000, bracket900_950: 220_000, bracket950_1000: 110_000 } },
+    { maxIncome: 1_050_000, amounts: { under900: 310_000, bracket900_950: 210_000, bracket950_1000: 110_000 } },
+    { maxIncome: 1_100_000, amounts: { under900: 260_000, bracket900_950: 180_000, bracket950_1000: 90_000 } },
+    { maxIncome: 1_150_000, amounts: { under900: 210_000, bracket900_950: 140_000, bracket950_1000: 70_000 } },
+    { maxIncome: 1_200_000, amounts: { under900: 160_000, bracket900_950: 110_000, bracket950_1000: 60_000 } },
+    { maxIncome: 1_250_000, amounts: { under900: 110_000, bracket900_950: 80_000, bracket950_1000: 40_000 } },
+    { maxIncome: 1_300_000, amounts: { under900: 60_000, bracket900_950: 40_000, bracket950_1000: 20_000 } },
+    { maxIncome: 1_330_000, amounts: { under900: 30_000, bracket900_950: 20_000, bracket950_1000: 10_000 } },
   ],
 } as const;
 
@@ -387,21 +366,25 @@ const SPOUSE_SPECIAL_DEDUCTION_TABLE = {
  * 
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1195.htm
  */
-function getSpouseSpecialDeduction(spouseNetIncome: number, taxpayerNetIncome: number): DeductionAmount {
+function getSpouseSpecialDeduction(spouseNetIncome: number, taxpayerNetIncome: number, year: number): DeductionAmount {
   // No deduction if taxpayer income exceeds 10,000,000
   if (taxpayerNetIncome > 10_000_000) {
     return { national: 0, residence: 0 };
   }
-  
+
+  const eligibilityMax = getDependentEligibilityMax(year);
+
   // Must be in spouse special deduction income range
-  if (spouseNetIncome <= DEPENDENT_INCOME_THRESHOLDS.SPOUSE_DEDUCTION_MAX || 
-      spouseNetIncome > DEPENDENT_INCOME_THRESHOLDS.SPOUSE_SPECIAL_DEDUCTION_MAX) {
+  if (spouseNetIncome <= eligibilityMax ||
+      spouseNetIncome > SPOUSE_SPECIAL_DEDUCTION_MAX_INCOME) {
     return { national: 0, residence: 0 };
   }
-  
+
   const getAmount = (table: typeof SPOUSE_SPECIAL_DEDUCTION_TABLE.NATIONAL | typeof SPOUSE_SPECIAL_DEDUCTION_TABLE.RESIDENCE) => {
-    // Find the bracket that matches the spouse's income
-    const bracket = table.find(b => spouseNetIncome > b.minIncome && spouseNetIncome <= b.maxIncome);
+    // Brackets are ordered ascending by maxIncome; the eligibility range check above
+    // already guarantees spouseNetIncome > eligibilityMax, so just find the first
+    // bracket whose maxIncome covers the income.
+    const bracket = table.find(b => spouseNetIncome <= b.maxIncome);
     
     if (!bracket) {
       return 0;
@@ -425,17 +408,22 @@ function getSpouseSpecialDeduction(spouseNetIncome: number, taxpayerNetIncome: n
 
 /**
  * Get specific relative special deduction amount based on actual total net income
- * Applies to age 19-22 dependents with income between 58万円 and 123万円 (2025 tax reform)
+ * Applies to age 19-22 dependents with income more than the dependent deduction eligibility threshold but below the specific relative special deduction max income.
+ * The deduction amount is determined by which bracket the dependent's total net income falls into.
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1177.htm
+ * @see getDependentEligibilityMax(year) for the lower income limit for eligibility.
+ * @see SPECIFIC_RELATIVE_DEDUCTION_MAX_INCOME for the upper income limit for eligibility.
+ * @see SPECIFIC_RELATIVE_DEDUCTION_BRACKETS for the specific income brackets and corresponding deduction amounts.
  */
-function getSpecificRelativeDeduction(totalNetIncome: number): DeductionAmount {
+function getSpecificRelativeDeduction(totalNetIncome: number, year: number): DeductionAmount {
+  const eligibilityMax = getDependentEligibilityMax(year);
   const getAmount = (deductions: typeof NATIONAL_TAX_DEDUCTIONS | typeof RESIDENCE_TAX_DEDUCTIONS) => {
     // Specific relative special deduction brackets (all values in yen)
-    if (totalNetIncome <= DEPENDENT_INCOME_THRESHOLDS.DEPENDENT_DEDUCTION_MAX || 
-        totalNetIncome > DEPENDENT_INCOME_THRESHOLDS.SPECIFIC_RELATIVE_DEDUCTION_MAX) {
+    if (totalNetIncome <= eligibilityMax ||
+        totalNetIncome > SPECIFIC_RELATIVE_DEDUCTION_MAX_INCOME) {
       return 0;
     } else if (totalNetIncome <= SPECIFIC_RELATIVE_DEDUCTION_BRACKETS.BRACKET_85) {
-      return deductions.SPECIFIC_RELATIVE_58TO85; // 58万円超～85万円以下
+      return deductions.SPECIFIC_RELATIVE_58TO85; // 62万円超～85万円以下
     } else if (totalNetIncome <= SPECIFIC_RELATIVE_DEDUCTION_BRACKETS.BRACKET_90) {
       return deductions.SPECIFIC_RELATIVE_85TO90; // 85万円超～90万円以下
     } else if (totalNetIncome <= SPECIFIC_RELATIVE_DEDUCTION_BRACKETS.BRACKET_95) {
@@ -467,19 +455,19 @@ function getSpecificRelativeDeduction(totalNetIncome: number): DeductionAmount {
  * @returns Deduction amounts for national and residence tax
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm
  */
-function calculateDependentDeduction(dependent: Dependent): DeductionAmount {
-  if (!isEligibleForDependentDeduction(dependent)) {
+function calculateDependentDeduction(dependent: Dependent, year: number): DeductionAmount {
+  if (!isEligibleForDependentDeduction(dependent, year)) {
     return { national: 0, residence: 0 };
   }
-  
+
   const getAmount = (deductions: typeof NATIONAL_TAX_DEDUCTIONS | typeof RESIDENCE_TAX_DEDUCTIONS) => {
     // Check for special dependent (age 19-22)
-    if (isSpecialDependent(dependent)) {
+    if (isSpecialDependent(dependent, year)) {
       return deductions.SPECIAL_DEPENDENT;
     }
-    
+
     // Check for elderly dependent (age 70+)
-    if (isElderlyDependent(dependent)) {
+    if (isElderlyDependent(dependent, year)) {
       // Additional deduction if cohabiting parent or grandparent
       if (dependent.isCohabiting && (dependent.relationship === 'parent')) {
         return deductions.ELDERLY_COHABITING;
@@ -504,8 +492,8 @@ function calculateDependentDeduction(dependent: Dependent): DeductionAmount {
  * @returns Deduction amounts for national and residence tax
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1191.htm
  */
-function calculateSpouseDeduction(dependent: Dependent, taxpayerNetIncome: number): DeductionAmount {
-  if (!isEligibleForSpouseDeduction(dependent) || taxpayerNetIncome > 10_000_000) {
+function calculateSpouseDeduction(dependent: Dependent, taxpayerNetIncome: number, year: number): DeductionAmount {
+  if (!isEligibleForSpouseDeduction(dependent, year) || taxpayerNetIncome > 10_000_000) {
     return { national: 0, residence: 0 };
   }
 
@@ -541,7 +529,8 @@ function calculateSpouseDeduction(dependent: Dependent, taxpayerNetIncome: numbe
  */
 export function calculateDependentDeductions(
   dependents: Dependent[],
-  taxpayerNetIncome: number = 0
+  taxpayerNetIncome: number = 0,
+  year: number = new Date().getFullYear()
 ): DependentDeductionResults {
   const results: DependentDeductionResults = {
     nationalTax: {
@@ -603,9 +592,9 @@ export function calculateDependentDeductions(
 
     // Spouse deductions
     if (dependent.relationship === 'spouse') {
-      if (isEligibleForSpouseDeduction(dependent)) {
-        const spouseDeduction = calculateSpouseDeduction(dependent, taxpayerNetIncome);
-        
+      if (isEligibleForSpouseDeduction(dependent, year)) {
+        const spouseDeduction = calculateSpouseDeduction(dependent, taxpayerNetIncome, year);
+
         results.nationalTax.spouseDeduction += spouseDeduction.national;
         results.residenceTax.spouseDeduction += spouseDeduction.residence;
 
@@ -615,13 +604,13 @@ export function calculateDependentDeductions(
           residenceTaxAmount: spouseDeduction.residence,
           deductionType: DEDUCTION_TYPES.SPOUSE,
         });
-      } else if (isEligibleForSpouseSpecialDeduction(dependent)) {
-        const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
-        const spouseSpecialDeduction = getSpouseSpecialDeduction(totalNetIncome, taxpayerNetIncome);
-        
+      } else if (isEligibleForSpouseSpecialDeduction(dependent, year)) {
+        const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, year);
+        const spouseSpecialDeduction = getSpouseSpecialDeduction(totalNetIncome, taxpayerNetIncome, year);
+
         results.nationalTax.spouseSpecialDeduction += spouseSpecialDeduction.national;
         results.residenceTax.spouseSpecialDeduction += spouseSpecialDeduction.residence;
-        
+
         results.breakdown.push({
           dependent,
           nationalTaxAmount: spouseSpecialDeduction.national,
@@ -631,9 +620,9 @@ export function calculateDependentDeductions(
       }
     }
     // Specific relative special deduction
-    else if (isEligibleForSpecificRelativeSpecialDeduction(dependent)) {
-      const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
-      const specificRelativeDeduction = getSpecificRelativeDeduction(totalNetIncome);
+    else if (isEligibleForSpecificRelativeSpecialDeduction(dependent, year)) {
+      const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, year);
+      const specificRelativeDeduction = getSpecificRelativeDeduction(totalNetIncome, year);
       
       results.nationalTax.specificRelativeDeduction += specificRelativeDeduction.national;
       results.residenceTax.specificRelativeDeduction += specificRelativeDeduction.residence;
@@ -646,8 +635,8 @@ export function calculateDependentDeductions(
       });
     }
     // Standard dependent deduction
-    else if (isEligibleForDependentDeduction(dependent)) {
-      const dependentDeduction = calculateDependentDeduction(dependent);
+    else if (isEligibleForDependentDeduction(dependent, year)) {
+      const dependentDeduction = calculateDependentDeduction(dependent, year);
       
       results.nationalTax.dependentDeduction += dependentDeduction.national;
       results.residenceTax.dependentDeduction += dependentDeduction.residence;
@@ -656,8 +645,8 @@ export function calculateDependentDeductions(
         dependent,
         nationalTaxAmount: dependentDeduction.national,
         residenceTaxAmount: dependentDeduction.residence,
-        deductionType: isSpecialDependent(dependent) ? DEDUCTION_TYPES.SPECIAL_DEPENDENT :
-                       isElderlyDependent(dependent) ? DEDUCTION_TYPES.ELDERLY_DEPENDENT :
+        deductionType: isSpecialDependent(dependent, year) ? DEDUCTION_TYPES.SPECIAL_DEPENDENT :
+                       isElderlyDependent(dependent, year) ? DEDUCTION_TYPES.ELDERLY_DEPENDENT :
                        DEDUCTION_TYPES.GENERAL_DEPENDENT,
       });
     } else {

--- a/src/utils/pensionCalculator.ts
+++ b/src/utils/pensionCalculator.ts
@@ -4,13 +4,9 @@
 import type { BonusIncomeStream } from '../types/tax';
 import { roundSocialInsurancePremium } from './taxCalculations';
 import type { StandardMonthlyRemunerationBracket } from '../data/employeesHealthInsurance/smrBrackets';
+import { getNationalPensionAnnualTotal } from '../data/nationalPensionContribution';
 
 export type { StandardMonthlyRemunerationBracket };
-
-/** National pension (国民年金) - fixed monthly contribution.
- * Source: https://www.nenkin.go.jp/service/kokunen/hokenryo/hokenryo.html#cms01
- */
-export const monthlyNationalPensionContribution = 17510;
 
 /**
  * Employees' pension insurance rate (厚生年金保険料率)
@@ -84,10 +80,11 @@ export function calculatePensionBreakdown(
   isEmployeesPension: boolean = true,
   monthlyIncome: number = 0,
   isHalfAmount: boolean = true,
-  bonuses: BonusIncomeStream[] = []
+  bonuses: BonusIncomeStream[] = [],
+  year: number = new Date().getFullYear()
 ): PensionBreakdown {
   if (!isEmployeesPension) {
-    return { total: monthlyNationalPensionContribution * 12, bonusPortion: 0 };
+    return { total: getNationalPensionAnnualTotal(year), bonusPortion: 0 };
   }
   if (monthlyIncome < 0) {
     throw new Error('Monthly income must be a positive number');
@@ -185,7 +182,8 @@ export function calculatePensionPremium(
   isEmployeesPension: boolean = true,
   monthlyIncome: number = 0,
   isHalfAmount: boolean = true,
-  bonuses: BonusIncomeStream[] = []
+  bonuses: BonusIncomeStream[] = [],
+  year: number = new Date().getFullYear()
 ): number {
-  return calculatePensionBreakdown(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses).total;
+  return calculatePensionBreakdown(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year).total;
 }

--- a/src/utils/residenceTax.ts
+++ b/src/utils/residenceTax.ts
@@ -5,7 +5,7 @@ import type { FurusatoNozeiDetails, ResidenceTaxDetails } from "../types/tax";
 import { calculateNationalIncomeTax } from "./taxCalculations";
 import type { DependentDeductionResults } from "../types/dependents";
 import { DEDUCTION_TYPES } from "../types/dependents";
-import { calculateDependentTotalNetIncome, DEPENDENT_INCOME_THRESHOLDS } from './dependentDeductions';
+import { calculateDependentTotalNetIncome, getDependentEligibilityMax } from './dependentDeductions';
 
 /**
  * Calculates the basic deduction (基礎控除) for residence tax based on income
@@ -78,9 +78,10 @@ export const calculateResidenceTax = (
     netIncome: number,
     nonBasicDeductions: number,
     dependentDeductions: DependentDeductionResults,
-    taxCredit: number = 0
+    taxCredit: number = 0,
+    year: number = new Date().getFullYear()
 ): ResidenceTaxDetails => {
-    const qualifiedDependentsCount = countQualifiedDependents(dependentDeductions);
+    const qualifiedDependentsCount = countQualifiedDependents(dependentDeductions, year);
     const { perCapitaLimit, incomeBasedLimit } = getResidenceTaxExemptionLimits(qualifiedDependentsCount);
 
     if (netIncome <= perCapitaLimit) {
@@ -162,16 +163,16 @@ export const calculateResidenceTax = (
  * 扶養親族は、年齢16歳未満の者及び地方税法第314条の2第1項第11号に規定する控除対象扶養親族に限ります。
  * @see https://www.tax.metro.tokyo.lg.jp/kazei/life/kojin_ju#gaiyo_06
  */
-function countQualifiedDependents(dependentDeductions: DependentDeductionResults): number {
+function countQualifiedDependents(dependentDeductions: DependentDeductionResults, year: number): number {
     const uniqueDependents = new Map();
     dependentDeductions.breakdown.forEach(b => {
         uniqueDependents.set(b.dependent.id, b.dependent);
     });
-    
+
     let qualifiedDependentsCount = 0;
     uniqueDependents.forEach((dependent) => {
-        const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
-        if (totalNetIncome <= DEPENDENT_INCOME_THRESHOLDS.DEPENDENT_DEDUCTION_MAX) {
+        const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, year);
+        if (totalNetIncome <= getDependentEligibilityMax(year)) {
             qualifiedDependentsCount++;
         }
     });

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -20,9 +20,11 @@ import {
     NON_TAXABLE_RESIDENCE_TAX_DETAIL
 } from './residenceTax';
 import {calculateDependentDeductions} from './dependentDeductions';
-import {COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP, NATIONAL_BASIC_DEDUCTION_TIERS,} from '../constants/taxThresholds';
+import {COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP} from '../constants/taxThresholds';
 import {getCommutingAllowanceAnnualAmount} from './formatters';
 import {getEmploymentInsuranceRate} from '../data/employmentInsurance';
+import {getNationalBasicDeductionTiers} from '../data/nationalBasicDeduction';
+import {getEmploymentIncomeDeductionPeriod, calculateNetEmploymentIncomeForPeriod} from '../data/employmentIncomeDeduction';
 
 /**
  * Rounds the premium to a nearby whole yen according to the given mode.
@@ -41,31 +43,21 @@ export const roundSocialInsurancePremium = (amount: number, mode: 'halfTrunc' | 
 }
 
 /**
- * Calculates the net employment income based on the tax rules for 2025/2026 income, applying the employment income deduction.
- * Source: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm
+ * Calculates the net employment income (給与所得の金額) for the given income year,
+ * applying the employment income deduction (給与所得控除) rules for that year.
+ *
+ * Delegates to the year-indexed period data in `src/data/employmentIncomeDeduction.ts`.
+ *
+ * @param grossEmploymentIncome  Gross employment income (給与等の収入金額) in yen
+ * @param year                   Income year; defaults to the current calendar year
  */
-export const calculateNetEmploymentIncome = (grossEmploymentIncome: number): number => {
-    if (grossEmploymentIncome < 651_000)
-        return 0;
-
-    if (grossEmploymentIncome < 1_900_000)
-        return grossEmploymentIncome - 650_000;
-
-    // From 1.9M yen through 6.6M yen, gross income is rounded down to the nearest 4,000 yen
-    const roundedGrossIncome = Math.floor(grossEmploymentIncome / 4000) * 4000;
-
-    if (grossEmploymentIncome <= 3_600_000) {
-        return Math.floor(roundedGrossIncome * 0.7) - 80_000;
-    } else if (grossEmploymentIncome <= 6_600_000) {
-        return Math.floor(roundedGrossIncome * 0.8) - 440_000;
-    }
-
-    if (grossEmploymentIncome <= 8_500_000) {
-        return Math.floor(grossEmploymentIncome * 0.9) - 1_100_000;
-    } else {
-        return grossEmploymentIncome - 1_950_000;
-    }
-}
+export const calculateNetEmploymentIncome = (
+    grossEmploymentIncome: number,
+    year: number = new Date().getFullYear()
+): number => calculateNetEmploymentIncomeForPeriod(
+    grossEmploymentIncome,
+    getEmploymentIncomeDeductionPeriod(year)
+);
 
 /**
  * Breakdown of Employment Insurance premium components
@@ -136,12 +128,14 @@ export const calculateEmploymentInsurance = (
 }
 
 /**
- * Calculates the basic deduction (基礎控除) for national income tax based on income
+ * Calculates the basic deduction (基礎控除) for national income tax based on income and year.
  * Source: National Tax Agency https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1199.htm
- * 2025 Update: https://www.nta.go.jp/users/gensen/2025kiso/index.htm#a-01
+ *
+ * @param netIncome Taxpayer's net income (合計所得金額) in yen
+ * @param year Income year (calendar year the income was earned); defaults to current year
  */
-export const calculateNationalIncomeTaxBasicDeduction = (netIncome: number): number => {
-    for (const { maxIncomeInclusive, deduction } of NATIONAL_BASIC_DEDUCTION_TIERS) {
+export const calculateNationalIncomeTaxBasicDeduction = (netIncome: number, year: number = new Date().getFullYear()): number => {
+    for (const { maxIncomeInclusive, deduction } of getNationalBasicDeductionTiers(year)) {
         if (netIncome <= maxIncomeInclusive) return deduction;
     }
     return 0;
@@ -294,8 +288,11 @@ const calculateIncomeBreakdown = (incomeStreams: IncomeStream[]): IncomeBreakdow
 /**
  * Calculates just the total net income.
  * This is lighter weight than the full tax calculation and used for dependent eligibility checks.
+ *
+ * @param incomeStreams  Income streams to calculate net income for
+ * @param year          Income year for the employment income deduction lookup; defaults to current year
  */
-export const calculateTotalNetIncome = (incomeStreams: IncomeStream[]): number => {
+export const calculateTotalNetIncome = (incomeStreams: IncomeStream[], year: number = new Date().getFullYear()): number => {
     const {
         salaryIncome,
         bonusIncome,
@@ -307,7 +304,7 @@ export const calculateTotalNetIncome = (incomeStreams: IncomeStream[]): number =
     const taxableCommutingAllowance = Math.max(0, commutingAllowance - COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP);
 
     const grossEmploymentIncome = salaryIncome + taxableCommutingAllowance + bonusIncome.reduce((sum, b) => sum + b.amount, 0) + stockCompensationIncome;
-    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome);
+    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, year);
 
     return netEmploymentIncome + netBusinessAndMiscIncome;
 };
@@ -337,7 +334,8 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     const taxableCommutingAllowance = Math.max(0, commutingAllowance - COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP);
 
     const grossEmploymentIncome = salaryIncome + taxableCommutingAllowance + bonusIncome.reduce((sum, b) => sum + b.amount, 0) + stockCompensationIncome;
-    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome);
+    const incomeYear = inputs.incomeYear ?? new Date().getFullYear();
+    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, incomeYear);
 
     const netIncome = netEmploymentIncome + netBusinessAndMiscIncome;
 
@@ -403,11 +401,11 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
             pensionPayments = 0;
         } else if (isInEmployeePensionSystem) {
             // Pension also includes full commuting allowance in SMR
-            const pensionResult = calculatePensionBreakdown(isInEmployeePensionSystem, (salaryIncome + commutingAllowance) / 12, true, bonusIncome);
+            const pensionResult = calculatePensionBreakdown(isInEmployeePensionSystem, (salaryIncome + commutingAllowance) / 12, true, bonusIncome, incomeYear);
             pensionPayments = pensionResult.total;
             pensionOnBonus = pensionResult.bonusPortion;
         } else { // National Pension
-            const pensionResult = calculatePensionBreakdown(isInEmployeePensionSystem);
+            const pensionResult = calculatePensionBreakdown(isInEmployeePensionSystem, 0, true, [], incomeYear);
             pensionPayments = pensionResult.total;
             pensionOnBonus = pensionResult.bonusPortion;
         }
@@ -425,9 +423,9 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     // iDeCo and corporate DC contributions are deductible as 小規模企業共済等掛金控除
     const idecoDeduction = Math.max(0, inputs.dcPlanContributions || 0);
 
-    const dependentDeductions = calculateDependentDeductions(inputs.dependents, netIncome);
+    const dependentDeductions = calculateDependentDeductions(inputs.dependents, netIncome, incomeYear);
 
-    const nationalIncomeTaxBasicDeduction = calculateNationalIncomeTaxBasicDeduction(netIncome);
+    const nationalIncomeTaxBasicDeduction = calculateNationalIncomeTaxBasicDeduction(netIncome, inputs.incomeYear ?? new Date().getFullYear());
 
     const taxableIncomeForNationalIncomeTax = Math.max(0, Math.floor((netIncome - socialInsuranceDeduction - idecoDeduction - nationalIncomeTaxBasicDeduction - dependentDeductions.nationalTax.total) / 1000) * 1000);
 
@@ -441,7 +439,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     const residenceTaxBasicDeduction = calculateResidenceTaxBasicDeduction(netIncome);
     const taxableIncomeForResidenceTax = Math.max(0, Math.floor(Math.max(0, netIncome - socialInsuranceDeduction - idecoDeduction - residenceTaxBasicDeduction - dependentDeductions.residenceTax.total) / 1000) * 1000);
 
-    const residenceTax = calculateResidenceTax(netIncome, socialInsuranceDeduction + idecoDeduction, dependentDeductions);
+    const residenceTax = calculateResidenceTax(netIncome, socialInsuranceDeduction + idecoDeduction, dependentDeductions, 0, incomeYear);
 
     // Calculate totals
     const totalSocialsAndTax = nationalIncomeTax + residenceTax.totalResidenceTax + socialInsuranceDeduction;

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -425,7 +425,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
 
     const dependentDeductions = calculateDependentDeductions(inputs.dependents, netIncome, incomeYear);
 
-    const nationalIncomeTaxBasicDeduction = calculateNationalIncomeTaxBasicDeduction(netIncome, inputs.incomeYear ?? new Date().getFullYear());
+    const nationalIncomeTaxBasicDeduction = calculateNationalIncomeTaxBasicDeduction(netIncome, incomeYear);
 
     const taxableIncomeForNationalIncomeTax = Math.max(0, Math.floor((netIncome - socialInsuranceDeduction - idecoDeduction - nationalIncomeTaxBasicDeduction - dependentDeductions.nationalTax.total) / 1000) * 1000);
 


### PR DESCRIPTION
Update relevant deductions data to be time-series data supporting multiple years. Look up data for given year, defaulting to most recent available data.

The gist of the changes can be seen in the new files added under the `data` folder to support time-series data for the national basic deduction, national pension contribution, dependent/spouse deduction income thresholds, and employment income deduction.

Not addressed here: updates for NHI rates for FY2026.

Already addressed 2026 updates: employment insurance #253 and employees health insurance #254