### PR TITLE
Add income amount adjustment deduction (所得金額調整控除)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Japan Take-Home Pay Calculator will be documented in this file.
 
-## 2026-06-20
+## 2026-06-21
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to the Japan Take-Home Pay Calculator will be documented in this file.
 
-## 2026-06-19
+## 2026-06-20
 
 ### Fixed
 
-- Applied the income amount adjustment deduction (所得金額調整控除（子ども・特別障害者等を有する者等）) for taxpayers with employment income over ¥8,500,000 who have a dependent under 23 or a specially-disabled spouse/dependent. Up to ¥150,000 is now subtracted from employment income, which lowers total net income (合計所得金額) and reduces both income tax and residence tax. Because total net income feeds several eligibility limits, this also corrects cases where, for example, the home loan tax credit was wrongly denied at the ¥20,000,000 income limit. See the Net Employment Income tooltip for the breakdown. (Note: qualification based on the taxpayer's own special-disability status is not yet supported.)
+- Added support for the income amount adjustment deduction ([所得金額調整控除（子ども・特別障害者等を有する者等）](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm)) for taxpayers with employment income over ¥8,500,000 who have a qualifying dependent under 23 or a specially-disabled spouse/dependent. Up to ¥150,000 is deducted from employment income, which lowers total net income (合計所得金額). Because total net income is the basis for several eligibility limits, this also corrects cases where, for example, the home loan tax credit was wrongly denied near the ¥20,000,000 income limit. See the Net Employment Income tooltip for the breakdown.
 
 ## 2026-05-18
 
@@ -20,7 +20,7 @@ All notable changes to the Japan Take-Home Pay Calculator will be documented in 
 
 ### Fixed
 
-- Corrected the residence-tax adjustment credit (調整控除) for filers whose taxable income is above ¥2,000,000 and claim a deduction for a spouse or dependents. Residence tax was being slightly under-stated for these households. Filers not claiming a spouse or dependent deduction, anyone with taxable income at or below ¥2,000,000, and anyone with net income exceeding ¥25,000,000, were unaffected.
+- Corrected the residence-tax adjustment credit (調整控除) for taxpayers whose taxable income is above ¥2,000,000 and claim a deduction for a spouse or dependents. Residence tax was being slightly under-stated for these households. Taxpayers not claiming a spouse or dependent deduction, anyone with taxable income at or below ¥2,000,000, and anyone with net income exceeding ¥25,000,000, were unaffected.
 
 ## 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Japan Take-Home Pay Calculator will be documented in 
 
 ### Fixed
 
-- Added support for the income amount adjustment deduction ([所得金額調整控除（子ども・特別障害者等を有する者等）](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm)) for eligible taxpayers. Up to ¥150,000 is deducted from employment income, which lowers total net income (合計所得金額). Because total net income is the basis for several eligibility limits, this also corrects cases where, for example, the home loan tax credit was wrongly denied near the ¥20,000,000 income limit. Details are in the Net Employment Income tooltip when eligible.
+- Added support for the income amount adjustment deduction ([所得金額調整控除（子ども・特別障害者等を有する者等）](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm)) for taxpayers with employment income exceeding ¥8,500,000 and who have a qualifying dependent (a dependent relative under 23, or a spouse/dependent with special disability status). Up to ¥150,000 is deducted from employment income, which lowers total net income (合計所得金額). Because total net income is the basis for several eligibility limits, this also corrects cases where, for example, the home loan tax credit was wrongly denied near the ¥20,000,000 income limit. Details are in the Net Employment Income tooltip when eligible.
 
 ## 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Japan Take-Home Pay Calculator will be documented in 
 
 ### Fixed
 
-- Added support for the income amount adjustment deduction ([所得金額調整控除（子ども・特別障害者等を有する者等）](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm)) for taxpayers with employment income over ¥8,500,000 who have a qualifying dependent under 23 or a specially-disabled spouse/dependent. Up to ¥150,000 is deducted from employment income, which lowers total net income (合計所得金額). Because total net income is the basis for several eligibility limits, this also corrects cases where, for example, the home loan tax credit was wrongly denied near the ¥20,000,000 income limit. See the Net Employment Income tooltip for the breakdown.
+- Added support for the income amount adjustment deduction ([所得金額調整控除（子ども・特別障害者等を有する者等）](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm)) for eligible taxpayers. Up to ¥150,000 is deducted from employment income, which lowers total net income (合計所得金額). Because total net income is the basis for several eligibility limits, this also corrects cases where, for example, the home loan tax credit was wrongly denied near the ¥20,000,000 income limit. Details are in the Net Employment Income tooltip when eligible.
 
 ## 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Japan Take-Home Pay Calculator will be documented in this file.
 
+## 2026-06-19
+
+### Fixed
+
+- Applied the income amount adjustment deduction (所得金額調整控除（子ども・特別障害者等を有する者等）) for taxpayers with employment income over ¥8,500,000 who have a dependent under 23 or a specially-disabled spouse/dependent. Up to ¥150,000 is now subtracted from employment income, which lowers total net income (合計所得金額) and reduces both income tax and residence tax. Because total net income feeds several eligibility limits, this also corrects cases where, for example, the home loan tax credit was wrongly denied at the ¥20,000,000 income limit. See the Net Employment Income tooltip for the breakdown. (Note: qualification based on the taxpayer's own special-disability status is not yet supported.)
+
 ## 2026-05-18
 
 ### New

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -8,7 +8,7 @@ import {
   calculateIncomeAdjustmentDeduction,
   hasIncomeAdjustmentDeductionDependent,
 } from '../utils/dependentDeductions'
-import { calculateIncomeAdjustmentDeductionAmount } from '../data/employmentIncomeDeduction'
+import { calculateIncomeAdjustmentDeductionAmount } from '../data/netEmploymentIncome'
 import { DEDUCTION_TYPES, type Dependent } from '../types/dependents'
 
 // --- Helper functions to test internal logic via public API ---
@@ -1585,7 +1585,9 @@ describe('所得金額調整控除 (Income Amount Adjustment Deduction)', () => 
 
     it('rounds fractions of a yen up', () => {
       expect(calculateIncomeAdjustmentDeductionAmount(8_500_001)).toBe(1); // ⌈0.1⌉
-      expect(calculateIncomeAdjustmentDeductionAmount(8_512_345)).toBe(1_235); // ⌈1234.5⌉
+      expect(calculateIncomeAdjustmentDeductionAmount(8_512_345)).toBe(1_235); // ⌈1,234.5⌉
+      expect(calculateIncomeAdjustmentDeductionAmount(9_001_040)).toBe(50_104); // ⌈50,104.0⌉
+      expect(calculateIncomeAdjustmentDeductionAmount(9_001_041)).toBe(50_105); // ⌈50,104.1⌉
     });
   });
 

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, it } from 'vitest'
 import {
   calculateDependentDeductions,
   calculateDependentTotalNetIncome,
+  calculateIncomeAdjustmentDeduction,
+  hasIncomeAdjustmentDeductionDependent,
 } from '../utils/dependentDeductions'
+import { calculateIncomeAdjustmentDeductionAmount } from '../data/employmentIncomeDeduction'
 import { DEDUCTION_TYPES, type Dependent } from '../types/dependents'
 
 // --- Helper functions to test internal logic via public API ---
@@ -1548,6 +1551,103 @@ describe('2025 income year (R7) — 58万円 threshold', () => {
       };
       expect(isEligibleForSpecificRelativeSpecialDeduction(dependent, 2025)).toBe(true);
       expect(isEligibleForDependentDeduction(dependent, 2026)).toBe(true);
+    });
+  });
+})
+
+describe('所得金額調整控除 (Income Amount Adjustment Deduction)', () => {
+  // Helper: a non-spouse dependent with sensible defaults (no income, no disability).
+  const dependent = (overrides: Partial<Dependent> = {}): Dependent => ({
+    id: 'dep',
+    relationship: 'child',
+    ageCategory: '19to22',
+    isCohabiting: false,
+    disability: 'none',
+    income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
+    ...overrides,
+  } as Dependent);
+
+  describe('calculateIncomeAdjustmentDeductionAmount (formula)', () => {
+    it('is 0 at or below the ¥8,500,000 threshold', () => {
+      expect(calculateIncomeAdjustmentDeductionAmount(8_000_000)).toBe(0);
+      expect(calculateIncomeAdjustmentDeductionAmount(8_500_000)).toBe(0);
+    });
+
+    it('is 10% of salary above ¥8,500,000', () => {
+      expect(calculateIncomeAdjustmentDeductionAmount(9_000_000)).toBe(50_000);
+      expect(calculateIncomeAdjustmentDeductionAmount(9_350_000)).toBe(85_000);
+    });
+
+    it('caps at ¥150,000 once salary reaches ¥10,000,000', () => {
+      expect(calculateIncomeAdjustmentDeductionAmount(10_000_000)).toBe(150_000);
+      expect(calculateIncomeAdjustmentDeductionAmount(22_000_000)).toBe(150_000);
+    });
+
+    it('rounds fractions of a yen up', () => {
+      expect(calculateIncomeAdjustmentDeductionAmount(8_500_001)).toBe(1); // ⌈0.1⌉
+      expect(calculateIncomeAdjustmentDeductionAmount(8_512_345)).toBe(1_235); // ⌈1234.5⌉
+    });
+  });
+
+  describe('hasIncomeAdjustmentDeductionDependent (eligibility)', () => {
+    it('returns false with no dependents', () => {
+      expect(hasIncomeAdjustmentDeductionDependent([], 2026)).toBe(false);
+    });
+
+    it('qualifies via ロ for a 扶養親族 under 23 (incl. under 16)', () => {
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: 'under16' })], 2026)).toBe(true);
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: '16to18' })], 2026)).toBe(true);
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: '19to22' })], 2026)).toBe(true);
+    });
+
+    it('does NOT qualify via ロ for a dependent 23 or older without special disability', () => {
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: '23to69' })], 2026)).toBe(false);
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: '70plus' })], 2026)).toBe(false);
+    });
+
+    it('qualifies via ハ for a special-disability dependent of any age', () => {
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: '23to69', disability: 'special' })], 2026)).toBe(true);
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: '70plus', disability: 'special' })], 2026)).toBe(true);
+    });
+
+    it('does NOT qualify via ハ for a regular (non-special) disability', () => {
+      expect(hasIncomeAdjustmentDeductionDependent([dependent({ ageCategory: '23to69', disability: 'regular' })], 2026)).toBe(false);
+    });
+
+    it('requires the dependent to be within the 扶養親族 income threshold', () => {
+      // 2026 threshold is ¥620,000.
+      const richChild = dependent({ ageCategory: '19to22', income: { grossEmploymentIncome: 0, otherNetIncome: 700_000 } });
+      expect(hasIncomeAdjustmentDeductionDependent([richChild], 2026)).toBe(false);
+      const poorChild = dependent({ ageCategory: '19to22', income: { grossEmploymentIncome: 0, otherNetIncome: 620_000 } });
+      expect(hasIncomeAdjustmentDeductionDependent([poorChild], 2026)).toBe(true);
+    });
+
+    it('qualifies a spouse only via ハ (special disability), never via ロ', () => {
+      const spouse = (overrides: Partial<Dependent> = {}): Dependent => ({
+        id: 'sp', relationship: 'spouse', ageCategory: 'under70', isCohabiting: true,
+        disability: 'none', income: { grossEmploymentIncome: 0, otherNetIncome: 0 }, ...overrides,
+      } as Dependent);
+      expect(hasIncomeAdjustmentDeductionDependent([spouse()], 2026)).toBe(false);
+      expect(hasIncomeAdjustmentDeductionDependent([spouse({ disability: 'special' })], 2026)).toBe(true);
+      // A high-earning special-disability spouse is not a 同一生計配偶者, so does not qualify.
+      const richSpouse = spouse({ disability: 'special', income: { grossEmploymentIncome: 0, otherNetIncome: 700_000 } });
+      expect(hasIncomeAdjustmentDeductionDependent([richSpouse], 2026)).toBe(false);
+    });
+  });
+
+  describe('calculateIncomeAdjustmentDeduction (gated amount)', () => {
+    it('returns the formula amount when a qualifying dependent is present', () => {
+      expect(calculateIncomeAdjustmentDeduction(22_000_000, [dependent({ ageCategory: '19to22' })], 2026)).toBe(150_000);
+      expect(calculateIncomeAdjustmentDeduction(9_000_000, [dependent({ ageCategory: 'under16' })], 2026)).toBe(50_000);
+    });
+
+    it('returns 0 when there is no qualifying dependent, even over ¥8.5M', () => {
+      expect(calculateIncomeAdjustmentDeduction(22_000_000, [], 2026)).toBe(0);
+      expect(calculateIncomeAdjustmentDeduction(22_000_000, [dependent({ ageCategory: '23to69' })], 2026)).toBe(0);
+    });
+
+    it('returns 0 when salary is at or below ¥8.5M even with a qualifying dependent', () => {
+      expect(calculateIncomeAdjustmentDeduction(8_400_000, [dependent({ ageCategory: '19to22' })], 2026)).toBe(0);
     });
   });
 })

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from 'vitest'
 import {
   calculateDependentDeductions,
   calculateDependentTotalNetIncome,
-  calculateIncomeAdjustmentDeduction,
   hasIncomeAdjustmentDeductionDependent,
 } from '../utils/dependentDeductions'
 import { calculateIncomeAdjustmentDeductionAmount } from '../data/netEmploymentIncome'
@@ -1634,22 +1633,6 @@ describe('所得金額調整控除 (Income Amount Adjustment Deduction)', () => 
       // A high-earning special-disability spouse is not a 同一生計配偶者, so does not qualify.
       const richSpouse = spouse({ disability: 'special', income: { grossEmploymentIncome: 0, otherNetIncome: 700_000 } });
       expect(hasIncomeAdjustmentDeductionDependent([richSpouse], 2026)).toBe(false);
-    });
-  });
-
-  describe('calculateIncomeAdjustmentDeduction (gated amount)', () => {
-    it('returns the formula amount when a qualifying dependent is present', () => {
-      expect(calculateIncomeAdjustmentDeduction(22_000_000, [dependent({ ageCategory: '19to22' })], 2026)).toBe(150_000);
-      expect(calculateIncomeAdjustmentDeduction(9_000_000, [dependent({ ageCategory: 'under16' })], 2026)).toBe(50_000);
-    });
-
-    it('returns 0 when there is no qualifying dependent, even over ¥8.5M', () => {
-      expect(calculateIncomeAdjustmentDeduction(22_000_000, [], 2026)).toBe(0);
-      expect(calculateIncomeAdjustmentDeduction(22_000_000, [dependent({ ageCategory: '23to69' })], 2026)).toBe(0);
-    });
-
-    it('returns 0 when salary is at or below ¥8.5M even with a qualifying dependent', () => {
-      expect(calculateIncomeAdjustmentDeduction(8_400_000, [dependent({ ageCategory: '19to22' })], 2026)).toBe(0);
     });
   });
 })

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
 import { calculateTaxes, calculateNetEmploymentIncome, calculateEmploymentInsurance, calculateNationalIncomeTaxBasicDeduction, calculateNationalIncomeTax, calculateTotalNetIncome } from '../utils/taxCalculations'
 import { DEFAULT_PROVIDER, NATIONAL_HEALTH_INSURANCE_ID, CUSTOM_PROVIDER_ID } from '../types/healthInsurance'
+import type { Dependent } from '../types/dependents'
 
 // Pin the year so employment insurance rate lookups are deterministic.
 // Year 2025: all 12 months use the FY2025 rate (0.55%).
@@ -1158,5 +1159,72 @@ describe('RSU (Restricted Stock Unit) income', () => {
 
     // Combined 2M below 2.2M: net = 2M - 740k = 1.26M
     expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(1_260_000);
+  });
+});
+
+describe('所得金額調整控除 (income amount adjustment deduction) integration', () => {
+  const childUnder23: Dependent = {
+    id: 'c1', relationship: 'child', ageCategory: '19to22',
+    isCohabiting: false, disability: 'none',
+    income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
+  };
+  const adultChild: Dependent = {
+    id: 'c2', relationship: 'child', ageCategory: '23to69',
+    isCohabiting: false, disability: 'none',
+    income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
+  };
+
+  const baseInputs = (dependents: Dependent[]) => ({
+    incomeStreams: [{ id: 's1', type: 'salary' as const, amount: 22_000_000, frequency: 'annual' as const }],
+    isSubjectToLongTermCarePremium: false,
+    healthInsuranceProvider: DEFAULT_PROVIDER,
+    region: 'Tokyo',
+    dependents,
+    dcPlanContributions: 0,
+    manualSocialInsuranceEntry: false,
+    manualSocialInsuranceAmount: 0,
+    incomeYear: 2026,
+  });
+
+  it('reduces 給与所得 / 合計所得金額 by the adjustment for the worked example (¥22M salary, child under 23)', () => {
+    const result = calculateTaxes(baseInputs([childUnder23]));
+    // 給与所得控除: 22M - 1.95M = 20.05M; 所得金額調整控除: (10M - 8.5M) × 10% = 150k
+    expect(result.incomeAdjustmentDeduction).toBe(150_000);
+    expect(result.netEmploymentIncome).toBe(19_900_000);
+    expect(result.totalNetIncome).toBe(19_900_000);
+  });
+
+  it('does NOT apply when the only dependent is 23 or older without special disability', () => {
+    const result = calculateTaxes(baseInputs([adultChild]));
+    expect(result.incomeAdjustmentDeduction).toBe(0);
+    expect(result.netEmploymentIncome).toBe(20_050_000);
+    expect(result.totalNetIncome).toBe(20_050_000);
+  });
+
+  it('does NOT apply with no dependents', () => {
+    const result = calculateTaxes(baseInputs([]));
+    expect(result.incomeAdjustmentDeduction).toBe(0);
+    expect(result.totalNetIncome).toBe(20_050_000);
+  });
+
+  it('lets the adjustment bring 合計所得金額 under the ¥20M home-loan-credit limit (the bug in #344)', () => {
+    // With the qualifying child, 合計所得金額 = 19.9M ≤ 20M, so the credit applies.
+    const eligible = calculateTaxes({ ...baseInputs([childUnder23]), homeLoanTaxCredit: { moveInYear: 2024, creditAmount: 200_000 } });
+    expect(eligible.totalNetIncome).toBe(19_900_000);
+    expect(eligible.homeLoanTaxCredit?.annualCredit).toBe(200_000);
+    expect(eligible.homeLoanTaxCredit?.appliedToIncomeTax).toBe(200_000);
+
+    // Without a qualifying dependent, 合計所得金額 = 20.05M > 20M, so the credit is denied.
+    const denied = calculateTaxes({ ...baseInputs([adultChild]), homeLoanTaxCredit: { moveInYear: 2024, creditAmount: 200_000 } });
+    expect(denied.totalNetIncome).toBe(20_050_000);
+    expect(denied.homeLoanTaxCredit?.annualCredit).toBe(0);
+    expect(denied.homeLoanTaxCredit?.warnings[0]).toContain('eligibility limit');
+  });
+
+  it('calculateTotalNetIncome applies the adjustment when given qualifying dependents', () => {
+    const incomeStreams = [{ id: 's1', type: 'salary' as const, amount: 22_000_000, frequency: 'annual' as const }];
+    expect(calculateTotalNetIncome(incomeStreams, 2026, [childUnder23])).toBe(19_900_000);
+    // No dependents argument → no adjustment (backward compatible).
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(20_050_000);
   });
 });

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -90,6 +90,28 @@ describe('calculateNetEmploymentIncome', () => {
       expect(calculateNetEmploymentIncome(10_000_000, 2025)).toBe(10_000_000 - 1_950_000)
     })
   })
+
+  describe('income amount adjustment (所得金額調整控除)', () => {
+    const childUnder23: Dependent = {
+      id: 'c', relationship: 'child', ageCategory: '19to22',
+      isCohabiting: false, disability: 'none',
+      income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
+    }
+
+    it('subtracts the 所得金額調整控除 when a qualifying dependent is passed and salary exceeds ¥8.5M', () => {
+      // 22M (R8): 給与所得控除 → 20,050,000; 所得金額調整控除 → 150,000; net = 19,900,000
+      expect(calculateNetEmploymentIncome(22_000_000, 2026, [childUnder23])).toBe(19_900_000)
+    })
+
+    it('applies no adjustment without dependents (the default)', () => {
+      expect(calculateNetEmploymentIncome(22_000_000, 2026)).toBe(20_050_000)
+    })
+
+    it('applies no adjustment at or below ¥8.5M even with a qualifying dependent', () => {
+      expect(calculateNetEmploymentIncome(8_400_000, 2026, [childUnder23]))
+        .toBe(calculateNetEmploymentIncome(8_400_000, 2026))
+    })
+  })
 })
 
 describe('calculateTaxes', () => {

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1211,13 +1211,13 @@ describe('所得金額調整控除 (income amount adjustment deduction) integrat
     // With the qualifying child, 合計所得金額 = 19.9M ≤ 20M, so the credit applies.
     const eligible = calculateTaxes({ ...baseInputs([childUnder23]), homeLoanTaxCredit: { moveInYear: 2024, creditAmount: 200_000 } });
     expect(eligible.totalNetIncome).toBe(19_900_000);
-    expect(eligible.homeLoanTaxCredit?.annualCredit).toBe(200_000);
+    expect(eligible.homeLoanTaxCredit?.availableCredit).toBe(200_000);
     expect(eligible.homeLoanTaxCredit?.appliedToIncomeTax).toBe(200_000);
 
     // Without a qualifying dependent, 合計所得金額 = 20.05M > 20M, so the credit is denied.
     const denied = calculateTaxes({ ...baseInputs([adultChild]), homeLoanTaxCredit: { moveInYear: 2024, creditAmount: 200_000 } });
     expect(denied.totalNetIncome).toBe(20_050_000);
-    expect(denied.homeLoanTaxCredit?.annualCredit).toBe(0);
+    expect(denied.homeLoanTaxCredit?.availableCredit).toBe(0);
     expect(denied.homeLoanTaxCredit?.warnings[0]).toContain('eligibility limit');
   });
 

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -447,8 +447,9 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({ inputs, onInput
     }
   };
 
-  // We only need the total net income for the dependents modal.
-  const taxpayerNetIncome = React.useMemo(() => calculateTotalNetIncome(inputs.incomeStreams), [inputs.incomeStreams]);
+  // We only need the total net income for the dependents modal. Pass dependents so the
+  // 所得金額調整控除 is reflected, keeping the modal's eligibility hints consistent with the results.
+  const taxpayerNetIncome = React.useMemo(() => calculateTotalNetIncome(inputs.incomeStreams, undefined, inputs.dependents), [inputs.incomeStreams, inputs.dependents]);
 
   return (
     <Box className="form-container" sx={{ p: { xs: 1.2, sm: 2 }, bgcolor: 'background.paper', borderRadius: 3, boxShadow: 2 }}>

--- a/src/components/TakeHomeCalculator/tabs/EmploymentIncomeDeductionTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/EmploymentIncomeDeductionTooltip.tsx
@@ -10,9 +10,14 @@ const fmtNum = (n: number) => n.toLocaleString('en');
 
 interface EmploymentIncomeDeductionTooltipProps {
     year: number;
+    /**
+     * 所得金額調整控除 applied to this taxpayer (yen). When greater than 0, an explanatory note
+     * about the income amount adjustment deduction is shown below the 給与所得控除 table.
+     */
+    incomeAdjustmentDeduction?: number;
 }
 
-const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionTooltipProps> = ({ year }) => {
+const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionTooltipProps> = ({ year, incomeAdjustmentDeduction = 0 }) => {
     const period = getEmploymentIncomeDeductionPeriod(year);
 
     // The effective upper boundary of the flat-floor region (including transition values).
@@ -95,6 +100,31 @@ const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionToolti
                     </li>
                 </ul>
             </Box>
+
+            {incomeAdjustmentDeduction > 0 && (
+                <Box sx={{ mt: 1.5 }}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                        Income Amount Adjustment Deduction (所得金額調整控除)
+                    </Typography>
+                    <Typography variant="body2" sx={{ mb: 1 }}>
+                        Because your employment income exceeds ¥8,500,000 and you have a qualifying dependent
+                        (a relative under 23, or a specially-disabled spouse/dependent), a further deduction is
+                        subtracted from your employment income:
+                        ⌈(min(salary, ¥10,000,000) − ¥8,500,000) × 10%⌉, up to ¥150,000. This lowers your total
+                        net income (合計所得金額), reducing <strong>both income tax and residence tax</strong>.
+                    </Typography>
+                    <Box sx={{ mt: 1 }}>
+                        Official Source:
+                        <ul>
+                            <li>
+                                <a href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary-main)', textDecoration: 'underline', fontSize: '0.95em' }}>
+                                    所得金額調整控除 - NTA
+                                </a>
+                            </li>
+                        </ul>
+                    </Box>
+                </Box>
+            )}
         </Box>
     );
 };

--- a/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
@@ -5,20 +5,40 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { getEmploymentIncomeDeductionPeriod } from '../../../data/employmentIncomeDeduction';
+import { formatJPY } from '../../../utils/formatters';
 
 const fmtNum = (n: number) => n.toLocaleString('en');
 
-interface EmploymentIncomeDeductionTooltipProps {
-    year: number;
+interface NetEmploymentIncomeTooltipProps {
+    /** Gross employment income (給与等の収入金額) in yen. */
+    grossEmploymentIncome: number;
+    /** Net employment income (給与所得), already net of the 給与所得控除 and 所得金額調整控除. */
+    netEmploymentIncome: number;
     /**
-     * 所得金額調整控除 applied to this taxpayer (yen). When greater than 0, an explanatory note
-     * about the income amount adjustment deduction is shown below the 給与所得控除 table.
+     * 所得金額調整控除 applied to this taxpayer (yen). When greater than 0, it is shown as its own
+     * breakdown line and an explanatory note is added below the 給与所得控除 table.
      */
     incomeAdjustmentDeduction?: number;
+    /** Income year, for the 給与所得控除 table lookup. */
+    year: number;
 }
 
-const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionTooltipProps> = ({ year, incomeAdjustmentDeduction = 0 }) => {
+/**
+ * Tooltip body for the "Net Employment Income" row: shows how gross employment income becomes net
+ * employment income (the 給与所得控除, then the 所得金額調整控除 when applicable), followed by the
+ * 給与所得控除 rate table and source links. Shared by the Taxes and Social Insurance tabs.
+ */
+const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
+    grossEmploymentIncome,
+    netEmploymentIncome,
+    incomeAdjustmentDeduction = 0,
+    year,
+}) => {
     const period = getEmploymentIncomeDeductionPeriod(year);
+
+    // The 給与所得控除 portion is whatever remains after backing out the income adjustment, so the
+    // displayed rows always reconcile to net employment income regardless of which gross is passed.
+    const employmentIncomeDeduction = grossEmploymentIncome - netEmploymentIncome - incomeAdjustmentDeduction;
 
     // The effective upper boundary of the flat-floor region (including transition values).
     // For R8: transitions end at 2,199,999 → standard starts at 2,200,000.
@@ -46,6 +66,32 @@ const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionToolti
 
     return (
         <Box>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                Calculation Breakdown
+            </Typography>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem', marginBottom: '8px' }}>
+                <tbody>
+                    <tr>
+                        <td style={{ padding: '2px 0' }}>Gross Employment Income:</td>
+                        <td style={{ padding: '2px 0', textAlign: 'right', fontWeight: 500 }}>{formatJPY(grossEmploymentIncome)}</td>
+                    </tr>
+                    <tr>
+                        <td style={{ padding: '2px 0' }}>Employment Income Deduction:</td>
+                        <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(employmentIncomeDeduction)}</Box>
+                    </tr>
+                    {incomeAdjustmentDeduction > 0 && (
+                        <tr>
+                            <td style={{ padding: '2px 0' }}>Income Adjustment Deduction:</td>
+                            <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(incomeAdjustmentDeduction)}</Box>
+                        </tr>
+                    )}
+                    <Box component="tr" sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
+                        <td style={{ padding: '4px 0', fontWeight: 600 }}>Net Employment Income:</td>
+                        <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 600 }}>{formatJPY(netEmploymentIncome)}</td>
+                    </Box>
+                </tbody>
+            </table>
+
             <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
                 Employment Income Deduction Table
             </Typography>
@@ -129,4 +175,4 @@ const EmploymentIncomeDeductionTooltip: React.FC<EmploymentIncomeDeductionToolti
     );
 };
 
-export default EmploymentIncomeDeductionTooltip;
+export default NetEmploymentIncomeTooltip;

--- a/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
@@ -157,9 +157,9 @@ const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
                     <Typography variant="body2" sx={{ mb: 1 }}>
                         Because your employment income exceeds ¥8,500,000 and you have a qualifying dependent
                         (a relative under 23, or a specially-disabled spouse/dependent), a further deduction is
-                        subtracted from your employment income:
-                        ⌈(min(salary, ¥10,000,000) − ¥8,500,000) × 10%⌉, up to ¥150,000. This lowers your total
-                        net income (合計所得金額), reducing <strong>both income tax and residence tax</strong>.
+                        subtracted from your employment income: 10% of the part of your salary between
+                        ¥8,500,000 and ¥10,000,000, so at most ¥150,000. This lowers your total net income
+                        (合計所得金額), reducing <strong>both income tax and residence tax</strong>.
                     </Typography>
                     <Box sx={{ mt: 1 }}>
                         Official Source:

--- a/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
@@ -157,8 +157,8 @@ const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
                     <Typography variant="body2" sx={{ mb: 1 }}>
                         Because your employment income exceeds ¥8,500,000 and you have a qualifying dependent
                         (a relative under 23, or a specially-disabled spouse/dependent), a further deduction is
-                        subtracted from your employment income: 10% of the part of your salary between
-                        ¥8,500,000 and ¥10,000,000, so at most ¥150,000. This lowers your total net income
+                        subtracted from your employment income: 10% of your gross salary less ¥8,500,000,
+                        up to ¥150,000. This lowers your total net income
                         (合計所得金額), reducing <strong>both income tax and residence tax</strong>.
                     </Typography>
                     <Box sx={{ mt: 1 }}>

--- a/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
@@ -155,10 +155,10 @@ const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
                         Income Amount Adjustment Deduction (所得金額調整控除)
                     </Typography>
                     <Typography variant="body2" sx={{ mb: 1 }}>
-                        Because your employment income exceeds ¥8,500,000 and you have a qualifying dependent
-                        (a dependent relative under 23, or a spouse/dependent with special disability status), a further deduction is
-                        subtracted from your employment income: 10% of your gross salary less ¥8,500,000,
-                        up to ¥150,000.
+                        Taxpayers with employment income exceeding ¥8,500,000 and who have a qualifying dependent
+                        (a dependent relative under 23, or a spouse/dependent with special disability status) 
+                        are eligible for this deduction. It reduces net employment income by 
+                        10% of gross employment income less ¥8,500,000, up to ¥150,000.
                     </Typography>
                     <Typography variant="body2" sx={{ mb: 1 }}>
                         <strong>Rounding:</strong> Fractional yen amounts are rounded up.

--- a/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { getEmploymentIncomeDeductionPeriod } from '../../../data/employmentIncomeDeduction';
+import { getEmploymentIncomeDeductionPeriod } from '../../../data/netEmploymentIncome';
 import { formatJPY } from '../../../utils/formatters';
 import { DetailedTooltip } from '../../ui/Tooltips';
 
@@ -158,8 +158,7 @@ const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
                         Because your employment income exceeds ¥8,500,000 and you have a qualifying dependent
                         (a relative under 23, or a specially-disabled spouse/dependent), a further deduction is
                         subtracted from your employment income: 10% of your gross salary less ¥8,500,000,
-                        up to ¥150,000. This lowers your total net income
-                        (合計所得金額), reducing <strong>both income tax and residence tax</strong>.
+                        up to ¥150,000. This lowers your total net income (合計所得金額).
                     </Typography>
                     <Box sx={{ mt: 1 }}>
                         Official Source:

--- a/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
@@ -156,9 +156,12 @@ const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
                     </Typography>
                     <Typography variant="body2" sx={{ mb: 1 }}>
                         Because your employment income exceeds ¥8,500,000 and you have a qualifying dependent
-                        (a relative under 23, or a specially-disabled spouse/dependent), a further deduction is
+                        (a dependent relative under 23, or a spouse/dependent with special disability status), a further deduction is
                         subtracted from your employment income: 10% of your gross salary less ¥8,500,000,
-                        up to ¥150,000. This lowers your total net income (合計所得金額).
+                        up to ¥150,000.
+                    </Typography>
+                    <Typography variant="body2" sx={{ mb: 1 }}>
+                        <strong>Rounding:</strong> Fractional yen amounts are rounded up.
                     </Typography>
                     <Box sx={{ mt: 1 }}>
                         Official Source:

--- a/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { getEmploymentIncomeDeductionPeriod } from '../../../data/employmentIncomeDeduction';
 import { formatJPY } from '../../../utils/formatters';
+import { DetailedTooltip } from '../../ui/Tooltips';
 
 const fmtNum = (n: number) => n.toLocaleString('en');
 
@@ -24,9 +25,10 @@ interface NetEmploymentIncomeTooltipProps {
 }
 
 /**
- * Tooltip body for the "Net Employment Income" row: shows how gross employment income becomes net
+ * Tooltip for the "Net Employment Income" row: shows how gross employment income becomes net
  * employment income (the 給与所得控除, then the 所得金額調整控除 when applicable), followed by the
- * 給与所得控除 rate table and source links. Shared by the Taxes and Social Insurance tabs.
+ * 給与所得控除 rate table and source links. Renders its own DetailedTooltip trigger, so callers
+ * place it directly after the row label. Shared by the Taxes and Social Insurance tabs.
  */
 const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
     grossEmploymentIncome,
@@ -65,7 +67,7 @@ const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
     });
 
     return (
-        <Box>
+        <DetailedTooltip title="Employment Income Details">
             <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
                 Calculation Breakdown
             </Typography>
@@ -171,7 +173,7 @@ const NetEmploymentIncomeTooltip: React.FC<NetEmploymentIncomeTooltipProps> = ({
                     </Box>
                 </Box>
             )}
-        </Box>
+        </DetailedTooltip>
     );
 };
 

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -197,15 +197,21 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
                           </tr>
                           <tr>
                             <td style={{ padding: '2px 0' }}>Employment Income Deduction:</td>
-                            <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(grossEmploymentIncome - results.netEmploymentIncome)}</Box>
+                            <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(grossEmploymentIncome - results.netEmploymentIncome - (results.incomeAdjustmentDeduction ?? 0))}</Box>
                           </tr>
+                          {(results.incomeAdjustmentDeduction ?? 0) > 0 && (
+                            <tr>
+                              <td style={{ padding: '2px 0' }}>Income Adjustment Deduction (所得金額調整控除):</td>
+                              <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(results.incomeAdjustmentDeduction ?? 0)}</Box>
+                            </tr>
+                          )}
                           <tr style={{ borderTop: '1px solid #ddd' }}>
                             <td style={{ padding: '4px 0', fontWeight: 600 }}>Net Employment Income:</td>
                             <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 600 }}>{formatJPY(results.netEmploymentIncome)}</td>
                           </tr>
                         </tbody>
                       </table>
-                      <EmploymentIncomeDeductionTooltip year={inputs.incomeYear ?? new Date().getFullYear()} />
+                      <EmploymentIncomeDeductionTooltip year={inputs.incomeYear ?? new Date().getFullYear()} incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0} />
                     </Box>
                   </DetailedTooltip>
                 </span>

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -182,16 +182,12 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
               label={
                 <span>
                   Net Employment Income
-                  <DetailedTooltip
-                    title="Employment Income Details"
-                  >
-                    <NetEmploymentIncomeTooltip
-                      grossEmploymentIncome={grossEmploymentIncome}
-                      netEmploymentIncome={results.netEmploymentIncome}
-                      incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
-                      year={inputs.incomeYear ?? new Date().getFullYear()}
-                    />
-                  </DetailedTooltip>
+                  <NetEmploymentIncomeTooltip
+                    grossEmploymentIncome={grossEmploymentIncome}
+                    netEmploymentIncome={results.netEmploymentIncome}
+                    incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
+                    year={inputs.incomeYear ?? new Date().getFullYear()}
+                  />
                 </span>
               }
               value={formatJPY(results.netEmploymentIncome)}

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -15,7 +15,7 @@ import { ResultRow } from '../ResultRow';
 import { SalaryBreakdownTooltip, BonusBreakdownTooltip } from './EmploymentInsuranceRateTooltip';
 import HealthInsurancePremiumTooltip, { NHIPortionTooltip } from './HealthInsurancePremiumTooltip';
 import PensionPremiumTooltip from './PensionPremiumTooltip';
-import EmploymentIncomeDeductionTooltip from './EmploymentIncomeDeductionTooltip';
+import NetEmploymentIncomeTooltip from './NetEmploymentIncomeTooltip';
 import HealthInsuranceBonusTooltip from './HealthInsuranceBonusTooltip';
 import PensionBonusTooltip from './PensionBonusTooltip';
 import NationalPensionTooltip from './NationalPensionTooltip';
@@ -185,34 +185,12 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
                   <DetailedTooltip
                     title="Employment Income Details"
                   >
-                    <Box>
-                      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
-                        Calculation Breakdown
-                      </Typography>
-                      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem', marginBottom: '8px' }}>
-                        <tbody>
-                          <tr>
-                            <td style={{ padding: '2px 0' }}>Gross Employment Income:</td>
-                            <td style={{ padding: '2px 0', textAlign: 'right', fontWeight: 500 }}>{formatJPY(grossEmploymentIncome)}</td>
-                          </tr>
-                          <tr>
-                            <td style={{ padding: '2px 0' }}>Employment Income Deduction:</td>
-                            <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(grossEmploymentIncome - results.netEmploymentIncome - (results.incomeAdjustmentDeduction ?? 0))}</Box>
-                          </tr>
-                          {(results.incomeAdjustmentDeduction ?? 0) > 0 && (
-                            <tr>
-                              <td style={{ padding: '2px 0' }}>Income Adjustment Deduction (所得金額調整控除):</td>
-                              <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(results.incomeAdjustmentDeduction ?? 0)}</Box>
-                            </tr>
-                          )}
-                          <tr style={{ borderTop: '1px solid #ddd' }}>
-                            <td style={{ padding: '4px 0', fontWeight: 600 }}>Net Employment Income:</td>
-                            <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 600 }}>{formatJPY(results.netEmploymentIncome)}</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                      <EmploymentIncomeDeductionTooltip year={inputs.incomeYear ?? new Date().getFullYear()} incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0} />
-                    </Box>
+                    <NetEmploymentIncomeTooltip
+                      grossEmploymentIncome={grossEmploymentIncome}
+                      netEmploymentIncome={results.netEmploymentIncome}
+                      incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
+                      year={inputs.incomeYear ?? new Date().getFullYear()}
+                    />
                   </DetailedTooltip>
                 </span>
               }

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -22,7 +22,7 @@ import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import WarningIcon from '@mui/icons-material/Warning';
 import { DetailedTooltip } from '../../ui/Tooltips';
 import { ResultRow } from '../ResultRow';
-import EmploymentIncomeDeductionTooltip from './EmploymentIncomeDeductionTooltip';
+import NetEmploymentIncomeTooltip from './NetEmploymentIncomeTooltip';
 import { getNationalBasicDeductionTiers } from '../../../data/nationalBasicDeduction';
 
 interface TaxesTabProps {
@@ -163,34 +163,12 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                 <DetailedTooltip
                   title="Employment Income Details"
                 >
-                  <Box>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
-                      Calculation Breakdown
-                    </Typography>
-                    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem', marginBottom: '8px' }}>
-                      <tbody>
-                        <tr>
-                          <td style={{ padding: '2px 0' }}>Gross Employment Income:</td>
-                          <td style={{ padding: '2px 0', textAlign: 'right', fontWeight: 500 }}>{formatJPY(grossEmploymentIncome)}</td>
-                        </tr>
-                        <tr>
-                          <td style={{ padding: '2px 0' }}>Employment Income Deduction:</td>
-                          <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(grossEmploymentIncome - results.netEmploymentIncome - (results.incomeAdjustmentDeduction ?? 0))}</Box>
-                        </tr>
-                        {(results.incomeAdjustmentDeduction ?? 0) > 0 && (
-                          <tr>
-                            <td style={{ padding: '2px 0' }}>Income Adjustment Deduction (所得金額調整控除):</td>
-                            <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(results.incomeAdjustmentDeduction ?? 0)}</Box>
-                          </tr>
-                        )}
-                        <Box component="tr" sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
-                          <td style={{ padding: '4px 0', fontWeight: 600 }}>Net Employment Income:</td>
-                          <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 600 }}>{formatJPY(results.netEmploymentIncome)}</td>
-                        </Box>
-                      </tbody>
-                    </table>
-                    <EmploymentIncomeDeductionTooltip year={incomeYear} incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0} />
-                  </Box>
+                  <NetEmploymentIncomeTooltip
+                    grossEmploymentIncome={grossEmploymentIncome}
+                    netEmploymentIncome={results.netEmploymentIncome}
+                    incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
+                    year={incomeYear}
+                  />
                 </DetailedTooltip>
               </span>
             }

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -175,15 +175,21 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                         </tr>
                         <tr>
                           <td style={{ padding: '2px 0' }}>Employment Income Deduction:</td>
-                          <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(grossEmploymentIncome - results.netEmploymentIncome)}</Box>
+                          <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(grossEmploymentIncome - results.netEmploymentIncome - (results.incomeAdjustmentDeduction ?? 0))}</Box>
                         </tr>
+                        {(results.incomeAdjustmentDeduction ?? 0) > 0 && (
+                          <tr>
+                            <td style={{ padding: '2px 0' }}>Income Adjustment Deduction (所得金額調整控除):</td>
+                            <Box component="td" sx={{ padding: '2px 0', textAlign: 'right', color: 'error.main' }}>-{formatJPY(results.incomeAdjustmentDeduction ?? 0)}</Box>
+                          </tr>
+                        )}
                         <Box component="tr" sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
                           <td style={{ padding: '4px 0', fontWeight: 600 }}>Net Employment Income:</td>
                           <td style={{ padding: '4px 0', textAlign: 'right', fontWeight: 600 }}>{formatJPY(results.netEmploymentIncome)}</td>
                         </Box>
                       </tbody>
                     </table>
-                    <EmploymentIncomeDeductionTooltip year={incomeYear} />
+                    <EmploymentIncomeDeductionTooltip year={incomeYear} incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0} />
                   </Box>
                 </DetailedTooltip>
               </span>

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -160,16 +160,12 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
             label={
               <span>
                 Net Employment Income
-                <DetailedTooltip
-                  title="Employment Income Details"
-                >
-                  <NetEmploymentIncomeTooltip
-                    grossEmploymentIncome={grossEmploymentIncome}
-                    netEmploymentIncome={results.netEmploymentIncome}
-                    incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
-                    year={incomeYear}
-                  />
-                </DetailedTooltip>
+                <NetEmploymentIncomeTooltip
+                  grossEmploymentIncome={grossEmploymentIncome}
+                  netEmploymentIncome={results.netEmploymentIncome}
+                  incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
+                  year={incomeYear}
+                />
               </span>
             }
             value={formatJPY(results.netEmploymentIncome)}

--- a/src/data/employmentIncomeDeduction.ts
+++ b/src/data/employmentIncomeDeduction.ts
@@ -210,8 +210,16 @@ const INCOME_ADJUSTMENT_SALARY_CAP = 10_000_000;
  * qualifying dependent or special-disability status) is decided by the caller — see
  * `calculateIncomeAdjustmentDeduction` in `dependentDeductions.ts`.
  *
- * Legal basis: 措法41の3の11・41の3の12 (令和2年〜). Fractions of ¥1 are rounded up.
+ * Why it affects residence tax too: this is an adjustment to 給与所得 itself, NOT an 所得控除. The
+ * residence-tax 総所得金額 is computed "following the income-tax calculation" (地方税法§313②/§32②:
+ * 所得税法その他の所得税に関する法令…の計算の例によつて算定), and 措法 is one of those laws, so the
+ * adjusted 給与所得 carries straight over. Contrast 所得控除 (基礎控除, 扶養控除, …), whose amounts the
+ * Local Tax Act sets independently (地方税法§314の2/§34) — which is why those differ between the two taxes.
+ *
+ * Legal basis: 措法41の3の11・41の3の12 (income tax, 令和2年〜); applied to residence tax via
+ * 地方税法§313②・§32② from 令和3年度. Fractions of ¥1 are rounded up.
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm
+ * @see https://www.keisan.nta.go.jp/r5yokuaru_sp/socat1/377.html — residence-tax application
  *
  * @param grossEmploymentIncome Gross employment income (給与等の収入金額) in yen
  * @returns The adjustment amount in yen (0 when salary ≤ ¥8,500,000)

--- a/src/data/employmentIncomeDeduction.ts
+++ b/src/data/employmentIncomeDeduction.ts
@@ -191,3 +191,34 @@ export const calculateNetEmploymentIncomeForPeriod = (
 
     return 0; // unreachable: final tier has grossMaxInclusive = Infinity
 };
+
+/** 給与等の収入金額 above which the 所得金額調整控除 applies (措法41の3の11). */
+const INCOME_ADJUSTMENT_SALARY_THRESHOLD = 8_500_000;
+/** 給与等の収入金額 is capped here in the formula, yielding a maximum deduction of ¥150,000. */
+const INCOME_ADJUSTMENT_SALARY_CAP = 10_000_000;
+
+/**
+ * 所得金額調整控除（子ども・特別障害者等を有する者等）— the income amount adjustment deduction.
+ *
+ * For taxpayers whose gross employment income (給与等の収入金額) exceeds ¥8,500,000, this amount
+ * is subtracted from net employment income (給与所得) AFTER the standard 給与所得控除, which lowers
+ * 合計所得金額 and therefore the taxable income for BOTH income tax and residence tax.
+ *
+ *   amount = ⌈{min(給与等の収入金額, ¥10,000,000) − ¥8,500,000} × 10%⌉   (max ¥150,000)
+ *
+ * This returns the amount as a pure function of salary only; ELIGIBILITY (the taxpayer having a
+ * qualifying dependent or special-disability status) is decided by the caller — see
+ * `calculateIncomeAdjustmentDeduction` in `dependentDeductions.ts`.
+ *
+ * Legal basis: 措法41の3の11・41の3の12 (令和2年〜). Fractions of ¥1 are rounded up.
+ * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm
+ *
+ * @param grossEmploymentIncome Gross employment income (給与等の収入金額) in yen
+ * @returns The adjustment amount in yen (0 when salary ≤ ¥8,500,000)
+ */
+export const calculateIncomeAdjustmentDeductionAmount = (grossEmploymentIncome: number): number => {
+    if (grossEmploymentIncome <= INCOME_ADJUSTMENT_SALARY_THRESHOLD) return 0;
+    const cappedSalary = Math.min(grossEmploymentIncome, INCOME_ADJUSTMENT_SALARY_CAP);
+    // Divide by 10 (rather than × 0.1) to avoid binary floating-point error before rounding up.
+    return Math.ceil((cappedSalary - INCOME_ADJUSTMENT_SALARY_THRESHOLD) / 10);
+};

--- a/src/data/netEmploymentIncome.ts
+++ b/src/data/netEmploymentIncome.ts
@@ -10,8 +10,9 @@
  *    fixed transition values, and the standard percentage-formula tiers for that income year.
  *  - 所得金額調整控除（子ども・特別障害者等）: {@link calculateIncomeAdjustmentDeductionAmount} computes the amount
  *    purely from 給与等の収入金額; whether the taxpayer qualifies (a dependent under 23, or a special-disability
- *    spouse/dependent) is decided by the caller,
- *    {@link import("../utils/dependentDeductions").calculateIncomeAdjustmentDeduction}.
+ *    spouse/dependent) is checked separately by
+ *    {@link import("../utils/dependentDeductions").hasIncomeAdjustmentDeductionDependent}, and the two are
+ *    combined in `taxCalculations.ts`.
  *
  * Sources:
  *  - 給与所得控除: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm
@@ -214,8 +215,9 @@ const INCOME_ADJUSTMENT_SALARY_CAP = 10_000_000;
  *   amount = ⌈{min(給与等の収入金額, ¥10,000,000) − ¥8,500,000} × 10%⌉   (max ¥150,000)
  *
  * This returns the amount as a pure function of salary only; ELIGIBILITY (the taxpayer having a
- * qualifying dependent or special-disability status) is decided by the caller — see
- * `calculateIncomeAdjustmentDeduction` in `dependentDeductions.ts`.
+ * qualifying dependent or special-disability status) is checked separately by
+ * `hasIncomeAdjustmentDeductionDependent` in `dependentDeductions.ts`, with the two combined in
+ * `taxCalculations.ts`.
  *
  * Why it affects residence tax too: this is an adjustment to 給与所得 itself, NOT an 所得控除. The
  * residence-tax 総所得金額 is computed "following the income-tax calculation" (地方税法§313②/§32②:

--- a/src/data/netEmploymentIncome.ts
+++ b/src/data/netEmploymentIncome.ts
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /**
- * Employment Income Deduction (給与所得控除) tables, indexed by income year.
+ * Net employment income (給与所得) computation data and helpers, indexed by income year.
  *
- * The deduction is determined by the taxpayer's gross employment income (給与等の収入金額).
- * Each period defines the flat-floor region, any fixed transition values, and the standard
- * percentage-formula tiers that apply for the given income year.
+ * Gross employment income (給与等の収入金額) is reduced to 給与所得 by two things, both modelled here:
+ *  - 給与所得控除 (employment income deduction): the year-indexed tables below, applied by
+ *    {@link calculateNetEmploymentIncomeForPeriod}. Each period defines the flat-floor region, any
+ *    fixed transition values, and the standard percentage-formula tiers for that income year.
+ *  - 所得金額調整控除（子ども・特別障害者等）: the salary-only amount, {@link calculateIncomeAdjustmentDeductionAmount}
+ *    (eligibility is decided by the caller — see `dependentDeductions.ts`).
  *
- * Source: NTA overview: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm
+ * Sources:
+ *  - 給与所得控除: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm
+ *  - 所得金額調整控除: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm
  */
 
 /** One tier in the standard percentage-formula region. */

--- a/src/data/netEmploymentIncome.ts
+++ b/src/data/netEmploymentIncome.ts
@@ -8,8 +8,10 @@
  *  - 給与所得控除 (employment income deduction): the year-indexed tables below, applied by
  *    {@link calculateNetEmploymentIncomeForPeriod}. Each period defines the flat-floor region, any
  *    fixed transition values, and the standard percentage-formula tiers for that income year.
- *  - 所得金額調整控除（子ども・特別障害者等）: the salary-only amount, {@link calculateIncomeAdjustmentDeductionAmount}
- *    (eligibility is decided by the caller — see `dependentDeductions.ts`).
+ *  - 所得金額調整控除（子ども・特別障害者等）: {@link calculateIncomeAdjustmentDeductionAmount} computes the amount
+ *    purely from 給与等の収入金額; whether the taxpayer qualifies (a dependent under 23, or a special-disability
+ *    spouse/dependent) is decided by the caller,
+ *    {@link import("../utils/dependentDeductions").calculateIncomeAdjustmentDeduction}.
  *
  * Sources:
  *  - 給与所得控除: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1410.htm

--- a/src/data/netEmploymentIncome.ts
+++ b/src/data/netEmploymentIncome.ts
@@ -201,9 +201,9 @@ export const calculateNetEmploymentIncomeForPeriod = (
 };
 
 /** 給与等の収入金額 above which the 所得金額調整控除 applies (措法41の3の11). */
-const INCOME_ADJUSTMENT_SALARY_THRESHOLD = 8_500_000;
+const INCOME_ADJUSTMENT_EMPLOYMENT_INCOME_THRESHOLD = 8_500_000;
 /** 給与等の収入金額 is capped here in the formula, yielding a maximum deduction of ¥150,000. */
-const INCOME_ADJUSTMENT_SALARY_CAP = 10_000_000;
+const INCOME_ADJUSTMENT_EMPLOYMENT_INCOME_CAP = 10_000_000;
 
 /**
  * 所得金額調整控除（子ども・特別障害者等を有する者等）— the income amount adjustment deduction.
@@ -234,8 +234,8 @@ const INCOME_ADJUSTMENT_SALARY_CAP = 10_000_000;
  * @returns The adjustment amount in yen (0 when salary ≤ ¥8,500,000)
  */
 export const calculateIncomeAdjustmentDeductionAmount = (grossEmploymentIncome: number): number => {
-    if (grossEmploymentIncome <= INCOME_ADJUSTMENT_SALARY_THRESHOLD) return 0;
-    const cappedSalary = Math.min(grossEmploymentIncome, INCOME_ADJUSTMENT_SALARY_CAP);
+    if (grossEmploymentIncome <= INCOME_ADJUSTMENT_EMPLOYMENT_INCOME_THRESHOLD) return 0;
+    const cappedEmploymentIncome = Math.min(grossEmploymentIncome, INCOME_ADJUSTMENT_EMPLOYMENT_INCOME_CAP);
     // Divide by 10 (rather than × 0.1) to avoid binary floating-point error before rounding up.
-    return Math.ceil((cappedSalary - INCOME_ADJUSTMENT_SALARY_THRESHOLD) / 10);
+    return Math.ceil((cappedEmploymentIncome - INCOME_ADJUSTMENT_EMPLOYMENT_INCOME_THRESHOLD) / 10);
 };

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -144,6 +144,13 @@ export interface TakeHomeResults {
   employmentInsuranceOnBonus?: number;
   // Added detailed properties
   netEmploymentIncome?: number | undefined;
+  /**
+   * 所得金額調整控除（子ども・特別障害者等を有する者等）applied to net employment income (給与所得).
+   * Subtracted after the 給与所得控除, so it lowers 合計所得金額 and the taxable income for both
+   * income tax and residence tax. 0 when the taxpayer is not eligible. {@link netEmploymentIncome}
+   * is already net of this amount.
+   */
+  incomeAdjustmentDeduction?: number | undefined;
   totalNetIncome: number;
   commutingAllowanceIncome?: number; // Total amount
   commutingAllowanceTaxable?: number;

--- a/src/utils/dependentDeductions.ts
+++ b/src/utils/dependentDeductions.ts
@@ -28,7 +28,6 @@ import type {
 import { DEDUCTION_TYPES } from '../types/dependents';
 import { calculateNetEmploymentIncome } from './taxCalculations';
 import { getDependentEligibilityMax } from '../data/dependentDeductionThresholds';
-import { calculateIncomeAdjustmentDeductionAmount } from '../data/netEmploymentIncome';
 
 export { getDependentEligibilityMax };
 
@@ -93,27 +92,6 @@ export function hasIncomeAdjustmentDeductionDependent(dependents: Dependent[], y
                       dependent.ageCategory === '19to22'; // ロ
     return isUnder23 || isSpecialDisability;
   });
-}
-
-/**
- * Calculates the 所得金額調整控除（子ども・特別障害者等を有する者等）for the taxpayer.
- *
- * Returns the amount only when the taxpayer both earns over ¥8.5M in employment income and has a
- * {@link hasIncomeAdjustmentDeductionDependent qualifying dependent}; otherwise 0. The amount is
- * subtracted from net employment income (給与所得), so it lowers 合計所得金額 and thus the taxable
- * income for both income tax and residence tax.
- *
- * @param grossEmploymentIncome Gross employment income (給与等の収入金額) in yen
- * @param dependents            The taxpayer's dependents
- * @param year                  Income year (for the 扶養親族 income threshold)
- */
-export function calculateIncomeAdjustmentDeduction(
-  grossEmploymentIncome: number,
-  dependents: Dependent[],
-  year: number
-): number {
-  if (!hasIncomeAdjustmentDeductionDependent(dependents, year)) return 0;
-  return calculateIncomeAdjustmentDeductionAmount(grossEmploymentIncome);
 }
 
 /**

--- a/src/utils/dependentDeductions.ts
+++ b/src/utils/dependentDeductions.ts
@@ -28,7 +28,7 @@ import type {
 import { DEDUCTION_TYPES } from '../types/dependents';
 import { calculateNetEmploymentIncome } from './taxCalculations';
 import { getDependentEligibilityMax } from '../data/dependentDeductionThresholds';
-import { calculateIncomeAdjustmentDeductionAmount } from '../data/employmentIncomeDeduction';
+import { calculateIncomeAdjustmentDeductionAmount } from '../data/netEmploymentIncome';
 
 export { getDependentEligibilityMax };
 

--- a/src/utils/dependentDeductions.ts
+++ b/src/utils/dependentDeductions.ts
@@ -28,6 +28,7 @@ import type {
 import { DEDUCTION_TYPES } from '../types/dependents';
 import { calculateNetEmploymentIncome } from './taxCalculations';
 import { getDependentEligibilityMax } from '../data/dependentDeductionThresholds';
+import { calculateIncomeAdjustmentDeductionAmount } from '../data/employmentIncomeDeduction';
 
 export { getDependentEligibilityMax };
 
@@ -56,6 +57,63 @@ export function calculateDependentTotalNetIncome(income: DependentIncome, year: 
 
   // Total net income = net employment income + other net income
   return netEmploymentIncome + otherNetIncome;
+}
+
+/**
+ * Whether the taxpayer has a dependent that qualifies them for the
+ * 所得金額調整控除（子ども・特別障害者等を有する者等）. Two of the three statutory conditions are
+ * derivable from the dependent data this calculator models:
+ *
+ *  - ロ 年齢23歳未満の扶養親族: a non-spouse dependent (扶養親族) under 23 whose 合計所得金額 is
+ *    within the 扶養親族 threshold. Unlike 扶養控除, this includes children under 16.
+ *  - ハ 特別障害者である同一生計配偶者または扶養親族: a spouse or non-spouse dependent with special
+ *    disability whose 合計所得金額 is within the threshold (any age).
+ *
+ * The third condition — イ, the taxpayer being a 特別障害者 themselves — is NOT modeled, as the
+ * calculator has no input for the taxpayer's own disability status.
+ *
+ * Note: a spouse is never a 扶養親族, so condition ロ cannot apply to a spouse; a spouse qualifies
+ * only via ハ (a 特別障害者 同一生計配偶者).
+ *
+ * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1411.htm
+ */
+export function hasIncomeAdjustmentDeductionDependent(dependents: Dependent[], year: number): boolean {
+  const eligibilityMax = getDependentEligibilityMax(year);
+  return dependents.some(dependent => {
+    // 扶養親族 / 同一生計配偶者 status requires 合計所得金額 within the threshold.
+    if (calculateDependentTotalNetIncome(dependent.income, year) > eligibilityMax) {
+      return false;
+    }
+    const isSpecialDisability = dependent.disability === 'special'; // ハ
+    if (dependent.relationship === 'spouse') {
+      return isSpecialDisability;
+    }
+    const isUnder23 = dependent.ageCategory === 'under16' ||
+                      dependent.ageCategory === '16to18' ||
+                      dependent.ageCategory === '19to22'; // ロ
+    return isUnder23 || isSpecialDisability;
+  });
+}
+
+/**
+ * Calculates the 所得金額調整控除（子ども・特別障害者等を有する者等）for the taxpayer.
+ *
+ * Returns the amount only when the taxpayer both earns over ¥8.5M in employment income and has a
+ * {@link hasIncomeAdjustmentDeductionDependent qualifying dependent}; otherwise 0. The amount is
+ * subtracted from net employment income (給与所得), so it lowers 合計所得金額 and thus the taxable
+ * income for both income tax and residence tax.
+ *
+ * @param grossEmploymentIncome Gross employment income (給与等の収入金額) in yen
+ * @param dependents            The taxpayer's dependents
+ * @param year                  Income year (for the 扶養親族 income threshold)
+ */
+export function calculateIncomeAdjustmentDeduction(
+  grossEmploymentIncome: number,
+  dependents: Dependent[],
+  year: number
+): number {
+  if (!hasIncomeAdjustmentDeductionDependent(dependents, year)) return 0;
+  return calculateIncomeAdjustmentDeductionAmount(grossEmploymentIncome);
 }
 
 /**

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type {BonusIncomeStream, IncomeStream, TakeHomeInputs, TakeHomeResults} from '../types/tax'
+import type {Dependent} from '../types/dependents'
 import {
     CUSTOM_PROVIDER_ID,
     DEFAULT_PROVIDER,
@@ -19,7 +20,7 @@ import {
     calculateResidenceTaxBasicDeduction,
     NON_TAXABLE_RESIDENCE_TAX_DETAIL
 } from './residenceTax';
-import {calculateDependentDeductions} from './dependentDeductions';
+import {calculateDependentDeductions, calculateIncomeAdjustmentDeduction} from './dependentDeductions';
 import {COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP} from '../constants/taxThresholds';
 import {getCommutingAllowanceAnnualAmount} from './formatters';
 import {getEmploymentInsuranceRate} from '../data/employmentInsurance';
@@ -208,6 +209,7 @@ const DEFAULT_TAKE_HOME_RESULTS: TakeHomeResults = {
     healthInsuranceProvider: DEFAULT_PROVIDER,
     region: 'Tokyo',
     isSubjectToLongTermCarePremium: false,
+    incomeAdjustmentDeduction: 0,
     totalNetIncome: 0,
 };
 
@@ -287,13 +289,19 @@ const calculateIncomeBreakdown = (incomeStreams: IncomeStream[]): IncomeBreakdow
 };
 
 /**
- * Calculates just the total net income.
+ * Calculates just the total net income (合計所得金額).
  * This is lighter weight than the full tax calculation and used for dependent eligibility checks.
  *
  * @param incomeStreams  Income streams to calculate net income for
  * @param year          Income year for the employment income deduction lookup; defaults to current year
+ * @param dependents    The taxpayer's dependents, used to apply the 所得金額調整控除 when a qualifying
+ *                      dependent is present. Defaults to none (no adjustment).
  */
-export const calculateTotalNetIncome = (incomeStreams: IncomeStream[], year: number = new Date().getFullYear()): number => {
+export const calculateTotalNetIncome = (
+    incomeStreams: IncomeStream[],
+    year: number = new Date().getFullYear(),
+    dependents: Dependent[] = []
+): number => {
     const {
         salaryIncome,
         bonusIncome,
@@ -306,8 +314,9 @@ export const calculateTotalNetIncome = (incomeStreams: IncomeStream[], year: num
 
     const grossEmploymentIncome = salaryIncome + taxableCommutingAllowance + bonusIncome.reduce((sum, b) => sum + b.amount, 0) + stockCompensationIncome;
     const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, year);
+    const incomeAdjustmentDeduction = calculateIncomeAdjustmentDeduction(grossEmploymentIncome, dependents, year);
 
-    return netEmploymentIncome + netBusinessAndMiscIncome;
+    return netEmploymentIncome - incomeAdjustmentDeduction + netBusinessAndMiscIncome;
 };
 
 export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
@@ -336,7 +345,14 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
 
     const grossEmploymentIncome = salaryIncome + taxableCommutingAllowance + bonusIncome.reduce((sum, b) => sum + b.amount, 0) + stockCompensationIncome;
     const incomeYear = inputs.incomeYear ?? new Date().getFullYear();
-    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, incomeYear);
+    const netEmploymentIncomeBeforeAdjustment = calculateNetEmploymentIncome(grossEmploymentIncome, incomeYear);
+
+    // 所得金額調整控除（子ども・特別障害者等）: for salaries over ¥8.5M with a qualifying dependent,
+    // this is subtracted from 給与所得 here so the reduced 合計所得金額 flows into every downstream
+    // consumer (basic deductions, taxable income, residence-tax 調整控除 cutoff, home-loan-credit
+    // income limit, spouse/dependent thresholds) for both income tax and residence tax.
+    const incomeAdjustmentDeduction = calculateIncomeAdjustmentDeduction(grossEmploymentIncome, inputs.dependents, incomeYear);
+    const netEmploymentIncome = netEmploymentIncomeBeforeAdjustment - incomeAdjustmentDeduction;
 
     const netIncome = netEmploymentIncome + netBusinessAndMiscIncome;
 
@@ -498,6 +514,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
         pensionOnBonus,
         employmentInsuranceOnBonus,
         netEmploymentIncome: hasEmploymentIncome ? netEmploymentIncome : undefined,
+        incomeAdjustmentDeduction,
         totalNetIncome: netIncome,
         nationalIncomeTaxBasicDeduction,
         taxableIncomeForNationalIncomeTax,

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -25,7 +25,7 @@ import {COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP} from '../constants/taxThresho
 import {getCommutingAllowanceAnnualAmount} from './formatters';
 import {getEmploymentInsuranceRate} from '../data/employmentInsurance';
 import {getNationalBasicDeductionTiers} from '../data/nationalBasicDeduction';
-import {getEmploymentIncomeDeductionPeriod, calculateNetEmploymentIncomeForPeriod} from '../data/employmentIncomeDeduction';
+import {getEmploymentIncomeDeductionPeriod, calculateNetEmploymentIncomeForPeriod} from '../data/netEmploymentIncome';
 import {applyHomeLoanTaxCredit} from './homeLoanTaxCredit';
 
 /**
@@ -48,7 +48,7 @@ export const roundSocialInsurancePremium = (amount: number, mode: 'halfTrunc' | 
  * Calculates the net employment income (給与所得の金額) for the given income year,
  * applying the employment income deduction (給与所得控除) rules for that year.
  *
- * Delegates to the year-indexed period data in `src/data/employmentIncomeDeduction.ts`.
+ * Delegates to the year-indexed period data in `src/data/netEmploymentIncome.ts`.
  *
  * @param grossEmploymentIncome  Gross employment income (給与等の収入金額) in yen
  * @param year                   Income year; defaults to the current calendar year

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -20,12 +20,12 @@ import {
     calculateResidenceTaxBasicDeduction,
     NON_TAXABLE_RESIDENCE_TAX_DETAIL
 } from './residenceTax';
-import {calculateDependentDeductions, calculateIncomeAdjustmentDeduction} from './dependentDeductions';
+import {calculateDependentDeductions, hasIncomeAdjustmentDeductionDependent} from './dependentDeductions';
 import {COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP} from '../constants/taxThresholds';
 import {getCommutingAllowanceAnnualAmount} from './formatters';
 import {getEmploymentInsuranceRate} from '../data/employmentInsurance';
 import {getNationalBasicDeductionTiers} from '../data/nationalBasicDeduction';
-import {getEmploymentIncomeDeductionPeriod, calculateNetEmploymentIncomeForPeriod} from '../data/netEmploymentIncome';
+import {getEmploymentIncomeDeductionPeriod, calculateNetEmploymentIncomeForPeriod, calculateIncomeAdjustmentDeductionAmount} from '../data/netEmploymentIncome';
 import {applyHomeLoanTaxCredit} from './homeLoanTaxCredit';
 
 /**
@@ -60,6 +60,20 @@ export const calculateNetEmploymentIncome = (
     grossEmploymentIncome,
     getEmploymentIncomeDeductionPeriod(year)
 );
+
+/**
+ * Composes the 所得金額調整控除（子ども・特別障害者等）: the salary-based amount
+ * ({@link calculateIncomeAdjustmentDeductionAmount}), gated on the taxpayer having a qualifying
+ * dependent ({@link hasIncomeAdjustmentDeductionDependent}). Returns 0 when not eligible. Subtracted
+ * from net employment income (給与所得), so it lowers 合計所得金額 for both income tax and residence tax.
+ */
+const calculateIncomeAdjustmentDeduction = (
+    grossEmploymentIncome: number,
+    dependents: Dependent[],
+    year: number
+): number => hasIncomeAdjustmentDeductionDependent(dependents, year)
+    ? calculateIncomeAdjustmentDeductionAmount(grossEmploymentIncome)
+    : 0;
 
 /**
  * Breakdown of Employment Insurance premium components

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -45,27 +45,9 @@ export const roundSocialInsurancePremium = (amount: number, mode: 'halfTrunc' | 
 }
 
 /**
- * Calculates the net employment income (給与所得の金額) for the given income year,
- * applying the employment income deduction (給与所得控除) rules for that year.
- *
- * Delegates to the year-indexed period data in `src/data/netEmploymentIncome.ts`.
- *
- * @param grossEmploymentIncome  Gross employment income (給与等の収入金額) in yen
- * @param year                   Income year; defaults to the current calendar year
- */
-export const calculateNetEmploymentIncome = (
-    grossEmploymentIncome: number,
-    year: number = new Date().getFullYear()
-): number => calculateNetEmploymentIncomeForPeriod(
-    grossEmploymentIncome,
-    getEmploymentIncomeDeductionPeriod(year)
-);
-
-/**
  * Composes the 所得金額調整控除（子ども・特別障害者等）: the salary-based amount
  * ({@link calculateIncomeAdjustmentDeductionAmount}), gated on the taxpayer having a qualifying
- * dependent ({@link hasIncomeAdjustmentDeductionDependent}). Returns 0 when not eligible. Subtracted
- * from net employment income (給与所得), so it lowers 合計所得金額 for both income tax and residence tax.
+ * dependent ({@link hasIncomeAdjustmentDeductionDependent}). Returns 0 when not eligible.
  */
 const calculateIncomeAdjustmentDeduction = (
     grossEmploymentIncome: number,
@@ -74,6 +56,28 @@ const calculateIncomeAdjustmentDeduction = (
 ): number => hasIncomeAdjustmentDeductionDependent(dependents, year)
     ? calculateIncomeAdjustmentDeductionAmount(grossEmploymentIncome)
     : 0;
+
+/**
+ * Calculates net employment income (給与所得の金額) for the given income year: gross minus the
+ * employment income deduction (給与所得控除) and — when a qualifying dependent makes the taxpayer
+ * eligible — the income amount adjustment deduction (所得金額調整控除). Pass the taxpayer's
+ * `dependents` to apply the adjustment; omit them (the default) where it can't apply, e.g. when
+ * computing a dependent's own net income.
+ *
+ * Delegates to the year-indexed period data in `src/data/netEmploymentIncome.ts`.
+ *
+ * @param grossEmploymentIncome  Gross employment income (給与等の収入金額) in yen
+ * @param year                   Income year; defaults to the current calendar year
+ * @param dependents             Taxpayer's dependents, for the 所得金額調整控除; defaults to none
+ */
+export const calculateNetEmploymentIncome = (
+    grossEmploymentIncome: number,
+    year: number = new Date().getFullYear(),
+    dependents: Dependent[] = []
+): number => calculateNetEmploymentIncomeForPeriod(
+    grossEmploymentIncome,
+    getEmploymentIncomeDeductionPeriod(year)
+) - calculateIncomeAdjustmentDeduction(grossEmploymentIncome, dependents, year);
 
 /**
  * Breakdown of Employment Insurance premium components
@@ -327,10 +331,9 @@ export const calculateTotalNetIncome = (
     const taxableCommutingAllowance = Math.max(0, commutingAllowance - COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP);
 
     const grossEmploymentIncome = salaryIncome + taxableCommutingAllowance + bonusIncome.reduce((sum, b) => sum + b.amount, 0) + stockCompensationIncome;
-    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, year);
-    const incomeAdjustmentDeduction = calculateIncomeAdjustmentDeduction(grossEmploymentIncome, dependents, year);
+    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, year, dependents);
 
-    return netEmploymentIncome - incomeAdjustmentDeduction + netBusinessAndMiscIncome;
+    return netEmploymentIncome + netBusinessAndMiscIncome;
 };
 
 export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
@@ -359,14 +362,9 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
 
     const grossEmploymentIncome = salaryIncome + taxableCommutingAllowance + bonusIncome.reduce((sum, b) => sum + b.amount, 0) + stockCompensationIncome;
     const incomeYear = inputs.incomeYear ?? new Date().getFullYear();
-    const netEmploymentIncomeBeforeAdjustment = calculateNetEmploymentIncome(grossEmploymentIncome, incomeYear);
 
-    // 所得金額調整控除（子ども・特別障害者等）: for salaries over ¥8.5M with a qualifying dependent,
-    // this is subtracted from 給与所得 here so the reduced 合計所得金額 flows into every downstream
-    // consumer (basic deductions, taxable income, residence-tax 調整控除 cutoff, home-loan-credit
-    // income limit, spouse/dependent thresholds) for both income tax and residence tax.
+    const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, incomeYear, inputs.dependents);
     const incomeAdjustmentDeduction = calculateIncomeAdjustmentDeduction(grossEmploymentIncome, inputs.dependents, incomeYear);
-    const netEmploymentIncome = netEmploymentIncomeBeforeAdjustment - incomeAdjustmentDeduction;
 
     const netIncome = netEmploymentIncome + netBusinessAndMiscIncome;
 


### PR DESCRIPTION
Fixes #344.

## What

Applies the **所得金額調整控除（子ども・特別障害者等を有する者等）** (income amount adjustment deduction) for taxpayers with employment income over **¥8,500,000** who have a qualifying dependent. Up to **¥150,000** — `⌈{min(salary, ¥10M) − ¥8.5M} × 10%⌉` — is subtracted from 給与所得.

Previously, net employment income and taxable income were overstated by up to ¥150,000 for these households, inflating both income tax and residence tax and, because 合計所得金額 feeds several eligibility thresholds, wrongly denying things like the home loan tax credit at its ¥20M income limit. (Pre-existing; surfaced while cross-checking #307.)

## Why fold it into net employment income (and not show it as a separate 所得控除)

This is technically correct, not just convenient. 措法41の3の11 defines 給与所得の金額 itself as `(収入 − 給与所得控除) − 所得金額調整控除`, so it reduces 給与所得 by statute — it is **not** in the 所得控除 bucket (基礎控除/扶養控除/etc.). This matches:
- the 源泉徴収票 box **給与所得控除後の金額（調整控除後）**, which is already net of it; and
- the 確定申告書, where it is folded into the 給与 所得金額 line, not the deductions section.

Applying it once, right after the 給与所得控除, means the reduced 合計所得金額 flows consistently into every downstream consumer: income-tax & residence-tax taxable income, both basic-deduction tier lookups, the residence-tax 調整控除 ¥25M cutoff, the home-loan-credit income limit, spouse/dependent thresholds, the NHI base, and the furusato limit. It creates no 人的控除差, so the residence-tax 調整控除 statutory-difference logic is intentionally untouched.

**Applies to both income tax and residence tax**, because it lowers the shared 合計所得金額 base.

## Eligibility

Derived from existing dependent data:
- **ロ** a 扶養親族 under 23 (includes under-16, unlike 扶養控除) within the income threshold
- **ハ** a special-disability 同一生計配偶者 or 扶養親族 within the income threshold

Not modeled (documented in tooltip + CHANGELOG): **イ** the taxpayer's own special-disability status (needs a new input field), and the 給与・年金 both-income variant (措法41の3の12).

## UI

The Net Employment Income tooltip (Taxes tab and Social Insurance tab) now shows the adjustment as its own line, plus an explanatory note with the NTA source — only when it applies. The final "Net Employment Income" figure equals the 源泉徴収票's 調整控除後 box; the tooltip just breaks out the two components.

## Testing

- 534 tests pass (new unit + integration tests cover the formula/eligibility edge cases, the worked example, and the home-loan-credit flip at the ¥20M limit); `tsc -b` and ESLint clean.
- Browser-verified the worked example (¥22M salary + child under 23): Net Employment Income ¥20,050,000 → **¥19,900,000**, subtotal taxable income down exactly ¥150,000, both income tax and residence tax decrease, tooltip reconciles. No adjustment row when there's no qualifying dependent.