### PR TITLE
Add Childcare Support Contribution to custom EHI rate tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the Japan Take-Home Pay Calculator will be documented in 
 
 ### Updated
 
-- Updated Employee Health Insurance rates for FY2026 for all supported providers, including the new Child/Childcare Support Levy (子ども・子育て支援金). Rates are now applied per-month, so premiums are calculated accurately when rates change mid-year.
+- Updated Employee Health Insurance rates for FY2026 for all supported providers, including the new Childcare Support Contribution (子ども・子育て支援金). Rates are now applied per-month, so premiums are calculated accurately when rates change mid-year.
 
 ## 2026-03-29
 

--- a/src/__tests__/healthInsuranceCalculator.test.ts
+++ b/src/__tests__/healthInsuranceCalculator.test.ts
@@ -351,8 +351,8 @@ describe('calculateHealthInsuranceBonusBreakdown details', () => {
 describe('FY2026 time-series rate support', () => {
   // Calendar year 2026 for Kyokai Kenpo (Tokyo):
   // - Months 0-2 (Jan-Mar): FY2025 rates — health 4.955%, LTC 0.795%
-  // - Month 3 (Apr): FY2026 without levy — health 4.925%, LTC 0.81%
-  // - Months 4-11 (May-Dec): FY2026 with levy — health 5.04%, LTC 0.81%
+  // - Month 3 (Apr): FY2026 without contribution — health 4.925%, LTC 0.81%
+  // - Months 4-11 (May-Dec): FY2026 with contribution — health 5.04%, LTC 0.81%
   //
   // SMR for 5M income = 410,000
 
@@ -385,16 +385,16 @@ describe('FY2026 time-series rate support', () => {
     const marchResult = calculateHealthInsuranceBreakdown(0, false, KYOKAI_KENPO_PROVIDER, 'Tokyo', undefined, marchBonus, 2026);
     expect(marchResult.bonusPortion).toBe(24_775);
 
-    // Bonus in May (month 4) → FY2026 with levy rate: 0.05040
+    // Bonus in May (month 4) → FY2026 with contribution rate: 0.05040
     // 500,000 × 0.05040 = 25,200
     const mayBonus = [{ amount: 500_000, id: 'b2', type: 'bonus' as const, month: 4 }];
     const mayResult = calculateHealthInsuranceBreakdown(0, false, KYOKAI_KENPO_PROVIDER, 'Tokyo', undefined, mayBonus, 2026);
     expect(mayResult.bonusPortion).toBe(25_200);
   });
 
-  it('ITS Kenpo rates in 2026 are uniform (levy offsets health rate reduction)', () => {
+  it('ITS Kenpo rates in 2026 are uniform (contribution offsets health rate reduction)', () => {
     // ITS in 2026:
-    // All months: 4.75% (FY2025: 4.75%, FY2026 Apr: 4.75%, FY2026 May+: 4.635% + 0.115% levy = 4.75%)
+    // All months: 4.75% (FY2025: 4.75%, FY2026 Apr: 4.75%, FY2026 May+: 4.635% + 0.115% contribution = 4.75%)
     // 410,000 × 0.0475 = 19,475 × 12 = 233,700
     expect(calculateHealthInsurancePremium(5_000_000, false, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION, undefined, [], 2026)).toBe(233_700);
   });

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -819,7 +819,7 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({ inputs, onInput
                   <FormControl fullWidth>
                     <Typography gutterBottom sx={{ fontSize: '0.97rem', fontWeight: 500, display: 'flex', alignItems: 'center' }}>
                       Health Insurance
-                      <SimpleTooltip>Enter the employee's share of the health insurance premium rate (usually half of the total rate). Look for 健康保険料率 or 一般保険料率 on the provider's website. This should include the 調整保険料率.</SimpleTooltip>
+                      <SimpleTooltip>Enter the employee's share of the health insurance premium rate (usually half of the total rate). Look for 健康保険料率 or 一般保険料率 on the provider's website. This should include the 調整保険料率 and the Childcare Support Contribution (子ども・子育て支援金率).</SimpleTooltip>
                     </Typography>
                     <SpinnerNumberField
                       id="customHealthInsuranceRate"

--- a/src/data/employeesHealthInsurance/providerRateData.ts
+++ b/src/data/employeesHealthInsurance/providerRateData.ts
@@ -57,7 +57,7 @@ export interface ProviderDefinition {
  * National Health Insurance is handled separately as it has a different calculation structure.
  *
  * FY2026 notes:
- * - Child/Childcare Support Levy (子ども・子育て支援金) of 0.23% (0.115% employee) is folded
+ * - Childcare Support Contribution (子ども・子育て支援金) of 0.23% (0.115% employee) is folded
  *   into employeeHealthInsuranceRate starting from its effective paycheck month. It is calculated
  *   on the same SMR base with the same rounding, so combining it is exact.
  */
@@ -67,14 +67,14 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     defaultSource: 'https://www.its-kenpo.or.jp/hoken/jimu/hokenryou/index.html',
     regions: {
       'DEFAULT': [
-        // FY2026 with child support levy (May 2026 paycheck — April billing + levy)
-        // Health 4.635% + levy 0.115% = 4.75%
+        // FY2026 with childcare support contribution (May 2026 paycheck — April billing + contribution)
+        // Health 4.635% + contribution 0.115% = 4.75%
         { effectiveFrom: { year: 2026, month: 4 }, rates: {
           source: 'https://www.its-kenpo.or.jp/documents/hoken/jimu/hokenryou/20260401kara_hokenryouichiran.pdf',
           employeeHealthInsuranceRate: 0.0475, // 4.75%
           employeeLongTermCareRate: 0.009, // 0.9%
         }},
-        // FY2026 without levy (April 2026 paycheck — March billing, new health rate)
+        // FY2026 without contribution (April 2026 paycheck — March billing, new health rate)
         { effectiveFrom: { year: 2026, month: 3 }, rates: {
           source: 'https://www.its-kenpo.or.jp/documents/hoken/jimu/hokenryou/20260331made_hokenryouichiran.pdf',
           employeeHealthInsuranceRate: 0.0475, // 4.75%
@@ -346,7 +346,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
       // FY2025 nursing insurance rate is 1.59% for all regions
       // FY2026 health insurance rates from Table 18 (effective March 2026 billing / April 2026 paycheck)
       // FY2026 nursing insurance rate is 1.62% for all regions
-      // FY2026 child support levy of 0.23% (effective April 2026 billing / May 2026 paycheck) is folded into health rate
+      // FY2026 childcare support contribution of 0.23% (effective April 2026 billing / May 2026 paycheck) is folded into health rate
     }
   },
   'RakutenKenpo': {
@@ -354,8 +354,8 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     defaultSource: 'https://kenpo.rakuten.or.jp/member/outline/fee.html',
     regions: {
       'DEFAULT': [
-        // FY2026 with child support levy (May 2026 paycheck)
-        // Health 4.7% + levy 0.115% = 4.815%
+        // FY2026 with childcare support contribution (May 2026 paycheck)
+        // Health 4.7% + contribution 0.115% = 4.815%
         { effectiveFrom: { year: 2026, month: 4 }, rates: {
           source: 'https://kenpo.rakuten.or.jp/member/outline/files/fee.pdf',
           employeeHealthInsuranceRate: 0.04815, // 4.815%
@@ -375,8 +375,8 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     defaultSource: 'https://kempo.recruit.co.jp/member/outline/fee.html',
     regions: {
       'DEFAULT': [
-        // FY2026 with child support levy (May 2026 paycheck)
-        // Employee health 4.35% + levy 0.115% = 4.465%, employer health 4.65% + 0.115% = 4.765%
+        // FY2026 with childcare support contribution (May 2026 paycheck)
+        // Employee health 4.35% + contribution 0.115% = 4.465%, employer health 4.65% + 0.115% = 4.765%
         { effectiveFrom: { year: 2026, month: 4 }, rates: {
           source: 'https://kempo.recruit.co.jp/member/info/pdf/r8_fee.pdf',
           employeeHealthInsuranceRate: 0.04465, // 4.465%
@@ -398,8 +398,8 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     defaultSource: 'https://www.shoken-kenpo.or.jp/member/outline/fee.html',
     regions: {
       'DEFAULT': [
-        // FY2026 with child support levy (May 2026 paycheck)
-        // Employee health 3.3% + levy 0.115% = 3.415%, employer health 5.1% + 0.115% = 5.215%
+        // FY2026 with childcare support contribution (May 2026 paycheck)
+        // Employee health 3.3% + contribution 0.115% = 3.415%, employer health 5.1% + 0.115% = 5.215%
         { effectiveFrom: { year: 2026, month: 4 }, rates: {
           source: 'https://www.shoken-kenpo.or.jp/member/outline/files/hokenryou_getsugaku_2026.pdf',
           employeeHealthInsuranceRate: 0.03415, // 3.415%


### PR DESCRIPTION
## Summary
- Updated the tooltip on the custom health insurance rate input to mention that the rate should include the Childcare Support Contribution (子ども・子育て支援金率)
- Standardized terminology from "Child/Childcare Support Levy" to "Childcare Support Contribution" across the codebase (CHANGELOG, rate data comments, test comments)

## Test plan
- [x] All 465 existing tests pass
- [x] Verify tooltip text by selecting "Custom Provider" for health insurance in the calculator

🤖 Generated with [Claude Code](https://claude.com/claude-code)