### PR TITLE
Fix dark mode rendering for tooltips and tables

### DIFF
--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -65,7 +65,7 @@ const percentileBandsPlugin = {
     });
 
     // Draw dotted lines between bands
-    ctx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue('--chart-grid').trim() || 'rgba(128, 128, 128, 0.4)';
+    ctx.strokeStyle = 'rgba(128, 128, 128, 0.5)';
     ctx.lineWidth = 1;
     ctx.setLineDash([4, 4]); // Create dotted line pattern
 

--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -65,7 +65,7 @@ const percentileBandsPlugin = {
     });
 
     // Draw dotted lines between bands
-    ctx.strokeStyle = 'rgba(128, 128, 128, 0.4)';
+    ctx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue('--chart-grid').trim() || 'rgba(128, 128, 128, 0.4)';
     ctx.lineWidth = 1;
     ctx.setLineDash([4, 4]); // Create dotted line pattern
 

--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -65,7 +65,7 @@ const percentileBandsPlugin = {
     });
 
     // Draw dotted lines between bands
-    ctx.strokeStyle = 'rgba(128, 128, 128, 0.5)';
+    ctx.strokeStyle = 'rgba(128, 128, 128, 0.4)';
     ctx.lineWidth = 1;
     ctx.setLineDash([4, 4]); // Create dotted line pattern
 

--- a/src/components/TakeHomeCalculator/tabs/EmploymentIncomeDeductionTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/EmploymentIncomeDeductionTooltip.tsx
@@ -54,7 +54,8 @@ const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionToolti
                         padding: '2px 6px'
                     },
                     '& th': {
-                        borderBottom: '1px solid #ccc',
+                        borderBottom: 1,
+                        borderColor: 'divider',
                         padding: '2px 6px',
                         textAlign: 'left'
                     }

--- a/src/components/TakeHomeCalculator/tabs/EmploymentInsuranceRateTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/EmploymentInsuranceRateTooltip.tsx
@@ -14,9 +14,9 @@ const formatMonthShort = (month: number): string =>
 
 const cellStyle = { padding: '2px 8px 2px 0' } as const;
 const rightCellStyle = { ...cellStyle, textAlign: 'right' as const };
-const headerStyle = { ...cellStyle, borderBottom: '1px solid #ccc', fontWeight: 'normal' as const };
-const rightHeaderStyle = { ...rightCellStyle, borderBottom: '1px solid #ccc', fontWeight: 'normal' as const };
-const totalStyle = { ...rightCellStyle, borderTop: '1px solid #ccc', fontWeight: 600 };
+const headerStyle = { ...cellStyle, borderBottom: '1px solid var(--divider)', fontWeight: 'normal' as const };
+const rightHeaderStyle = { ...rightCellStyle, borderBottom: '1px solid var(--divider)', fontWeight: 'normal' as const };
+const totalStyle = { ...rightCellStyle, borderTop: '1px solid var(--divider)', fontWeight: 600 };
 
 interface SalaryTooltipProps {
     monthlyIncome: number;

--- a/src/components/TakeHomeCalculator/tabs/HealthInsuranceBonusTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/HealthInsuranceBonusTooltip.tsx
@@ -74,8 +74,8 @@ const HealthInsuranceBonusTooltip: React.FC<HealthInsuranceBonusTooltipProps> = 
               width: '100%',
               fontSize: '0.85em',
               borderCollapse: 'collapse',
-              '& th': { textAlign: 'left', borderBottom: '1px solid #ccc', p: 0.5 },
-              '& td': { p: 0.5, borderBottom: '1px solid #eee' },
+              '& th': { textAlign: 'left', borderBottom: 1, borderColor: 'divider', p: 0.5 },
+              '& td': { p: 0.5, borderBottom: 1, borderColor: 'divider' },
               '& td:not(:first-of-type), & th:not(:first-of-type)': { textAlign: 'right' }
             }}
           >
@@ -105,7 +105,7 @@ const HealthInsuranceBonusTooltip: React.FC<HealthInsuranceBonusTooltipProps> = 
               ))}
             </tbody>
             <tfoot>
-              <tr style={{ borderTop: '2px solid #aaa', fontWeight: 700 }}>
+              <tr style={{ borderTop: '2px solid var(--border-strong)', fontWeight: 700 }}>
                 <td style={{ paddingTop: 4 }}>Total</td>
                 <td style={{ paddingTop: 4 }}>
                   {formatJPY(breakdown.reduce((sum, item) => sum + item.bonusAmount, 0))}

--- a/src/components/TakeHomeCalculator/tabs/HealthInsurancePremiumTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/HealthInsurancePremiumTooltip.tsx
@@ -472,7 +472,7 @@ const HealthInsurancePremiumTooltip: React.FC<HealthInsurancePremiumTooltipProps
 
         <Box sx={{ mb: 0.5, p: 0, bgcolor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
           {/* Supporting Details */}
-          <Box sx={{ p: 1.5, bgcolor: 'grey.50', borderBottom: '1px solid', borderColor: 'divider' }}>
+          <Box sx={{ p: 1.5, bgcolor: 'var(--action-hover)', borderBottom: '1px solid', borderColor: 'divider' }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
               <Typography variant="caption" color="text.secondary">Monthly Remuneration</Typography>
               <Typography variant="caption" fontWeight={500}>
@@ -521,10 +521,10 @@ const HealthInsurancePremiumTooltip: React.FC<HealthInsurancePremiumTooltipProps
                     <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
                       <thead>
                         <tr>
-                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid #ccc', fontWeight: 'normal', textAlign: 'left' }}>Months</th>
-                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid #ccc', fontWeight: 'normal', textAlign: 'right' }}>Rate</th>
-                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid #ccc', fontWeight: 'normal', textAlign: 'right' }}>Monthly</th>
-                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid #ccc', fontWeight: 'normal', textAlign: 'right' }}>Subtotal</th>
+                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid var(--divider)', fontWeight: 'normal', textAlign: 'left' }}>Months</th>
+                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid var(--divider)', fontWeight: 'normal', textAlign: 'right' }}>Rate</th>
+                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid var(--divider)', fontWeight: 'normal', textAlign: 'right' }}>Monthly</th>
+                          <th style={{ padding: '2px 8px 2px 0', borderBottom: '1px solid var(--divider)', fontWeight: 'normal', textAlign: 'right' }}>Subtotal</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -543,8 +543,8 @@ const HealthInsurancePremiumTooltip: React.FC<HealthInsurancePremiumTooltipProps
                           );
                         })}
                         <tr>
-                          <td colSpan={3} style={{ padding: '2px 8px 2px 0', textAlign: 'right', borderTop: '1px solid #ccc', fontWeight: 600 }}>Annual Total</td>
-                          <td style={{ padding: '2px 8px 2px 0', textAlign: 'right', borderTop: '1px solid #ccc', fontWeight: 600 }}>
+                          <td colSpan={3} style={{ padding: '2px 8px 2px 0', textAlign: 'right', borderTop: '1px solid var(--divider)', fontWeight: 600 }}>Annual Total</td>
+                          <td style={{ padding: '2px 8px 2px 0', textAlign: 'right', borderTop: '1px solid var(--divider)', fontWeight: 600 }}>
                             {formatJPY(annualTotal)}
                           </td>
                         </tr>

--- a/src/components/TakeHomeCalculator/tabs/NationalPensionTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NationalPensionTooltip.tsx
@@ -12,9 +12,9 @@ const formatMonthShort = (month: number): string =>
 
 const cellStyle = { padding: '2px 8px 2px 0' } as const;
 const rightCellStyle = { ...cellStyle, textAlign: 'right' as const };
-const headerStyle = { ...cellStyle, borderBottom: '1px solid #ccc', fontWeight: 'normal' as const };
-const rightHeaderStyle = { ...rightCellStyle, borderBottom: '1px solid #ccc', fontWeight: 'normal' as const };
-const totalStyle = { ...rightCellStyle, borderTop: '1px solid #ccc', fontWeight: 600 };
+const headerStyle = { ...cellStyle, borderBottom: '1px solid var(--divider)', fontWeight: 'normal' as const };
+const rightHeaderStyle = { ...rightCellStyle, borderBottom: '1px solid var(--divider)', fontWeight: 'normal' as const };
+const totalStyle = { ...rightCellStyle, borderTop: '1px solid var(--divider)', fontWeight: 600 };
 
 interface NationalPensionTooltipProps {
     year: number;

--- a/src/components/TakeHomeCalculator/tabs/PensionBonusTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/PensionBonusTooltip.tsx
@@ -49,8 +49,8 @@ const PensionBonusTooltip: React.FC<PensionBonusTooltipProps> = ({ breakdown }) 
               width: '100%',
               fontSize: '0.85em',
               borderCollapse: 'collapse',
-              '& th': { textAlign: 'left', borderBottom: '1px solid #ccc', p: 0.5 },
-              '& td': { p: 0.5, borderBottom: '1px solid #eee' },
+              '& th': { textAlign: 'left', borderBottom: 1, borderColor: 'divider', p: 0.5 },
+              '& td': { p: 0.5, borderBottom: 1, borderColor: 'divider' },
               '& td:not(:first-of-type), & th:not(:first-of-type)': { textAlign: 'right' }
             }}
           >
@@ -78,7 +78,7 @@ const PensionBonusTooltip: React.FC<PensionBonusTooltipProps> = ({ breakdown }) 
               ))}
             </tbody>
             <tfoot>
-              <tr style={{ borderTop: '2px solid #aaa', fontWeight: 700 }}>
+              <tr style={{ borderTop: '2px solid var(--border-strong)', fontWeight: 700 }}>
                 <td style={{ paddingTop: 4 }}>Total</td>
                 <td style={{ paddingTop: 4 }}>
                   {formatJPY(breakdown.reduce((sum, item) => sum + item.totalBonusAmount, 0))}

--- a/src/components/TakeHomeCalculator/tabs/PensionPremiumTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/PensionPremiumTooltip.tsx
@@ -70,7 +70,7 @@ const PensionPremiumTooltip: React.FC<PensionPremiumTooltipProps> = ({ inputs, s
 
       <Box sx={{ mb: 0.5, p: 0, bgcolor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
         {/* Supporting Details */}
-        <Box sx={{ p: 1.5, bgcolor: 'grey.50', borderBottom: '1px solid', borderColor: 'divider' }}>
+        <Box sx={{ p: 1.5, bgcolor: 'var(--action-hover)', borderBottom: '1px solid', borderColor: 'divider' }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
             <Typography variant="caption" color="text.secondary">Monthly Remuneration</Typography>
             <Typography variant="caption" fontWeight={500}>

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -315,7 +315,8 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                         padding: '2px 6px'
                       },
                       '& th': {
-                        borderBottom: '1px solid #ccc',
+                        borderBottom: 1,
+                        borderColor: 'divider',
                         padding: '2px 6px',
                         textAlign: 'left'
                       }
@@ -444,7 +445,8 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                             padding: '2px 6px'
                           },
                           '& th': {
-                            borderBottom: '1px solid #ccc',
+                            borderBottom: 1,
+                        borderColor: 'divider',
                             padding: '2px 6px',
                             textAlign: 'left'
                           }
@@ -641,7 +643,8 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                         padding: '2px 6px'
                       },
                       '& th': {
-                        borderBottom: '1px solid #ccc',
+                        borderBottom: 1,
+                        borderColor: 'divider',
                         padding: '2px 6px',
                         textAlign: 'left'
                       }
@@ -765,7 +768,8 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                         padding: '2px 6px'
                       },
                       '& th': {
-                        borderBottom: '1px solid #ccc',
+                        borderBottom: 1,
+                        borderColor: 'divider',
                         padding: '2px 6px',
                         textAlign: 'left'
                       }
@@ -853,7 +857,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                             The adjustment credit is calculated:
                           </Typography>
 
-                          <Box sx={{ pl: 1, borderLeft: '2px solid #eee', mb: 1 }}>
+                          <Box sx={{ pl: 1, borderLeft: 2, borderColor: 'divider', mb: 1 }}>
                             <Typography variant="caption" display="block" sx={{ fontWeight: 600 }}>
                               If Taxable Income ≤ 2,000,000 JPY:
                             </Typography>
@@ -931,7 +935,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                             The adjustment credit is calculated:
                           </Typography>
 
-                          <Box sx={{ pl: 1, borderLeft: '2px solid #eee', mb: 1 }}>
+                          <Box sx={{ pl: 1, borderLeft: 2, borderColor: 'divider', mb: 1 }}>
                             <Typography variant="caption" display="block" sx={{ fontWeight: 600 }}>
                               If Taxable Income ≤ 2,000,000 JPY:
                             </Typography>
@@ -999,7 +1003,8 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                         padding: '2px 6px'
                       },
                       '& th': {
-                        borderBottom: '1px solid #ccc',
+                        borderBottom: 1,
+                        borderColor: 'divider',
                         padding: '2px 6px',
                         textAlign: 'left'
                       }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -22,7 +22,6 @@ export const getTheme = (mode: 'light' | 'dark') => {
   root.style.setProperty('--action-selected', isDark ? 'rgba(255, 255, 255, 0.16)' : 'rgba(0, 0, 0, 0.08)');
   root.style.setProperty('--primary-main', '#1976d2');
   root.style.setProperty('--border-strong', isDark ? 'rgba(255, 255, 255, 0.23)' : '#aaa');
-  root.style.setProperty('--chart-grid', isDark ? 'rgba(255, 255, 255, 0.3)' : 'rgba(128, 128, 128, 0.4)');
 
   return createTheme({
     palette: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,9 +3,14 @@
 
 import { createTheme } from '@mui/material/styles';
 
+declare module '@mui/material/styles' {
+  interface PaletteColor { 50?: string; }
+  interface SimplePaletteColorOptions { 50?: string; }
+}
+
 export const getTheme = (mode: 'light' | 'dark') => {
   const isDark = mode === 'dark';
-  
+
   // Set CSS variables on the root element
   const root = document.documentElement;
   root.style.setProperty('--background-default', isDark ? '#121212' : '#f5f5f5');
@@ -16,12 +21,15 @@ export const getTheme = (mode: 'light' | 'dark') => {
   root.style.setProperty('--action-hover', isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.04)');
   root.style.setProperty('--action-selected', isDark ? 'rgba(255, 255, 255, 0.16)' : 'rgba(0, 0, 0, 0.08)');
   root.style.setProperty('--primary-main', '#1976d2');
-  
+  root.style.setProperty('--border-strong', isDark ? 'rgba(255, 255, 255, 0.23)' : '#aaa');
+  root.style.setProperty('--chart-grid', isDark ? 'rgba(255, 255, 255, 0.3)' : 'rgba(128, 128, 128, 0.4)');
+
   return createTheme({
     palette: {
       mode,
       primary: {
         main: '#1976d2',
+        50: isDark ? 'rgba(25, 118, 210, 0.12)' : '#e3f2fd',
       },
       secondary: {
         main: '#9c27b0',


### PR DESCRIPTION
## Summary

- Fix bright white/blue boxes in EHI and Pension tooltip info sections (`grey.50` / `primary.50`) that rendered as solid color blocks in dark mode
- Replace ~30 hardcoded border colors (`#ccc`, `#eee`, `#aaa`) across tooltip and tax breakdown tables with theme-aware tokens

## Before / After (Dark Mode — EHI Tooltip)

| Before | After |
|--------|-------|
| <img width="650" height="642" alt="before-dark-mode" src="https://github.com/user-attachments/assets/cfce4c18-89fb-430b-9ba5-c03ddd5aa1fc" /> | <img width="650" height="642" alt="after-dark-mode" src="https://github.com/user-attachments/assets/95740ba4-7835-4a42-a840-63e5bdade6c3" /> |

**Before**: The Monthly Remuneration / SMR info box renders as a bright white block. The Salary Premium calculation area is a solid bright blue block. Table borders are nearly invisible.

**After**: The info box uses a subtle dark highlight. The calculation area uses a soft blue tint. Table borders are clearly visible using the theme divider color.

## Changes

### Theme (`src/theme.ts`)
- Added dark-mode-aware `primary.50` to the palette
- Added CSS variable `--border-strong`
- Added TypeScript augmentation for `PaletteColor.50`

### Tooltip background colors
- `HealthInsurancePremiumTooltip.tsx`, `PensionPremiumTooltip.tsx`: replaced `bgcolor: 'grey.50'` with `bgcolor: 'var(--action-hover)'`
- `primary.50` boxes now resolve correctly via the theme palette extension

### Hardcoded border colors → theme tokens
- **MUI `sx` props**: `HealthInsuranceBonusTooltip`, `PensionBonusTooltip`, `EmploymentIncomeDeductionTooltip`, `TaxesTab` — replaced `#ccc`/`#eee` with `borderColor: 'divider'`
- **Inline `style` props**: `EmploymentInsuranceRateTooltip`, `NationalPensionTooltip`, `HealthInsurancePremiumTooltip` — replaced `#ccc` with `var(--divider)`
- **Bold footer borders**: `HealthInsuranceBonusTooltip`, `PensionBonusTooltip` — replaced `#aaa` with `var(--border-strong)`

## Test plan
- [x] Toggle dark mode and check each tooltip: EHI salary, Pension, EHI bonus, Pension bonus, Employment Insurance, National Pension, Employment Income Deduction
- [x] Check TaxesTab table borders in dark mode
- [x] Check chart percentile band divider lines in dark mode