### PR TITLE
Clarify home loan credit input label and add a first-year explainer

### DIFF
--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -152,7 +152,7 @@ describe('calculateFurusatoNozeiLimit', () => {
       });
       const credit = withCredit.homeLoanTaxCredit!;
       expect(credit.appliedToIncomeTax).toBe(0);
-      expect(credit.annualCredit).toBe(0);
+      expect(credit.availableCredit).toBe(0);
       // Specifically the income-eligibility warning (it names the exceeded net income and the
       // ¥20,000,000 limit), not just any warning that happens to contain "eligibility limit".
       expect(credit.warnings.some(w => w.includes('net income exceeds') && w.includes('20,000,000'))).toBe(true);
@@ -226,7 +226,7 @@ describe('calculateFurusatoNozeiLimit', () => {
       expect(withCredit.nationalIncomeTax).toBe(0);              // income tax fully wiped
       expect(credit.appliedToIncomeTax).toBe(baseTax);          // whole base absorbed
       expect(credit.unusedCredit).toBe(0);                      // spillover under the cap
-      expect(credit.appliedToResidenceTax).toBe(credit.annualCredit - credit.appliedToIncomeTax);
+      expect(credit.appliedToResidenceTax).toBe(credit.availableCredit - credit.appliedToIncomeTax);
       // Furusato limit is unaffected (it is based on the pre-credit 所得割)...
       expect(withCredit.furusatoNozei.limit).toBe(baseline.furusatoNozei.limit);
       // ...but the income-tax refund portion is lost once the credit wipes income tax to 0

--- a/src/__tests__/homeLoanTaxCredit.test.ts
+++ b/src/__tests__/homeLoanTaxCredit.test.ts
@@ -42,7 +42,7 @@ describe('applyHomeLoanTaxCredit', () => {
             500_000,
             5_000_000,
         );
-        expect(result.annualCredit).toBe(200_000);
+        expect(result.availableCredit).toBe(200_000);
         expect(result.appliedToIncomeTax).toBe(200_000);
         expect(result.appliedToResidenceTax).toBe(0);
         expect(result.unusedCredit).toBe(0);
@@ -114,7 +114,7 @@ describe('applyHomeLoanTaxCredit', () => {
             1_000_000,
             18_000_000,
         );
-        expect(result.annualCredit).toBe(0);
+        expect(result.availableCredit).toBe(0);
         expect(result.appliedToIncomeTax).toBe(0);
         expect(result.warnings[0]).toContain('eligibility limit');
     });
@@ -146,7 +146,7 @@ describe('applyHomeLoanTaxCredit', () => {
             572_500,
             5_000_000,
         );
-        expect(result.annualCredit).toBe(0);
+        expect(result.availableCredit).toBe(0);
         expect(result.warnings[0]).toContain('No home loan tax credit rules');
     });
 
@@ -158,7 +158,7 @@ describe('applyHomeLoanTaxCredit', () => {
                 500_000,
                 5_000_000,
             );
-            expect(result.annualCredit).toBe(0);
+            expect(result.availableCredit).toBe(0);
             expect(result.appliedToIncomeTax).toBe(0);
             expect(result.appliedToResidenceTax).toBe(0);
         }

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -232,13 +232,13 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 </AccordionSummary>
                 <AccordionDetails>
                   <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}>
-                    For each year, your available credit amount is your <strong>year-end mortgage balance &times; the credit rate</strong> &mdash; <strong>0.7%</strong> for homes moved into from 2022, or <strong>1%</strong> for 2014-2021 move-ins.
+                    The available credit amount is the <strong>year-end mortgage balance &times; the credit rate</strong> (<strong>0.7%</strong> for homes moved into from 2022, or <strong>1%</strong> for move-ins before 2022).
                   </Typography>
                   <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}>
-                    Only the balance up to a <strong>borrowing limit (借入限度額)</strong> counts. That limit depends on the home's energy-efficiency standard (認定長期優良住宅, ZEH水準, 省エネ基準, or 一般住宅), your household, and your move-in year &mdash; and the credit runs for <strong>10 or 13 years</strong>, so the amount falls each year as you pay down the loan.
+                    The year-end balance is capped by a <strong>borrowing limit (借入限度額)</strong>. That limit depends on the home's energy-efficiency standard (認定長期優良住宅, ZEH水準, 省エネ基準, or 一般住宅), your household, and your move-in year. The credit runs for <strong>10 or 13 years</strong>.
                   </Typography>
                   <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.secondary' }}>
-                    After the first year, this figure appears as <strong>住宅借入金等特別控除可能額</strong> on your 源泉徴収票. To work it out for the first year, or to check the limits, see the{' '}
+                    After the first year, this figure appears as <strong>住宅借入金等特別控除可能額</strong> on your annual withholding summary (源泉徴収票). To work it out for the first year, or to check the limits, see the{' '}
                     <a href="https://www.mlit.go.jp/jutakukentiku/house/jutakukentiku_house_tk2_000017.html" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>MLIT overview</a> (which has the full limit table) and the{' '}
                     <a href="https://www.nta.go.jp/taxes/shiraberu/shinkoku/tokushu/keisubetsu/juutaku.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>NTA guide</a>.
                   </Typography>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -214,7 +214,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
               </Box>
 
               {/* Surface any warning the credit calculation produced: income over the limit
-                  (credit zeroed) OR part of the credit unusable this year (annualCredit > 0 but
+                  (credit zeroed) OR part of the credit unusable this year (availableCredit > 0 but
                   capped). Gated only on a positive entered amount so we don't warn before the
                   user has entered a credit (the income-limit warning fires even at amount 0). */}
               {homeLoanTaxCreditResult && homeLoanTaxCreditResult.warnings.length > 0 && effectiveHomeLoan.creditAmount > 0 && (

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -16,9 +16,13 @@ import CardContent from '@mui/material/CardContent';
 import FormControl from '@mui/material/FormControl';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
 import CloseIcon from '@mui/icons-material/Close';
 import TuneIcon from '@mui/icons-material/Tune';
 import WarningIcon from '@mui/icons-material/Warning';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
@@ -186,7 +190,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     name="creditAmount"
                     value={effectiveHomeLoan.creditAmount}
                     onInputChange={(e) => updateHomeLoan({ creditAmount: Number((e.target as HTMLInputElement).value) || 0 })}
-                    label="Credit amount (控除可能額)"
+                    label="Available credit amount (控除可能額)"
                     step={1_000}
                     shiftStep={10_000}
                     min={0}
@@ -222,19 +226,24 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 </Box>
               )}
 
-              <Box sx={{ p: 1.5, bgcolor: 'action.hover', borderRadius: 1, mt: 2 }}>
-                <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.secondary' }}>
-                  Is it your first year claiming the credit? See the{' '}
-                  <a
-                    href="https://www.nta.go.jp/taxes/shiraberu/shinkoku/tokushu/keisubetsu/juutaku.htm"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{ color: 'inherit', textDecoration: 'underline' }}
-                  >
-                    NTA's home loan tax credit guide
-                  </a>.
-                </Typography>
-              </Box>
+              <Accordion disableGutters elevation={0} sx={{ mt: 2, border: '1px solid', borderColor: 'divider' }}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>How is the available credit amount calculated?</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}>
+                    For each year, your available credit amount is your <strong>year-end mortgage balance &times; the credit rate</strong> &mdash; <strong>0.7%</strong> for homes moved into from 2022, or <strong>1%</strong> for 2014-2021 move-ins.
+                  </Typography>
+                  <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}>
+                    Only the balance up to a <strong>borrowing limit (借入限度額)</strong> counts. That limit depends on the home's energy-efficiency standard (認定長期優良住宅, ZEH水準, 省エネ基準, or 一般住宅), your household, and your move-in year &mdash; and the credit runs for <strong>10 or 13 years</strong>, so the amount falls each year as you pay down the loan.
+                  </Typography>
+                  <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.secondary' }}>
+                    After the first year, this figure appears as <strong>住宅借入金等特別控除可能額</strong> on your 源泉徴収票. To work it out for the first year, or to check the limits, see the{' '}
+                    <a href="https://www.mlit.go.jp/jutakukentiku/house/jutakukentiku_house_tk2_000017.html" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>MLIT overview</a> (which has the full limit table) and the{' '}
+                    <a href="https://www.nta.go.jp/taxes/shiraberu/shinkoku/tokushu/keisubetsu/juutaku.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>NTA guide</a>.
+                  </Typography>
+                </AccordionDetails>
+              </Accordion>
             </CardContent>
           </Card>
         </Box>

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -950,9 +950,9 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({ inputs, onInput
               if (inputs.dcPlanContributions > 0) parts.push(`DC ${formatJPY(inputs.dcPlanContributions)}`);
               if (inputs.homeLoanTaxCredit && inputs.homeLoanTaxCredit.creditAmount > 0) parts.push(`Home loan tax credit ${formatJPY(inputs.homeLoanTaxCredit.creditAmount)}`);
               // Via the UI the move-in dropdown only offers eligible years, so a credit entered
-              // but zeroed (annualCredit 0) means income exceeded the cohort's eligibility limit.
+              // but zeroed (availableCredit 0) means income exceeded the cohort's eligibility limit.
               const homeLoanNotApplied = !!(inputs.homeLoanTaxCredit && inputs.homeLoanTaxCredit.creditAmount > 0
-                && homeLoanTaxCreditResult && homeLoanTaxCreditResult.annualCredit === 0);
+                && homeLoanTaxCreditResult && homeLoanTaxCreditResult.availableCredit === 0);
               return parts.length > 0 ? (
                 <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
                   <Typography component="span" sx={{ fontSize: '0.95rem', fontWeight: 500 }}>

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -543,7 +543,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                     </Typography>
                     {results.homeLoanTaxCredit.appliedToResidenceTax > 0 && (
                       <Typography variant="body2" sx={{ mb: 1 }}>
-                        Your home loan tax credit is larger than your income tax. The remainder spills over to residence tax. See the <strong>Home Loan Tax Credit</strong> line under Residence Tax (below) for the spillover cap and any amount that cannot be claimed.
+                        Your available credit amount is larger than your income tax. The remainder spills over to residence tax. See the <strong>Home Loan Tax Credit</strong> line under Residence Tax (below) for the spillover cap and any amount that cannot be claimed.
                       </Typography>
                     )}
                     <Box sx={{ mt: 1 }}>
@@ -1046,7 +1046,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                 <DetailedTooltip title="Home Loan Tax Credit — Residence Tax Spillover">
                   <Box>
                     <Typography variant="body2" sx={{ mb: 1 }}>
-                      When the home loan tax credit exceeds your income tax, the remainder spills over to reduce residence tax. The cap is the lower of ¥97,500 (¥136,500 for 2014–2021 move-ins) and 5% (7% for 2014–2021 move-ins) of your <strong>income-tax</strong> taxable total income (所得税の課税総所得金額等).
+                      When your available credit amount exceeds your income tax, the remainder spills over to reduce residence tax. The cap is the lower of ¥97,500 (¥136,500 for 2014–2021 move-ins) and 5% (7% for 2014–2021 move-ins) of your <strong>income-tax</strong> taxable total income (所得税の課税総所得金額等).
                     </Typography>
                     {results.homeLoanTaxCredit.residenceTaxSpilloverCap && (
                       <Typography variant="body2" sx={{ mb: 1 }}>
@@ -1055,7 +1055,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                     )}
                     {results.homeLoanTaxCredit.unusedCredit > 0 && (
                       <Typography variant="body2" sx={{ mb: 1, color: 'warning.main' }}>
-                        Your full credit ({formatJPY(results.homeLoanTaxCredit.annualCredit)}) is more than your income tax ({formatJPY(results.homeLoanTaxCredit.appliedToIncomeTax)}) plus this cap ({formatJPY(results.homeLoanTaxCredit.appliedToResidenceTax)}) combined, so {formatJPY(results.homeLoanTaxCredit.unusedCredit)} cannot be applied and is lost.
+                        Your available credit amount ({formatJPY(results.homeLoanTaxCredit.annualCredit)}) is more than your income tax ({formatJPY(results.homeLoanTaxCredit.appliedToIncomeTax)}) plus this cap ({formatJPY(results.homeLoanTaxCredit.appliedToResidenceTax)}) combined, so {formatJPY(results.homeLoanTaxCredit.unusedCredit)} cannot be applied and is lost.
                       </Typography>
                     )}
                     <Typography variant="body2" sx={{ mb: 1 }}>

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -1055,7 +1055,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                     )}
                     {results.homeLoanTaxCredit.unusedCredit > 0 && (
                       <Typography variant="body2" sx={{ mb: 1, color: 'warning.main' }}>
-                        Your available credit amount ({formatJPY(results.homeLoanTaxCredit.annualCredit)}) is more than your income tax ({formatJPY(results.homeLoanTaxCredit.appliedToIncomeTax)}) plus this cap ({formatJPY(results.homeLoanTaxCredit.appliedToResidenceTax)}) combined, so {formatJPY(results.homeLoanTaxCredit.unusedCredit)} cannot be applied and is lost.
+                        Your available credit amount ({formatJPY(results.homeLoanTaxCredit.availableCredit)}) is more than your income tax ({formatJPY(results.homeLoanTaxCredit.appliedToIncomeTax)}) plus this cap ({formatJPY(results.homeLoanTaxCredit.appliedToResidenceTax)}) combined, so {formatJPY(results.homeLoanTaxCredit.unusedCredit)} cannot be applied and is lost.
                       </Typography>
                     )}
                     <Typography variant="body2" sx={{ mb: 1 }}>

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -65,8 +65,13 @@ export interface HomeLoanTaxCreditInput {
 
 /** Computed application of the home loan tax credit. */
 export interface HomeLoanTaxCreditResult {
-  /** Total credit for the year (yen). Sum of {@link appliedToIncomeTax}, {@link appliedToResidenceTax}, {@link unusedCredit} */
-  annualCredit: number;
+  /**
+   * The credit available to apply this year (yen). Sum of {@link appliedToIncomeTax},
+   * {@link appliedToResidenceTax}, and {@link unusedCredit}. Zero when the taxpayer is
+   * ineligible (income over the cohort limit, or an unsupported move-in year), so it may
+   * be less than the entered 控除可能額 in that case.
+   */
+  availableCredit: number;
   /** Portion applied against national income tax. */
   appliedToIncomeTax: number;
   /** Portion that spilled over and was applied against residence tax. */

--- a/src/utils/homeLoanTaxCredit.ts
+++ b/src/utils/homeLoanTaxCredit.ts
@@ -14,7 +14,7 @@ import type { HomeLoanTaxCreditInput, HomeLoanTaxCreditResult } from "../types/t
 import { getHomeLoanTaxCreditCohort, HOME_LOAN_TAX_CREDIT_COHORTS } from "../data/homeLoanTaxCredit";
 
 const EMPTY_RESULT: HomeLoanTaxCreditResult = {
-    annualCredit: 0,
+    availableCredit: 0,
     appliedToIncomeTax: 0,
     appliedToResidenceTax: 0,
     unusedCredit: 0,
@@ -83,20 +83,20 @@ export function applyHomeLoanTaxCredit(
         return { ...EMPTY_RESULT, warnings };
     }
 
-    const annualCredit = Math.max(0, Math.floor(input.creditAmount));
-    if (annualCredit <= 0) {
+    const availableCredit = Math.max(0, Math.floor(input.creditAmount));
+    if (availableCredit <= 0) {
         return { ...EMPTY_RESULT, warnings };
     }
 
     // Apply to the base income tax (所得税額) first — this is a 税額控除.
-    const appliedToIncomeTax = Math.min(annualCredit, Math.max(0, baseIncomeTax));
-    const spilloverEligible = annualCredit - appliedToIncomeTax;
+    const appliedToIncomeTax = Math.min(availableCredit, Math.max(0, baseIncomeTax));
+    const spilloverEligible = availableCredit - appliedToIncomeTax;
 
     // Remainder spills over to residence tax, capped at min(定額限度 flatCap, 定率限度 課税総所得金額等 × rate).
     const incomeRateCap = Math.floor(Math.max(0, taxableTotalIncome) * cohort.spillover.taxableIncomeRate);
     const residenceTaxCap = Math.min(cohort.spillover.flatCap, incomeRateCap);
     const appliedToResidenceTax = Math.min(spilloverEligible, residenceTaxCap);
-    const unusedCredit = annualCredit - appliedToIncomeTax - appliedToResidenceTax;
+    const unusedCredit = availableCredit - appliedToIncomeTax - appliedToResidenceTax;
 
     if (unusedCredit > 0) {
         warnings.push(
@@ -106,7 +106,7 @@ export function applyHomeLoanTaxCredit(
     }
 
     return {
-        annualCredit,
+        availableCredit,
         appliedToIncomeTax,
         appliedToResidenceTax,
         unusedCredit,


### PR DESCRIPTION
Follow-up to #307 (home loan tax credit). Two UI/copy refinements to the "Additional Deductions & Credits" modal — no calculation changes.

## Changes

- **Clearer input label.** "Credit amount (控除可能額)" → **"Available credit amount (控除可能額)"**, to distinguish the amount *available* to claim from the amounts the calculator then shows as applied to income tax, spilled to residence tax, or unused.
- **First-year explainer behind an accordion.** The small first-year note is replaced with a collapsed accordion (same pattern as the stock-based-compensation explainers), so it stays out of the way for the majority who just read the figure off their 源泉徴収票 but is there for first-time claimers. It explains that the available credit amount is the year-end loan balance × the credit rate (0.7% for 2022+ move-ins, 1% for 2014–2021), counted up to a borrowing limit (借入限度額) that depends on the home and move-in year, over a 10- or 13-year period — and links to the [MLIT overview](https://www.mlit.go.jp/jutakukentiku/house/jutakukentiku_house_tk2_000017.html) (full limit table) and the [NTA guide](https://www.nta.go.jp/taxes/shiraberu/shinkoku/tokushu/keisubetsu/juutaku.htm).
