### PR TITLE
Add FY2026 NHI rates for Chuo Ward

### DIFF
--- a/src/data/nationalHealthInsurance/nhiParamsData.ts
+++ b/src/data/nationalHealthInsurance/nhiParamsData.ts
@@ -41,6 +41,14 @@ const allNHIRegions: Record<string, NHIRegionDefinition> = {
   'Tokyo-Chuo': {
     regionName: "Chuo Ward, Tokyo / 中央区",
     periods: [
+      { effectiveFrom: { year: 2026, month: 3 }, params: {
+        source: "https://www.city.chuo.lg.jp/a0024/kurashi/hokennenkin/kokuho/kokuhonitsuite/noufu/hokenryo.html",
+        medicalRate: 0.0751, supportRate: 0.0280, ltcRateForEligible: 0.0243,
+        medicalPerCapita: 47600, supportPerCapita: 17600, ltcPerCapitaForEligible: 17800,
+        medicalCap: 670000, supportCap: 260000, ltcCapForEligible: 170000,
+        childSupportRate: 0.0027, childSupportPerCapita: 1873, childSupportCap: 30000,
+        nhiStandardDeduction: 430000,
+      }},
       { effectiveFrom: { year: 2025, month: 3 }, params: {
         source: "https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/kokuho/aramashi/hokennryou/h30hokenryougaku",
         medicalRate: 0.0771,


### PR DESCRIPTION
## Summary

Chuo Ward had not yet posted their FY2026 National Health Insurance rates when the rest of the supported Tokyo wards were updated in #260, so residents of Chuo Ward have been falling back to FY2025 rates for calendar year 2026 (producing incorrect blended premiums). The rates have now been published, so this PR adds the FY2026 period to the `Tokyo-Chuo` entry.

Source: https://www.city.chuo.lg.jp/a0024/kurashi/hokennenkin/kokuho/kokuhonitsuite/noufu/hokenryo.html

## Rates added (effective April 2026 – March 2027)

| Portion | 所得割率 | 均等割額 | 賦課限度額 |
|---|---|---|---|
| 基礎分 (medical) | 7.51% | ¥47,600 | ¥670,000 |
| 後期高齢者支援金分 (support) | 2.80% | ¥17,600 | ¥260,000 |
| 介護分 (LTC, age 40–64) | 2.43% | ¥17,800 | ¥170,000 |
| 子ども・子育て支援金分 (child support, new) | 0.27% | ¥1,873 | ¥30,000 |

These figures are identical to the FY2026 values already in place for other Tokyo special wards (Chiyoda, Minato, etc.) — Tokyo-wide standardization. The FY2025 entry is left untouched so historical and 2026-blended calculations remain correct.

## Test plan

- [x] `npx tsc -b` passes
- [x] `npm run lint` passes
- [x] `npm test` — full suite passes (484/484)
- [x] Manual UI check: select Chuo Ward with year 2026 and confirm premium reflects the 3/10 FY2025 + 7/10 FY2026 blend