### PR TITLE
Model non-特定取得 in home loan tax credit residence-tax cap

### DIFF
--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -294,6 +294,28 @@ describe('calculateFurusatoNozeiLimit', () => {
       expect(credit.unusedCredit).toBeGreaterThan(0);
     });
 
+    it('applies the lower 5% / ¥97,500 residence cap for a 非特定取得 2014-2021 move-in', () => {
+      // Same scenario as the 特定取得 test above, but the 2020 purchase was 非特定取得 (no
+      // consumption tax — e.g. bought from a private individual): the residence cap drops to
+      // ¥97,500, so the credit reduces residence tax by ¥39,000 less and leaves more unused.
+      const inputs = {
+        ...baseInputs,
+        incomeStreams: [{ id: 'test', type: 'salary' as const, amount: 5_500_000, frequency: 'annual' as const }],
+      };
+      const tokutei = calculateTaxes({ ...inputs, homeLoanTaxCredit: { moveInYear: 2020, creditAmount: 350_000, isTokuteiShutoku: true } });
+      const nonTokutei = calculateTaxes({ ...inputs, homeLoanTaxCredit: { moveInYear: 2020, creditAmount: 350_000, isTokuteiShutoku: false } });
+
+      const nonTokuteiCredit = nonTokutei.homeLoanTaxCredit!;
+      expect(nonTokuteiCredit.residenceTaxSpilloverCap?.flatCap).toBe(97_500); // 非特定取得 cap
+      expect(nonTokuteiCredit.appliedToResidenceTax).toBe(97_500); // flat cap binds
+
+      // 非特定取得 spills ¥39,000 less to residence tax than 特定取得 (¥136,500 − ¥97,500),
+      // so residence tax ends up higher and the income tax is unchanged.
+      expect(tokutei.homeLoanTaxCredit!.appliedToResidenceTax - nonTokuteiCredit.appliedToResidenceTax).toBe(39_000);
+      expect(nonTokutei.residenceTax.totalResidenceTax).toBeGreaterThan(tokutei.residenceTax.totalResidenceTax);
+      expect(nonTokutei.nationalIncomeTax).toBe(tokutei.nationalIncomeTax);
+    });
+
     it('flows dependent deductions through to the credit (lowers the income tax it offsets)', () => {
       const incomeStreams = [{ id: 'test', type: 'salary' as const, amount: 6_000_000, frequency: 'annual' as const }];
       const homeLoanTaxCredit = { moveInYear: 2024, creditAmount: 280_000 };

--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -294,8 +294,8 @@ describe('calculateFurusatoNozeiLimit', () => {
       expect(credit.unusedCredit).toBeGreaterThan(0);
     });
 
-    it('applies the lower 5% / ¥97,500 residence cap for a 非特定取得 2014-2021 move-in', () => {
-      // Same scenario as the 特定取得 test above, but the 2020 purchase was 非特定取得 (no
+    it('applies the lower 5% / ¥97,500 residence cap for a non-特定取得 2014-2021 move-in', () => {
+      // Same scenario as the 特定取得 test above, but the 2020 purchase was non-特定取得 (no
       // consumption tax — e.g. bought from a private individual): the residence cap drops to
       // ¥97,500, so the credit reduces residence tax by ¥39,000 less and leaves more unused.
       const inputs = {
@@ -306,10 +306,10 @@ describe('calculateFurusatoNozeiLimit', () => {
       const nonTokutei = calculateTaxes({ ...inputs, homeLoanTaxCredit: { moveInYear: 2020, creditAmount: 350_000, isTokuteiShutoku: false } });
 
       const nonTokuteiCredit = nonTokutei.homeLoanTaxCredit!;
-      expect(nonTokuteiCredit.residenceTaxSpilloverCap?.flatCap).toBe(97_500); // 非特定取得 cap
+      expect(nonTokuteiCredit.residenceTaxSpilloverCap?.flatCap).toBe(97_500); // non-特定取得 cap
       expect(nonTokuteiCredit.appliedToResidenceTax).toBe(97_500); // flat cap binds
 
-      // 非特定取得 spills ¥39,000 less to residence tax than 特定取得 (¥136,500 − ¥97,500),
+      // non-特定取得 spills ¥39,000 less to residence tax than 特定取得 (¥136,500 − ¥97,500),
       // so residence tax ends up higher and the income tax is unchanged.
       expect(tokutei.homeLoanTaxCredit!.appliedToResidenceTax - nonTokuteiCredit.appliedToResidenceTax).toBe(39_000);
       expect(nonTokutei.residenceTax.totalResidenceTax).toBeGreaterThan(tokutei.residenceTax.totalResidenceTax);

--- a/src/__tests__/homeLoanTaxCredit.test.ts
+++ b/src/__tests__/homeLoanTaxCredit.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect } from 'vitest';
-import { applyHomeLoanTaxCredit, earliestEligibleMoveInYear } from '../utils/homeLoanTaxCredit';
+import {
+    applyHomeLoanTaxCredit,
+    earliestEligibleMoveInYear,
+    homeLoanCreditDistinguishesTokuteiShutoku,
+} from '../utils/homeLoanTaxCredit';
 import { getHomeLoanTaxCreditCohort } from '../data/homeLoanTaxCredit';
 
 describe('getHomeLoanTaxCreditCohort', () => {
@@ -15,15 +19,19 @@ describe('getHomeLoanTaxCreditCohort', () => {
         expect(band.spillover).toEqual({ flatCap: 97_500, taxableIncomeRate: 0.05 });
     });
 
-    it('returns the 2014-2021 band with the 7% / ¥136,500 spillover cap', () => {
-        // The 7% / ¥136,500 cap assumes 特定取得 (home acquired under the 8%/10% consumption tax).
-        // A pre-owned home bought from a private individual would use 5% / ¥97,500, which kei3 does
-        // not model — see the band's note in src/data/homeLoanTaxCredit.ts.
+    it('returns the 2014-2021 band with both 特定取得 (7% / ¥136,500) and 非特定取得 (5% / ¥97,500) caps', () => {
+        // 特定取得 (home acquired under the 8%/10% consumption tax) → 7% / ¥136,500. A 非特定取得
+        // purchase (e.g. a pre-owned home bought from a private individual) → 5% / ¥97,500.
         expect(getHomeLoanTaxCreditCohort(2014)?.moveInYearFrom).toBe(2014);
         expect(getHomeLoanTaxCreditCohort(2021)?.moveInYearFrom).toBe(2014);
         const band = getHomeLoanTaxCreditCohort(2018)!;
         expect(band.incomeLimit).toBe(30_000_000);
         expect(band.spillover).toEqual({ flatCap: 136_500, taxableIncomeRate: 0.07 });
+        expect(band.spilloverNonTokuteiShutoku).toEqual({ flatCap: 97_500, taxableIncomeRate: 0.05 });
+    });
+
+    it('does not carry a 非特定取得 cap for the 2022+ band (5% / ¥97,500 applies regardless)', () => {
+        expect(getHomeLoanTaxCreditCohort(2024)?.spilloverNonTokuteiShutoku).toBeUndefined();
     });
 
     it('returns undefined for unsupported (pre-2014) move-ins', () => {
@@ -107,6 +115,49 @@ describe('applyHomeLoanTaxCredit', () => {
         expect(result.residenceTaxSpilloverCap).toEqual({ applied: 70_000, flatCap: 136_500, incomeRateCap: 70_000 });
     });
 
+    it('uses the lower 5% / ¥97,500 cap for a 非特定取得 2014-2021 move-in', () => {
+        // Same inputs as the 特定取得 flat-cap test above, but 非特定取得: the flat cap drops to
+        // ¥97,500 (7% × 3M and 5% × 3M both exceed their flat caps, so the flat cap binds either way).
+        const result = applyHomeLoanTaxCredit(
+            { moveInYear: 2018, creditAmount: 400_000, isTokuteiShutoku: false },
+            4_000_000,
+            202_500,
+            3_000_000,
+        );
+        expect(result.appliedToIncomeTax).toBe(202_500);
+        expect(result.appliedToResidenceTax).toBe(97_500); // 非特定取得 flat cap, not ¥136,500
+        expect(result.unusedCredit).toBe(100_000); // 400,000 - 202,500 - 97,500
+        expect(result.residenceTaxSpilloverCap?.flatCap).toBe(97_500);
+    });
+
+    it('caps the 非特定取得 spillover at 課税総所得金額 × 5% when below the ¥97,500 flat cap', () => {
+        // taxableTotalIncome 1M → 5% × 1M = 50,000 < the ¥97,500 flat cap, so the rate cap binds
+        // (vs. 7% × 1M = 70,000 for 特定取得 — the lower rate produces a smaller cap).
+        const result = applyHomeLoanTaxCredit(
+            { moveInYear: 2018, creditAmount: 200_000, isTokuteiShutoku: false },
+            1_500_000,
+            50_000,
+            1_000_000,
+        );
+        expect(result.appliedToResidenceTax).toBe(50_000); // 5% × 1,000,000
+        expect(result.residenceTaxSpilloverCap).toEqual({ applied: 50_000, flatCap: 97_500, incomeRateCap: 50_000 });
+    });
+
+    it('treats an explicit isTokuteiShutoku: true the same as the default for a 2014-2021 move-in', () => {
+        const base = { moveInYear: 2018 as const, creditAmount: 400_000 };
+        const explicit = applyHomeLoanTaxCredit({ ...base, isTokuteiShutoku: true }, 4_000_000, 202_500, 3_000_000);
+        const defaulted = applyHomeLoanTaxCredit(base, 4_000_000, 202_500, 3_000_000);
+        expect(explicit.appliedToResidenceTax).toBe(136_500);
+        expect(defaulted.appliedToResidenceTax).toBe(136_500);
+    });
+
+    it('ignores isTokuteiShutoku for the 2022+ band (no 非特定取得 variant — 5% / ¥97,500 either way)', () => {
+        const tokutei = applyHomeLoanTaxCredit({ moveInYear: 2024, creditAmount: 350_000, isTokuteiShutoku: true }, 4_000_000, 202_500, 3_000_000);
+        const nonTokutei = applyHomeLoanTaxCredit({ moveInYear: 2024, creditAmount: 350_000, isTokuteiShutoku: false }, 4_000_000, 202_500, 3_000_000);
+        expect(tokutei.appliedToResidenceTax).toBe(97_500);
+        expect(nonTokutei.appliedToResidenceTax).toBe(97_500); // flag has no effect here
+    });
+
     it('rejects when net income exceeds the band eligibility limit', () => {
         const result = applyHomeLoanTaxCredit(
             { moveInYear: 2024, creditAmount: 200_000 },
@@ -185,5 +236,23 @@ describe('earliestEligibleMoveInYear (move-in dropdown floor)', () => {
     it('never returns a year before the cohort data starts (2014)', () => {
         // Far-past tax years would compute a floor below 2014; clamp to the earliest band.
         expect(earliestEligibleMoveInYear(2015)).toBe(2014);
+    });
+});
+
+describe('homeLoanCreditDistinguishesTokuteiShutoku (drives the 特定取得 checkbox)', () => {
+    it('is true only for the 2014-2021 cohort', () => {
+        for (const year of [2014, 2017, 2018, 2020, 2021]) {
+            expect(homeLoanCreditDistinguishesTokuteiShutoku(year)).toBe(true);
+        }
+    });
+
+    it('is false for 2022+ move-ins (5% / ¥97,500 regardless of 特定取得)', () => {
+        for (const year of [2022, 2024, 2026]) {
+            expect(homeLoanCreditDistinguishesTokuteiShutoku(year)).toBe(false);
+        }
+    });
+
+    it('is false for unsupported (pre-2014) move-ins', () => {
+        expect(homeLoanCreditDistinguishesTokuteiShutoku(2013)).toBe(false);
     });
 });

--- a/src/__tests__/homeLoanTaxCredit.test.ts
+++ b/src/__tests__/homeLoanTaxCredit.test.ts
@@ -19,8 +19,8 @@ describe('getHomeLoanTaxCreditCohort', () => {
         expect(band.spillover).toEqual({ flatCap: 97_500, taxableIncomeRate: 0.05 });
     });
 
-    it('returns the 2014-2021 band with both 特定取得 (7% / ¥136,500) and 非特定取得 (5% / ¥97,500) caps', () => {
-        // 特定取得 (home acquired under the 8%/10% consumption tax) → 7% / ¥136,500. A 非特定取得
+    it('returns the 2014-2021 band with both 特定取得 (7% / ¥136,500) and non-特定取得 (5% / ¥97,500) caps', () => {
+        // 特定取得 (home acquired under the 8%/10% consumption tax) → 7% / ¥136,500. A non-特定取得
         // purchase (e.g. a pre-owned home bought from a private individual) → 5% / ¥97,500.
         expect(getHomeLoanTaxCreditCohort(2014)?.moveInYearFrom).toBe(2014);
         expect(getHomeLoanTaxCreditCohort(2021)?.moveInYearFrom).toBe(2014);
@@ -30,7 +30,7 @@ describe('getHomeLoanTaxCreditCohort', () => {
         expect(band.spilloverNonTokuteiShutoku).toEqual({ flatCap: 97_500, taxableIncomeRate: 0.05 });
     });
 
-    it('does not carry a 非特定取得 cap for the 2022+ band (5% / ¥97,500 applies regardless)', () => {
+    it('does not carry a non-特定取得 cap for the 2022+ band (5% / ¥97,500 applies regardless)', () => {
         expect(getHomeLoanTaxCreditCohort(2024)?.spilloverNonTokuteiShutoku).toBeUndefined();
     });
 
@@ -115,8 +115,8 @@ describe('applyHomeLoanTaxCredit', () => {
         expect(result.residenceTaxSpilloverCap).toEqual({ applied: 70_000, flatCap: 136_500, incomeRateCap: 70_000 });
     });
 
-    it('uses the lower 5% / ¥97,500 cap for a 非特定取得 2014-2021 move-in', () => {
-        // Same inputs as the 特定取得 flat-cap test above, but 非特定取得: the flat cap drops to
+    it('uses the lower 5% / ¥97,500 cap for a non-特定取得 2014-2021 move-in', () => {
+        // Same inputs as the 特定取得 flat-cap test above, but non-特定取得: the flat cap drops to
         // ¥97,500 (7% × 3M and 5% × 3M both exceed their flat caps, so the flat cap binds either way).
         const result = applyHomeLoanTaxCredit(
             { moveInYear: 2018, creditAmount: 400_000, isTokuteiShutoku: false },
@@ -125,12 +125,12 @@ describe('applyHomeLoanTaxCredit', () => {
             3_000_000,
         );
         expect(result.appliedToIncomeTax).toBe(202_500);
-        expect(result.appliedToResidenceTax).toBe(97_500); // 非特定取得 flat cap, not ¥136,500
+        expect(result.appliedToResidenceTax).toBe(97_500); // non-特定取得 flat cap, not ¥136,500
         expect(result.unusedCredit).toBe(100_000); // 400,000 - 202,500 - 97,500
         expect(result.residenceTaxSpilloverCap?.flatCap).toBe(97_500);
     });
 
-    it('caps the 非特定取得 spillover at 課税総所得金額 × 5% when below the ¥97,500 flat cap', () => {
+    it('caps the non-特定取得 spillover at 課税総所得金額 × 5% when below the ¥97,500 flat cap', () => {
         // taxableTotalIncome 1M → 5% × 1M = 50,000 < the ¥97,500 flat cap, so the rate cap binds
         // (vs. 7% × 1M = 70,000 for 特定取得 — the lower rate produces a smaller cap).
         const result = applyHomeLoanTaxCredit(
@@ -151,7 +151,7 @@ describe('applyHomeLoanTaxCredit', () => {
         expect(defaulted.appliedToResidenceTax).toBe(136_500);
     });
 
-    it('ignores isTokuteiShutoku for the 2022+ band (no 非特定取得 variant — 5% / ¥97,500 either way)', () => {
+    it('ignores isTokuteiShutoku for the 2022+ band (no non-特定取得 variant — 5% / ¥97,500 either way)', () => {
         const tokutei = applyHomeLoanTaxCredit({ moveInYear: 2024, creditAmount: 350_000, isTokuteiShutoku: true }, 4_000_000, 202_500, 3_000_000);
         const nonTokutei = applyHomeLoanTaxCredit({ moveInYear: 2024, creditAmount: 350_000, isTokuteiShutoku: false }, 4_000_000, 202_500, 3_000_000);
         expect(tokutei.appliedToResidenceTax).toBe(97_500);

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -30,7 +30,8 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 
 import type { HomeLoanTaxCreditInput, HomeLoanTaxCreditResult } from '../../types/tax';
 import { SpinnerNumberField } from '../ui/SpinnerNumberField';
-import { SimpleTooltip } from '../ui/Tooltips';
+import { SimpleTooltip, DetailedTooltip } from '../ui/Tooltips';
+import { SIMPLE_TOOLTIP_ICON } from '../ui/constants';
 import { earliestEligibleMoveInYear, homeLoanCreditDistinguishesTokuteiShutoku } from '../../utils/homeLoanTaxCredit';
 
 interface AdditionalDeductionsModalProps {
@@ -231,15 +232,29 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                   label={
                     <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
                       <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
-                        特定取得 (8% or 10% consumption tax was paid)
+                        特定取得 (purchase subject to consumption tax)
                       </Typography>
-                      <SimpleTooltip>
-                        Check this if 8% or 10% consumption tax was charged on the purchase — i.e. a new build,
-                        or a pre-owned home bought from a business. Uncheck it for a 非特定取得 purchase with no
-                        consumption tax, such as a pre-owned home bought from a private individual. For 2014–2021
-                        move-ins this changes the residence-tax spillover cap (特定取得 → 7% / ¥136,500;
-                        非特定取得 → 5% / ¥97,500). Most purchases are 特定取得.
-                      </SimpleTooltip>
+                      <DetailedTooltip title="特定取得" icon={SIMPLE_TOOLTIP_ICON}>
+                        <Box>
+                          <Typography variant="body2">
+                            Check this if consumption tax was charged on the purchase — i.e. a new build, or a
+                            pre-owned home bought from a business. Uncheck it for a 非特定取得 purchase with no
+                            consumption tax, such as a pre-owned home bought from a private individual. For 2014–2021
+                            move-ins this changes the residence-tax spillover cap (特定取得 → 7% / ¥136,500;
+                            非特定取得 → 5% / ¥97,500).
+                          </Typography>
+                          <Box sx={{ mt: 1 }}>
+                            <a
+                              href="https://www.soumu.go.jp/main_sosiki/jichi_zeisei/czaisei/czaisei_seido/090929.html"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
+                            >
+                              総務省: 個人住民税の住宅ローン控除
+                            </a>
+                          </Box>
+                        </Box>
+                      </DetailedTooltip>
                     </Box>
                   }
                 />

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -14,6 +14,8 @@ import Divider from '@mui/material/Divider';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Accordion from '@mui/material/Accordion';
@@ -29,7 +31,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import type { HomeLoanTaxCreditInput, HomeLoanTaxCreditResult } from '../../types/tax';
 import { SpinnerNumberField } from '../ui/SpinnerNumberField';
 import { SimpleTooltip } from '../ui/Tooltips';
-import { earliestEligibleMoveInYear } from '../../utils/homeLoanTaxCredit';
+import { earliestEligibleMoveInYear, homeLoanCreditDistinguishesTokuteiShutoku } from '../../utils/homeLoanTaxCredit';
 
 interface AdditionalDeductionsModalProps {
   open: boolean;
@@ -212,6 +214,36 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                   ))}
                 </TextField>
               </Box>
+
+              {/* 特定取得 toggle, shown only for move-in years where it changes the residence-tax
+                  spillover cap (the 2014–2021 cohort). Defaults to checked = 特定取得. */}
+              {homeLoanCreditDistinguishesTokuteiShutoku(effectiveHomeLoan.moveInYear) && (
+                <FormControlLabel
+                  sx={{ mt: 1.5, ml: 0, alignItems: 'flex-start' }}
+                  control={
+                    <Checkbox
+                      size="small"
+                      checked={effectiveHomeLoan.isTokuteiShutoku ?? true}
+                      onChange={(e) => updateHomeLoan({ isTokuteiShutoku: e.target.checked })}
+                      sx={{ py: 0, mr: 0.5 }}
+                    />
+                  }
+                  label={
+                    <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                      <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
+                        特定取得 (8% or 10% consumption tax was paid)
+                      </Typography>
+                      <SimpleTooltip>
+                        Check this if 8% or 10% consumption tax was charged on the purchase — i.e. a new build,
+                        or a pre-owned home bought from a business. Uncheck it for a 非特定取得 purchase with no
+                        consumption tax, such as a pre-owned home bought from a private individual. For 2014–2021
+                        move-ins this changes the residence-tax spillover cap (特定取得 → 7% / ¥136,500;
+                        非特定取得 → 5% / ¥97,500). Most purchases are 特定取得.
+                      </SimpleTooltip>
+                    </Box>
+                  }
+                />
+              )}
 
               {/* Surface any warning the credit calculation produced: income over the limit
                   (credit zeroed) OR part of the credit unusable this year (availableCredit > 0 but

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -236,10 +236,10 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                         <Box>
                           <Typography variant="body2">
                             Check this if consumption tax was charged on the purchase — i.e. a new build, or a
-                            pre-owned home bought from a business. Uncheck it for a 非特定取得 purchase with no
+                            pre-owned home bought from a business. Uncheck it for a non-特定取得 purchase with no
                             consumption tax, such as a pre-owned home bought from a private individual. For 2014–2021
                             move-ins this changes the residence-tax spillover cap (特定取得 → 7% / ¥136,500;
-                            非特定取得 → 5% / ¥97,500).
+                            non-特定取得 → 5% / ¥97,500).
                           </Typography>
                           <Box sx={{ mt: 1 }}>
                             <a

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -236,8 +236,8 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                         <Box>
                           <Typography variant="body2">
                             Check this if consumption tax was charged on the purchase — i.e. a new build, or a
-                            pre-owned home bought from a business. Uncheck it for a non-特定取得 purchase with no
-                            consumption tax, such as a pre-owned home bought from a private individual. For 2014–2021
+                            pre-owned home bought from a consumption tax-collecting business. Uncheck it if no
+                            consumption tax was charged, such as a pre-owned home bought from a private individual. For 2014–2021
                             move-ins this changes the residence-tax spillover cap (特定取得 → 7% / ¥136,500;
                             non-特定取得 → 5% / ¥97,500).
                           </Typography>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -230,10 +230,8 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     />
                   }
                   label={
-                    <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                      <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
-                        特定取得 (purchase subject to consumption tax)
-                      </Typography>
+                    <Typography variant="body2" component="span" sx={{ fontSize: '0.85rem' }}>
+                      Purchase subject to consumption tax? (特定取得)
                       <DetailedTooltip title="特定取得" icon={SIMPLE_TOOLTIP_ICON}>
                         <Box>
                           <Typography variant="body2">
@@ -255,7 +253,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                           </Box>
                         </Box>
                       </DetailedTooltip>
-                    </Box>
+                    </Typography>
                   }
                 />
               )}

--- a/src/data/homeLoanTaxCredit.ts
+++ b/src/data/homeLoanTaxCredit.ts
@@ -25,6 +25,15 @@
  *   - MLIT 住宅ローン減税: https://www.mlit.go.jp/jutakukentiku/house/jutakukentiku_house_tk2_000017.html
  */
 
+/**
+ * A residence-tax spillover cap: the credit remainder (after income tax) is capped at
+ *   min(flatCap, floor(所得税の課税総所得金額等 × taxableIncomeRate)).
+ */
+export interface ResidenceTaxSpilloverCap {
+    flatCap: number;
+    taxableIncomeRate: number;
+}
+
 export interface HomeLoanTaxCreditCohort {
     /** Inclusive lower bound of move-in years this band covers. */
     moveInYearFrom: number;
@@ -34,7 +43,8 @@ export interface HomeLoanTaxCreditCohort {
     incomeLimit: number;
     /**
      * Residence-tax spillover cap applied when the credit exceeds income tax
-     * (個人住民税の住宅借入金等特別税額控除). Final cap =
+     * (個人住民税の住宅借入金等特別税額控除), for a 特定取得 purchase — and the only cap on
+     * bands that don't distinguish 特定取得 (see spilloverNonTokuteiShutoku). Final cap =
      *   min(flatCap, floor(所得税の課税総所得金額等 × taxableIncomeRate)).
      *
      * Figures are set by the 地方税法 residence-tax credit provisions (see the 総務省
@@ -49,10 +59,16 @@ export interface HomeLoanTaxCreditCohort {
      * always exceeds 5–7% of the income-tax base — i.e. flatCap or the 課税総所得 × rate
      * cap is always reached first. We therefore omit the 所得割 limit.
      */
-    spillover: {
-        flatCap: number;
-        taxableIncomeRate: number;
-    };
+    spillover: ResidenceTaxSpilloverCap;
+    /**
+     * Residence-tax spillover cap for a 非特定取得 purchase — one with no 8%/10% consumption
+     * tax, e.g. a pre-owned home bought from a private individual. Present only on the
+     * 2014–2021 band, where 特定取得 raised the cap to 7%/¥136,500 while a 非特定取得 purchase
+     * keeps the baseline 5%/¥97,500. Omitted on bands where the distinction is moot (2022+
+     * already uses 5%/¥97,500 for everyone); when omitted, applyHomeLoanTaxCredit uses
+     * `spillover` regardless of the 特定取得 flag.
+     */
+    spilloverNonTokuteiShutoku?: ResidenceTaxSpilloverCap;
 }
 
 /**
@@ -67,19 +83,23 @@ export const HOME_LOAN_TAX_CREDIT_COHORTS: ReadonlyArray<HomeLoanTaxCreditCohort
         incomeLimit: 20_000_000,
         spillover: { flatCap: 97_500, taxableIncomeRate: 0.05 },
     },
-    // 2014-2021 (特定取得): home acquired under the 8%/10% consumption tax — e.g. a new build or
-    // a pre-owned home bought from a business. Spillover cap raised to 7% / ¥136,500. Income limit 30M.
-    //
-    // ASSUMPTION: we treat every 2014-2021 move-in as 特定取得. A pre-owned home bought from a
-    // private individual is NOT subject to consumption tax (非特定取得) and uses the lower
-    // 5% / ¥97,500 cap instead. We have no input to distinguish that, so for such a purchase the
-    // residence-tax spillover cap modelled here is over-stated. Move-ins before 2014 are not
+    // 2014-2021: the 特定取得 distinction applies. A 特定取得 (home acquired under the 8%/10%
+    // consumption tax — e.g. a new build or a pre-owned home bought from a business) raises the
+    // spillover cap to 7% / ¥136,500; a 非特定取得 (no consumption tax, e.g. a pre-owned home
+    // bought from a private individual) keeps the baseline 5% / ¥97,500. The input's 特定取得 flag
+    // selects between them (default 特定取得). Income limit 30M. Move-ins before 2014 are not
     // supported (the UI offers move-ins from ~10 years ago onward; older credits have expired).
+    //
+    // The 8% consumption tax took effect 2014/4/1, so a 特定取得 is only possible from then on;
+    // a 2014/1/1–3/31 move-in is always 非特定取得. The move-in-year dropdown floor is ~10 years
+    // back (2017 for a 2026 calc), so those early-2014 move-ins are already past every credit
+    // period and never reach this band in practice — we don't model that sub-year boundary.
     {
         moveInYearFrom: 2014,
         moveInYearTo: 2021,
         incomeLimit: 30_000_000,
         spillover: { flatCap: 136_500, taxableIncomeRate: 0.07 },
+        spilloverNonTokuteiShutoku: { flatCap: 97_500, taxableIncomeRate: 0.05 },
     },
 ];
 

--- a/src/data/homeLoanTaxCredit.ts
+++ b/src/data/homeLoanTaxCredit.ts
@@ -61,9 +61,9 @@ export interface HomeLoanTaxCreditCohort {
      */
     spillover: ResidenceTaxSpilloverCap;
     /**
-     * Residence-tax spillover cap for a 非特定取得 purchase — one with no 8%/10% consumption
+     * Residence-tax spillover cap for a non-特定取得 purchase — one with no 8%/10% consumption
      * tax, e.g. a pre-owned home bought from a private individual. Present only on the
-     * 2014–2021 band, where 特定取得 raised the cap to 7%/¥136,500 while a 非特定取得 purchase
+     * 2014–2021 band, where 特定取得 raised the cap to 7%/¥136,500 while a non-特定取得 purchase
      * keeps the baseline 5%/¥97,500. Omitted on bands where the distinction is moot (2022+
      * already uses 5%/¥97,500 for everyone); when omitted, applyHomeLoanTaxCredit uses
      * `spillover` regardless of the 特定取得 flag.
@@ -85,13 +85,13 @@ export const HOME_LOAN_TAX_CREDIT_COHORTS: ReadonlyArray<HomeLoanTaxCreditCohort
     },
     // 2014-2021: the 特定取得 distinction applies. A 特定取得 (home acquired under the 8%/10%
     // consumption tax — e.g. a new build or a pre-owned home bought from a business) raises the
-    // spillover cap to 7% / ¥136,500; a 非特定取得 (no consumption tax, e.g. a pre-owned home
+    // spillover cap to 7% / ¥136,500; a non-特定取得 (no consumption tax, e.g. a pre-owned home
     // bought from a private individual) keeps the baseline 5% / ¥97,500. The input's 特定取得 flag
     // selects between them (default 特定取得). Income limit 30M. Move-ins before 2014 are not
     // supported (the UI offers move-ins from ~10 years ago onward; older credits have expired).
     //
     // The 8% consumption tax took effect 2014/4/1, so a 特定取得 is only possible from then on;
-    // a 2014/1/1–3/31 move-in is always 非特定取得. The move-in-year dropdown floor is ~10 years
+    // a 2014/1/1–3/31 move-in is always non-特定取得. The move-in-year dropdown floor is ~10 years
     // back (2017 for a 2026 calc), so those early-2014 move-ins are already past every credit
     // period and never reach this band in practice — we don't model that sub-year boundary.
     {

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -61,6 +61,14 @@ export interface HomeLoanTaxCreditInput {
    * (E1 / 住宅借入金等特別控除の額), which is capped at the prior year's income tax.
    */
   creditAmount: number;
+  /**
+   * Whether the home was a 特定取得 — acquired under the 8%/10% consumption tax (a new build,
+   * or a pre-owned home bought from a business). A 非特定取得 (e.g. a pre-owned home bought from
+   * a private individual, with no consumption tax) uses a lower residence-tax spillover cap.
+   * Only affects the 2014–2021 move-in cohort (特定取得 → 7%/¥136,500; 非特定取得 → 5%/¥97,500);
+   * 2022+ move-ins use 5%/¥97,500 regardless. Defaults to true (特定取得) when omitted.
+   */
+  isTokuteiShutoku?: boolean;
 }
 
 /** Computed application of the home loan tax credit. */

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -63,9 +63,9 @@ export interface HomeLoanTaxCreditInput {
   creditAmount: number;
   /**
    * Whether the home was a 特定取得 — acquired under the 8%/10% consumption tax (a new build,
-   * or a pre-owned home bought from a business). A 非特定取得 (e.g. a pre-owned home bought from
+   * or a pre-owned home bought from a business). A non-特定取得 (e.g. a pre-owned home bought from
    * a private individual, with no consumption tax) uses a lower residence-tax spillover cap.
-   * Only affects the 2014–2021 move-in cohort (特定取得 → 7%/¥136,500; 非特定取得 → 5%/¥97,500);
+   * Only affects the 2014–2021 move-in cohort (特定取得 → 7%/¥136,500; non-特定取得 → 5%/¥97,500);
    * 2022+ move-ins use 5%/¥97,500 regardless. Defaults to true (特定取得) when omitted.
    */
   isTokuteiShutoku?: boolean;

--- a/src/utils/homeLoanTaxCredit.ts
+++ b/src/utils/homeLoanTaxCredit.ts
@@ -44,8 +44,8 @@ export function earliestEligibleMoveInYear(taxYear: number): number {
 }
 
 /**
- * Whether the 特定取得 / 非特定取得 distinction changes the residence-tax spillover cap for the
- * given move-in year — true only for cohorts that carry a separate 非特定取得 cap (the 2014–2021
+ * Whether the 特定取得 / non-特定取得 distinction changes the residence-tax spillover cap for the
+ * given move-in year — true only for cohorts that carry a separate non-特定取得 cap (the 2014–2021
  * band). The UI uses this to show the 特定取得 checkbox only for move-in years where it matters.
  */
 export function homeLoanCreditDistinguishesTokuteiShutoku(moveInYear: number): boolean {
@@ -101,10 +101,10 @@ export function applyHomeLoanTaxCredit(
     const appliedToIncomeTax = Math.min(availableCredit, Math.max(0, baseIncomeTax));
     const spilloverEligible = availableCredit - appliedToIncomeTax;
 
-    // Pick the spillover cap variant. The 2014–2021 band carries a lower 非特定取得 cap
+    // Pick the spillover cap variant. The 2014–2021 band carries a lower non-特定取得 cap
     // (5%/¥97,500) alongside its 特定取得 cap (7%/¥136,500); we use it only when the input is
-    // explicitly 非特定取得 AND the band distinguishes them. Omitting the flag means 特定取得
-    // (matching the original behavior); other bands have no 非特定取得 variant, so the flag is moot.
+    // explicitly non-特定取得 AND the band distinguishes them. Omitting the flag means 特定取得
+    // (matching the original behavior); other bands have no non-特定取得 variant, so the flag is moot.
     const spillover = input.isTokuteiShutoku === false && cohort.spilloverNonTokuteiShutoku
         ? cohort.spilloverNonTokuteiShutoku
         : cohort.spillover;

--- a/src/utils/homeLoanTaxCredit.ts
+++ b/src/utils/homeLoanTaxCredit.ts
@@ -44,6 +44,15 @@ export function earliestEligibleMoveInYear(taxYear: number): number {
 }
 
 /**
+ * Whether the 特定取得 / 非特定取得 distinction changes the residence-tax spillover cap for the
+ * given move-in year — true only for cohorts that carry a separate 非特定取得 cap (the 2014–2021
+ * band). The UI uses this to show the 特定取得 checkbox only for move-in years where it matters.
+ */
+export function homeLoanCreditDistinguishesTokuteiShutoku(moveInYear: number): boolean {
+    return getHomeLoanTaxCreditCohort(moveInYear)?.spilloverNonTokuteiShutoku !== undefined;
+}
+
+/**
  * Computes how the user's home loan tax credit applies, split between the base
  * income tax and the residence-tax spillover.
  *
@@ -92,9 +101,17 @@ export function applyHomeLoanTaxCredit(
     const appliedToIncomeTax = Math.min(availableCredit, Math.max(0, baseIncomeTax));
     const spilloverEligible = availableCredit - appliedToIncomeTax;
 
+    // Pick the spillover cap variant. The 2014–2021 band carries a lower 非特定取得 cap
+    // (5%/¥97,500) alongside its 特定取得 cap (7%/¥136,500); we use it only when the input is
+    // explicitly 非特定取得 AND the band distinguishes them. Omitting the flag means 特定取得
+    // (matching the original behavior); other bands have no 非特定取得 variant, so the flag is moot.
+    const spillover = input.isTokuteiShutoku === false && cohort.spilloverNonTokuteiShutoku
+        ? cohort.spilloverNonTokuteiShutoku
+        : cohort.spillover;
+
     // Remainder spills over to residence tax, capped at min(定額限度 flatCap, 定率限度 課税総所得金額等 × rate).
-    const incomeRateCap = Math.floor(Math.max(0, taxableTotalIncome) * cohort.spillover.taxableIncomeRate);
-    const residenceTaxCap = Math.min(cohort.spillover.flatCap, incomeRateCap);
+    const incomeRateCap = Math.floor(Math.max(0, taxableTotalIncome) * spillover.taxableIncomeRate);
+    const residenceTaxCap = Math.min(spillover.flatCap, incomeRateCap);
     const appliedToResidenceTax = Math.min(spilloverEligible, residenceTaxCap);
     const unusedCredit = availableCredit - appliedToIncomeTax - appliedToResidenceTax;
 
@@ -112,7 +129,7 @@ export function applyHomeLoanTaxCredit(
         unusedCredit,
         residenceTaxSpilloverCap: {
             applied: residenceTaxCap,
-            flatCap: cohort.spillover.flatCap,
+            flatCap: spillover.flatCap,
             incomeRateCap,
         },
         warnings,


### PR DESCRIPTION
The home loan tax credit (住宅ローン控除) previously assumed every 2014–2021 move-in was a 特定取得 and hard-coded the higher residence-tax spillover cap (7% / ¥136,500). A non-特定取得 purchase — one with no consumption tax, e.g. a pre-owned home bought from a private individual — is capped lower at 5% / ¥97,500.

Add an optional `isTokuteiShutoku` flag (default true = current behavior) to HomeLoanTaxCreditInput and a `spilloverNonTokuteiShutoku` cap variant on the 2014–2021 cohort. applyHomeLoanTaxCredit selects the variant only when the input is explicitly non-特定取得 and the band distinguishes them; for 2022+ move-ins everyone uses 5% / ¥97,500, so the flag is ignored there.

The UI shows a checkbox (defaulting to checked) only for move-in years where the distinction changes the cap, driven by the new homeLoanCreditDistinguishesTokuteiShutoku helper.

Verified against 総務省 / NTA / municipal sources. Worked example (¥5.5M salary, single, Tokyo, 2020 move-in, ¥350,000 credit): 特定取得 spills ¥136,500 to residence tax; 非特定取得 spills ¥97,500 — a ¥39,000 difference.