### PR TITLE
Make income year first-class application state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ThemeToggle from './components/ThemeToggle'
 import ChangelogButton from './components/ChangelogButton'
 import { TakeHomeInputForm } from './components/TakeHomeCalculator/InputForm'
 import type { TakeHomeFormState, TakeHomeInputs, TakeHomeResults } from './types/tax'
+import { DEFAULT_INCOME_YEAR } from './types/tax'
 import { calculateTaxes } from './utils/taxCalculations'
 import { DEFAULT_PROVIDER_REGION, NATIONAL_HEALTH_INSURANCE_ID, DEFAULT_PROVIDER, DEPENDENT_COVERAGE_ID, isDependentCoverageEligible } from './types/healthInsurance'
 import { NATIONAL_HEALTH_INSURANCE_REGIONS } from './data/nationalHealthInsurance/nhiParamsData'
@@ -37,6 +38,7 @@ function App({ mode, toggleColorMode }: AppProps) {
   // Default values for the form
   const defaultInputs: TakeHomeFormState = {
     annualIncome: 5_000_000, // 5 million yen
+    incomeYear: DEFAULT_INCOME_YEAR, // single source of truth; pinned, not new Date().getFullYear()
     incomeMode: 'salary',
     incomeStreams: [{
       id: 'default-salary',
@@ -64,6 +66,7 @@ function App({ mode, toggleColorMode }: AppProps) {
     const calculateAndSetResults = () => {
       const calculationInputs: TakeHomeInputs = {
         incomeStreams: inputs.incomeStreams,
+        incomeYear: inputs.incomeYear,
         isSubjectToLongTermCarePremium: inputs.isSubjectToLongTermCarePremium,
         region: inputs.region,
         healthInsuranceProvider: inputs.healthInsuranceProvider,
@@ -87,6 +90,7 @@ function App({ mode, toggleColorMode }: AppProps) {
     return () => clearTimeout(handler);
   }, [
     inputs.incomeStreams,
+    inputs.incomeYear,
     inputs.isSubjectToLongTermCarePremium,
     inputs.region,
     inputs.healthInsuranceProvider,
@@ -255,6 +259,7 @@ function App({ mode, toggleColorMode }: AppProps) {
       }>
         <TakeHomeChart
           currentIncome={inputs.annualIncome}
+          incomeYear={inputs.incomeYear}
           isEmploymentIncome={inputs.incomeStreams.some(s => s.type === 'salary' || s.type === 'bonus')}
           isSubjectToLongTermCarePremium={inputs.isSubjectToLongTermCarePremium}
           healthInsuranceProvider={inputs.healthInsuranceProvider}

--- a/src/__tests__/BlueFilerDisplay.test.tsx
+++ b/src/__tests__/BlueFilerDisplay.test.tsx
@@ -61,7 +61,8 @@ const mockInputs: TakeHomeInputs = {
     dependents: [],
     dcPlanContributions: 0,
     manualSocialInsuranceEntry: false,
-    manualSocialInsuranceAmount: 0
+    manualSocialInsuranceAmount: 0,
+    incomeYear: 2026
 };
 
 describe('Blue-Filer Deduction Display', () => {

--- a/src/__tests__/HealthInsuranceBonusTooltip.test.tsx
+++ b/src/__tests__/HealthInsuranceBonusTooltip.test.tsx
@@ -65,6 +65,7 @@ describe('HealthInsuranceBonusTooltip', () => {
         dcPlanContributions: 0,
         manualSocialInsuranceEntry: false,
         manualSocialInsuranceAmount: 0,
+        incomeYear: 2026,
     };
 
     test('displays generic employer note for standard provider', () => {

--- a/src/__tests__/IncomeModeTransitions.test.tsx
+++ b/src/__tests__/IncomeModeTransitions.test.tsx
@@ -7,6 +7,7 @@ import { TakeHomeInputForm } from '../components/TakeHomeCalculator/InputForm';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import type { TakeHomeFormState, IncomeStream } from '../types/tax';
+import { DEFAULT_INCOME_YEAR } from '../types/tax';
 import { DEFAULT_PROVIDER, DEFAULT_PROVIDER_REGION } from '../types/healthInsurance';
 import { vi } from 'vitest';
 
@@ -23,6 +24,7 @@ vi.mock('../components/TakeHomeCalculator/Income/IncomeDetailsModal', () => ({
 const TestWrapper = ({ initialState }: { initialState?: Partial<TakeHomeFormState> }) => {
     const [inputs, setInputs] = useState<TakeHomeFormState>({
         annualIncome: 5000000,
+        incomeYear: DEFAULT_INCOME_YEAR,
         incomeMode: 'salary',
         incomeStreams: [{ id: '1', type: 'salary', amount: 5000000, frequency: 'annual' }],
         isSubjectToLongTermCarePremium: false,

--- a/src/__tests__/IncomeModeTransitions.test.tsx
+++ b/src/__tests__/IncomeModeTransitions.test.tsx
@@ -7,7 +7,6 @@ import { TakeHomeInputForm } from '../components/TakeHomeCalculator/InputForm';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import type { TakeHomeFormState, IncomeStream } from '../types/tax';
-import { DEFAULT_INCOME_YEAR } from '../types/tax';
 import { DEFAULT_PROVIDER, DEFAULT_PROVIDER_REGION } from '../types/healthInsurance';
 import { vi } from 'vitest';
 
@@ -24,7 +23,7 @@ vi.mock('../components/TakeHomeCalculator/Income/IncomeDetailsModal', () => ({
 const TestWrapper = ({ initialState }: { initialState?: Partial<TakeHomeFormState> }) => {
     const [inputs, setInputs] = useState<TakeHomeFormState>({
         annualIncome: 5000000,
-        incomeYear: DEFAULT_INCOME_YEAR,
+        incomeYear: 2026,
         incomeMode: 'salary',
         incomeStreams: [{ id: '1', type: 'salary', amount: 5000000, frequency: 'annual' }],
         isSubjectToLongTermCarePremium: false,

--- a/src/__tests__/InputForm.test.tsx
+++ b/src/__tests__/InputForm.test.tsx
@@ -6,7 +6,6 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TakeHomeInputForm } from '../components/TakeHomeCalculator/InputForm';
 import type { TakeHomeFormState } from '../types/tax';
-import { DEFAULT_INCOME_YEAR } from '../types/tax';
 import { PROVIDER_DEFINITIONS } from '../data/employeesHealthInsurance/providerRateData';
 import { getProviderDisplayName, NATIONAL_HEALTH_INSURANCE_ID, CUSTOM_PROVIDER_ID, DEFAULT_PROVIDER_REGION, DEFAULT_PROVIDER } from '../types/healthInsurance';
 import { calculateNetEmploymentIncome } from '../utils/taxCalculations';
@@ -16,7 +15,7 @@ describe('TakeHomeInputForm Tests', () => {
 
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
-    incomeYear: DEFAULT_INCOME_YEAR,
+    incomeYear: 2026,
     incomeMode: 'salary',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -310,7 +309,7 @@ describe('Dependent Coverage UI Behavior', () => {
   const mockOnInputChange = vi.fn();
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
-    incomeYear: DEFAULT_INCOME_YEAR,
+    incomeYear: 2026,
     incomeMode: 'salary',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -520,7 +519,7 @@ describe('Age Range Selection', () => {
   const mockOnInputChange = vi.fn();
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
-    incomeYear: DEFAULT_INCOME_YEAR,
+    incomeYear: 2026,
     incomeMode: 'salary',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -571,7 +570,7 @@ describe('TakeHomeInputForm Dependents Modal', () => {
 
   const defaultInputs: TakeHomeFormState = {
     annualIncome: 0,
-    incomeYear: DEFAULT_INCOME_YEAR,
+    incomeYear: 2026,
     incomeMode: 'advanced',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -613,7 +612,7 @@ describe('Commuting Allowance Integration', () => {
 
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
-    incomeYear: DEFAULT_INCOME_YEAR,
+    incomeYear: 2026,
     incomeMode: 'advanced',
     incomeStreams: [
       { id: '1', type: 'salary', amount: 5000000, frequency: 'annual' }
@@ -690,7 +689,7 @@ describe('Regression: Health Insurance Provider Auto-Correction', () => {
   const TestWrapper = () => {
     const [inputs, setInputs] = useState<TakeHomeFormState>({
       annualIncome: 10000000,
-      incomeYear: DEFAULT_INCOME_YEAR,
+      incomeYear: 2026,
       incomeMode: 'advanced',
       incomeStreams: [
         { id: '1', type: 'salary', amount: 6000000, frequency: 'annual' },

--- a/src/__tests__/InputForm.test.tsx
+++ b/src/__tests__/InputForm.test.tsx
@@ -599,7 +599,7 @@ describe('TakeHomeInputForm Dependents Modal', () => {
     const modal = screen.getByTestId('dependents-modal');
     const netIncomePassed = Number(modal.getAttribute('data-net-income'));
 
-    const expectedNetSalary = calculateNetEmploymentIncome(5_000_000);
+    const expectedNetSalary = calculateNetEmploymentIncome(5_000_000, 2026);
     const expectedTotalNet = expectedNetSalary + 5_000_000;
 
     expect(netIncomePassed).toBe(expectedTotalNet);

--- a/src/__tests__/InputForm.test.tsx
+++ b/src/__tests__/InputForm.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TakeHomeInputForm } from '../components/TakeHomeCalculator/InputForm';
 import type { TakeHomeFormState } from '../types/tax';
+import { DEFAULT_INCOME_YEAR } from '../types/tax';
 import { PROVIDER_DEFINITIONS } from '../data/employeesHealthInsurance/providerRateData';
 import { getProviderDisplayName, NATIONAL_HEALTH_INSURANCE_ID, CUSTOM_PROVIDER_ID, DEFAULT_PROVIDER_REGION, DEFAULT_PROVIDER } from '../types/healthInsurance';
 import { calculateNetEmploymentIncome } from '../utils/taxCalculations';
@@ -15,6 +16,7 @@ describe('TakeHomeInputForm Tests', () => {
 
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
+    incomeYear: DEFAULT_INCOME_YEAR,
     incomeMode: 'salary',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -308,6 +310,7 @@ describe('Dependent Coverage UI Behavior', () => {
   const mockOnInputChange = vi.fn();
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
+    incomeYear: DEFAULT_INCOME_YEAR,
     incomeMode: 'salary',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -517,6 +520,7 @@ describe('Age Range Selection', () => {
   const mockOnInputChange = vi.fn();
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
+    incomeYear: DEFAULT_INCOME_YEAR,
     incomeMode: 'salary',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -567,6 +571,7 @@ describe('TakeHomeInputForm Dependents Modal', () => {
 
   const defaultInputs: TakeHomeFormState = {
     annualIncome: 0,
+    incomeYear: DEFAULT_INCOME_YEAR,
     incomeMode: 'advanced',
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
@@ -608,6 +613,7 @@ describe('Commuting Allowance Integration', () => {
 
   const baseInputs: TakeHomeFormState = {
     annualIncome: 5000000,
+    incomeYear: DEFAULT_INCOME_YEAR,
     incomeMode: 'advanced',
     incomeStreams: [
       { id: '1', type: 'salary', amount: 5000000, frequency: 'annual' }
@@ -684,6 +690,7 @@ describe('Regression: Health Insurance Provider Auto-Correction', () => {
   const TestWrapper = () => {
     const [inputs, setInputs] = useState<TakeHomeFormState>({
       annualIncome: 10000000,
+      incomeYear: DEFAULT_INCOME_YEAR,
       incomeMode: 'advanced',
       incomeStreams: [
         { id: '1', type: 'salary', amount: 6000000, frequency: 'annual' },

--- a/src/__tests__/NHICapIndicator.test.tsx
+++ b/src/__tests__/NHICapIndicator.test.tsx
@@ -17,7 +17,7 @@ Element.prototype.scrollTo = vi.fn();
  */
 function buildNHIScenario(annualIncome: number, region: string, includeLTC: boolean) {
     const breakdown = calculateNationalHealthInsurancePremiumWithBreakdown(
-        annualIncome, includeLTC, region, 2026
+        annualIncome, includeLTC, 2026, region
     );
 
     const results: TakeHomeResults = {

--- a/src/__tests__/NHICapIndicator.test.tsx
+++ b/src/__tests__/NHICapIndicator.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import SocialInsuranceTab from '../components/TakeHomeCalculator/tabs/SocialInsuranceTab';
 import { calculateNationalHealthInsurancePremiumWithBreakdown } from '../utils/healthInsuranceCalculator';
 import { NATIONAL_HEALTH_INSURANCE_ID } from '../types/healthInsurance';
@@ -10,10 +10,6 @@ import type { TakeHomeResults, TakeHomeInputs, ResidenceTaxDetails, FurusatoNoze
 
 // Mock scrollTo (used by SMRTableTooltip)
 Element.prototype.scrollTo = vi.fn();
-
-// Pin to June 2026 for deterministic NHI rate lookups
-beforeAll(() => { vi.useFakeTimers({ now: new Date(2026, 5, 1) }); });
-afterAll(() => { vi.useRealTimers(); });
 
 /**
  * Build realistic TakeHomeResults and TakeHomeInputs using the real NHI calculator,

--- a/src/__tests__/NHICapIndicator.test.tsx
+++ b/src/__tests__/NHICapIndicator.test.tsx
@@ -56,6 +56,7 @@ function buildNHIScenario(annualIncome: number, region: string, includeLTC: bool
         dcPlanContributions: 0,
         manualSocialInsuranceEntry: false,
         manualSocialInsuranceAmount: 0,
+        incomeYear: 2026,
     };
 
     return { results, inputs, breakdown };

--- a/src/__tests__/NHIPortionTooltip.test.tsx
+++ b/src/__tests__/NHIPortionTooltip.test.tsx
@@ -54,6 +54,7 @@ function buildNHIScenario(annualIncome: number, region: string, includeLTC: bool
         dcPlanContributions: 0,
         manualSocialInsuranceEntry: false,
         manualSocialInsuranceAmount: 0,
+        incomeYear: 2026,
     };
 
     return { results, inputs, breakdown };

--- a/src/__tests__/NHIPortionTooltip.test.tsx
+++ b/src/__tests__/NHIPortionTooltip.test.tsx
@@ -2,16 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { render } from '@testing-library/react';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { NHIPortionTooltip, type NHIPortionType } from '../components/TakeHomeCalculator/tabs/HealthInsurancePremiumTooltip';
 import { calculateNationalHealthInsurancePremiumWithBreakdown } from '../utils/healthInsuranceCalculator';
 import { NATIONAL_HEALTH_INSURANCE_ID } from '../types/healthInsurance';
 import { formatJPY } from '../utils/formatters';
 import type { TakeHomeResults, TakeHomeInputs, ResidenceTaxDetails, FurusatoNozeiDetails } from '../types/tax';
-
-// Pin to June 2026 so rate lookups resolve to FY2026 (current) and FY2025 (previous).
-beforeAll(() => { vi.useFakeTimers({ now: new Date(2026, 5, 1) }); });
-afterAll(() => { vi.useRealTimers(); });
 
 /**
  * Build minimal TakeHomeResults and TakeHomeInputs for a given NHI scenario,

--- a/src/__tests__/NHIPortionTooltip.test.tsx
+++ b/src/__tests__/NHIPortionTooltip.test.tsx
@@ -15,7 +15,7 @@ import type { TakeHomeResults, TakeHomeInputs, ResidenceTaxDetails, FurusatoNoze
  */
 function buildNHIScenario(annualIncome: number, region: string, includeLTC: boolean) {
     const breakdown = calculateNationalHealthInsurancePremiumWithBreakdown(
-        annualIncome, includeLTC, region, 2026
+        annualIncome, includeLTC, 2026, region
     );
 
     const results: TakeHomeResults = {

--- a/src/__tests__/SocialInsuranceTab.test.tsx
+++ b/src/__tests__/SocialInsuranceTab.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import SocialInsuranceTab from '../components/TakeHomeCalculator/tabs/SocialInsuranceTab';
 import type { TakeHomeResults, TakeHomeInputs, ResidenceTaxDetails } from '../types/tax';
-import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { vi, describe, it, expect, beforeAll } from 'vitest';
 
 // Mock DetailedTooltip to render children directly for easier testing
 vi.mock('../components/ui/Tooltips', async () => {
@@ -34,10 +34,6 @@ beforeAll(() => {
     Element.prototype.scrollTo = vi.fn();
 });
 
-// Pin to June 2025 — within FY2025 rate period, rates are uniform across all months
-beforeAll(() => { vi.useFakeTimers({ now: new Date(2025, 5, 1) }) });
-afterAll(() => { vi.useRealTimers() });
-
 describe('SocialInsuranceTab', () => {
     const mockInputs: TakeHomeInputs = {
         incomeStreams: [
@@ -51,7 +47,7 @@ describe('SocialInsuranceTab', () => {
         dcPlanContributions: 0,
         manualSocialInsuranceEntry: false,
         manualSocialInsuranceAmount: 0,
-        incomeYear: 2025, // matches the fake-timer FY2025 pin above
+        incomeYear: 2025, // this fixture models income year 2025 (FY2025 rates); drives all tooltips via inputs
     };
 
     const mockResidenceTax: ResidenceTaxDetails = {

--- a/src/__tests__/SocialInsuranceTab.test.tsx
+++ b/src/__tests__/SocialInsuranceTab.test.tsx
@@ -51,6 +51,7 @@ describe('SocialInsuranceTab', () => {
         dcPlanContributions: 0,
         manualSocialInsuranceEntry: false,
         manualSocialInsuranceAmount: 0,
+        incomeYear: 2025, // matches the fake-timer FY2025 pin above
     };
 
     const mockResidenceTax: ResidenceTaxDetails = {

--- a/src/__tests__/ZeroAmountBonus.test.ts
+++ b/src/__tests__/ZeroAmountBonus.test.ts
@@ -1,28 +1,12 @@
 // Copyright the original author or authors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { calculateEmploymentInsurance as calculateEmploymentInsuranceForYear } from '../utils/taxCalculations';
-import { calculateHealthInsuranceBreakdown as calculateHealthInsuranceBreakdownForYear } from '../utils/healthInsuranceCalculator';
-import { calculatePensionBreakdown as calculatePensionBreakdownForYear } from '../utils/pensionCalculator';
+import { calculateEmploymentInsurance } from '../utils/taxCalculations';
+import { calculateHealthInsuranceBreakdown } from '../utils/healthInsuranceCalculator';
+import { calculatePensionBreakdown } from '../utils/pensionCalculator';
 import { DEFAULT_PROVIDER } from '../types/healthInsurance';
 
-// These calculators now require an income year. Thin wrappers default it to 2026 (the suite's
-// prior behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
 const TEST_INCOME_YEAR = 2026;
-const calculateEmploymentInsurance = (
-  salaryIncome: Parameters<typeof calculateEmploymentInsuranceForYear>[0],
-  bonuses?: Parameters<typeof calculateEmploymentInsuranceForYear>[2], year: number = TEST_INCOME_YEAR,
-) => calculateEmploymentInsuranceForYear(salaryIncome, year, bonuses);
-type HIBreakdownArgs = Parameters<typeof calculateHealthInsuranceBreakdownForYear>;
-const calculateHealthInsuranceBreakdown = (
-  income: HIBreakdownArgs[0], ltc: HIBreakdownArgs[1], provider: HIBreakdownArgs[2], region?: HIBreakdownArgs[4],
-  customRates?: HIBreakdownArgs[5], bonuses?: HIBreakdownArgs[6], year: number = TEST_INCOME_YEAR,
-) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, year, region, customRates, bonuses);
-type PenBreakdownArgs = Parameters<typeof calculatePensionBreakdownForYear>;
-const calculatePensionBreakdown = (
-  isEmployeesPension?: PenBreakdownArgs[0], monthlyIncome?: PenBreakdownArgs[1], isHalfAmount?: PenBreakdownArgs[2],
-  bonuses?: PenBreakdownArgs[3], year: number = TEST_INCOME_YEAR,
-) => calculatePensionBreakdownForYear(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year);
 
 describe('Zero Amount Bonus Handling', () => {
     const zeroAmountBonus = { amount: 0, type: 'bonus' as const, month: 6, id: '1' };
@@ -31,16 +15,16 @@ describe('Zero Amount Bonus Handling', () => {
     describe('calculateEmploymentInsurance', () => {
         it('should handle zero amount bonus correctly', () => {
             // Should be 0 if salary is 0 and bonus is 0
-            const result = calculateEmploymentInsurance(0, [zeroAmountBonus]);
+            const result = calculateEmploymentInsurance(0, TEST_INCOME_YEAR, [zeroAmountBonus]);
             expect(result).toBe(0);
         });
 
         it('should handle mixed zero and non-zero bonuses', () => {
             // Salary 0, one valid bonus
-            const resultWithValid = calculateEmploymentInsurance(0, [validBonus]);
+            const resultWithValid = calculateEmploymentInsurance(0, TEST_INCOME_YEAR, [validBonus]);
 
             // Salary 0, one valid bonus and one zero bonus
-            const resultWithMixed = calculateEmploymentInsurance(0, [validBonus, zeroAmountBonus]);
+            const resultWithMixed = calculateEmploymentInsurance(0, TEST_INCOME_YEAR, [validBonus, zeroAmountBonus]);
 
             expect(resultWithMixed).toBe(resultWithValid);
         });
@@ -49,10 +33,10 @@ describe('Zero Amount Bonus Handling', () => {
     describe('calculateHealthInsuranceBreakdown', () => {
         it('should handle zero amount bonus correctly', () => {
             // Calculate with no bonuses first
-            const baseResult = calculateHealthInsuranceBreakdown(3000000, false, DEFAULT_PROVIDER, 'Tokyo', undefined, []);
+            const baseResult = calculateHealthInsuranceBreakdown(3000000, false, DEFAULT_PROVIDER, TEST_INCOME_YEAR, 'Tokyo', undefined, []);
 
             // Calculate with zero bonus
-            const resultWithZeroBonus = calculateHealthInsuranceBreakdown(3000000, false, DEFAULT_PROVIDER, 'Tokyo', undefined, [zeroAmountBonus]);
+            const resultWithZeroBonus = calculateHealthInsuranceBreakdown(3000000, false, DEFAULT_PROVIDER, TEST_INCOME_YEAR, 'Tokyo', undefined, [zeroAmountBonus]);
 
             expect(resultWithZeroBonus.bonusPortion).toBe(0);
             expect(resultWithZeroBonus.total).toBe(baseResult.total);
@@ -62,10 +46,10 @@ describe('Zero Amount Bonus Handling', () => {
     describe('calculatePensionBreakdown', () => {
         it('should handle zero amount bonus correctly', () => {
             // Calculate with no bonuses first
-            const baseResult = calculatePensionBreakdown(true, 250000, true, []);
+            const baseResult = calculatePensionBreakdown(true, 250000, true, [], TEST_INCOME_YEAR);
 
             // Calculate with zero bonus
-            const resultWithZeroBonus = calculatePensionBreakdown(true, 250000, true, [zeroAmountBonus]);
+            const resultWithZeroBonus = calculatePensionBreakdown(true, 250000, true, [zeroAmountBonus], TEST_INCOME_YEAR);
 
             expect(resultWithZeroBonus.bonusPortion).toBe(0);
             expect(resultWithZeroBonus.total).toBe(baseResult.total);

--- a/src/__tests__/ZeroAmountBonus.test.ts
+++ b/src/__tests__/ZeroAmountBonus.test.ts
@@ -15,9 +15,9 @@ const calculateEmploymentInsurance = (
 ) => calculateEmploymentInsuranceForYear(salaryIncome, bonuses, year);
 type HIBreakdownArgs = Parameters<typeof calculateHealthInsuranceBreakdownForYear>;
 const calculateHealthInsuranceBreakdown = (
-  income: HIBreakdownArgs[0], ltc: HIBreakdownArgs[1], provider: HIBreakdownArgs[2], region?: HIBreakdownArgs[3],
-  customRates?: HIBreakdownArgs[4], bonuses?: HIBreakdownArgs[5], year: number = TEST_INCOME_YEAR,
-) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, region, customRates, bonuses, year);
+  income: HIBreakdownArgs[0], ltc: HIBreakdownArgs[1], provider: HIBreakdownArgs[2], region?: HIBreakdownArgs[4],
+  customRates?: HIBreakdownArgs[5], bonuses?: HIBreakdownArgs[6], year: number = TEST_INCOME_YEAR,
+) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, year, region, customRates, bonuses);
 type PenBreakdownArgs = Parameters<typeof calculatePensionBreakdownForYear>;
 const calculatePensionBreakdown = (
   isEmployeesPension?: PenBreakdownArgs[0], monthlyIncome?: PenBreakdownArgs[1], isHalfAmount?: PenBreakdownArgs[2],

--- a/src/__tests__/ZeroAmountBonus.test.ts
+++ b/src/__tests__/ZeroAmountBonus.test.ts
@@ -1,10 +1,28 @@
 // Copyright the original author or authors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { calculateEmploymentInsurance } from '../utils/taxCalculations';
-import { calculateHealthInsuranceBreakdown } from '../utils/healthInsuranceCalculator';
-import { calculatePensionBreakdown } from '../utils/pensionCalculator';
+import { calculateEmploymentInsurance as calculateEmploymentInsuranceForYear } from '../utils/taxCalculations';
+import { calculateHealthInsuranceBreakdown as calculateHealthInsuranceBreakdownForYear } from '../utils/healthInsuranceCalculator';
+import { calculatePensionBreakdown as calculatePensionBreakdownForYear } from '../utils/pensionCalculator';
 import { DEFAULT_PROVIDER } from '../types/healthInsurance';
+
+// These calculators now require an income year. Thin wrappers default it to 2026 (the suite's
+// prior behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
+const TEST_INCOME_YEAR = 2026;
+const calculateEmploymentInsurance = (
+  salaryIncome: Parameters<typeof calculateEmploymentInsuranceForYear>[0],
+  bonuses?: Parameters<typeof calculateEmploymentInsuranceForYear>[1], year: number = TEST_INCOME_YEAR,
+) => calculateEmploymentInsuranceForYear(salaryIncome, bonuses, year);
+type HIBreakdownArgs = Parameters<typeof calculateHealthInsuranceBreakdownForYear>;
+const calculateHealthInsuranceBreakdown = (
+  income: HIBreakdownArgs[0], ltc: HIBreakdownArgs[1], provider: HIBreakdownArgs[2], region?: HIBreakdownArgs[3],
+  customRates?: HIBreakdownArgs[4], bonuses?: HIBreakdownArgs[5], year: number = TEST_INCOME_YEAR,
+) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, region, customRates, bonuses, year);
+type PenBreakdownArgs = Parameters<typeof calculatePensionBreakdownForYear>;
+const calculatePensionBreakdown = (
+  isEmployeesPension?: PenBreakdownArgs[0], monthlyIncome?: PenBreakdownArgs[1], isHalfAmount?: PenBreakdownArgs[2],
+  bonuses?: PenBreakdownArgs[3], year: number = TEST_INCOME_YEAR,
+) => calculatePensionBreakdownForYear(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year);
 
 describe('Zero Amount Bonus Handling', () => {
     const zeroAmountBonus = { amount: 0, type: 'bonus' as const, month: 6, id: '1' };

--- a/src/__tests__/ZeroAmountBonus.test.ts
+++ b/src/__tests__/ZeroAmountBonus.test.ts
@@ -11,8 +11,8 @@ import { DEFAULT_PROVIDER } from '../types/healthInsurance';
 const TEST_INCOME_YEAR = 2026;
 const calculateEmploymentInsurance = (
   salaryIncome: Parameters<typeof calculateEmploymentInsuranceForYear>[0],
-  bonuses?: Parameters<typeof calculateEmploymentInsuranceForYear>[1], year: number = TEST_INCOME_YEAR,
-) => calculateEmploymentInsuranceForYear(salaryIncome, bonuses, year);
+  bonuses?: Parameters<typeof calculateEmploymentInsuranceForYear>[2], year: number = TEST_INCOME_YEAR,
+) => calculateEmploymentInsuranceForYear(salaryIncome, year, bonuses);
 type HIBreakdownArgs = Parameters<typeof calculateHealthInsuranceBreakdownForYear>;
 const calculateHealthInsuranceBreakdown = (
   income: HIBreakdownArgs[0], ltc: HIBreakdownArgs[1], provider: HIBreakdownArgs[2], region?: HIBreakdownArgs[4],

--- a/src/__tests__/adjustment-credit.test.ts
+++ b/src/__tests__/adjustment-credit.test.ts
@@ -34,9 +34,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income ≤ 900万円 → 5万円 statutory difference', () => {
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([spouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (spouse) = 100,000
       expect(result.personalDeductionDifference).toBe(100_000)
@@ -53,9 +53,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 900-950万円 → 4万円 statutory difference', () => {
       const taxpayerIncome = 9_200_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([spouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 40,000 (spouse) = 90,000
       expect(result.personalDeductionDifference).toBe(90_000)
@@ -64,9 +64,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 950-1000万円 → 2万円 statutory difference', () => {
       const taxpayerIncome = 9_700_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([spouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 20,000 (spouse) = 70,000
       expect(result.personalDeductionDifference).toBe(70_000)
@@ -75,9 +75,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income > 1000万円 → 0 statutory difference (no spouse deduction)', () => {
       const taxpayerIncome = 11_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([spouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 0 (no spouse deduction) = 50,000
       expect(result.personalDeductionDifference).toBe(50_000)
@@ -100,9 +100,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income ≤ 900万円 → 10万円 statutory difference', () => {
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([elderlySpouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([elderlySpouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 100,000 (elderly spouse) = 150,000
       expect(result.personalDeductionDifference).toBe(150_000)
@@ -111,9 +111,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 900-950万円 → 6万円 statutory difference', () => {
       const taxpayerIncome = 9_200_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([elderlySpouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([elderlySpouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 60,000 (elderly spouse) = 110,000
       expect(result.personalDeductionDifference).toBe(110_000)
@@ -122,9 +122,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 950-1000万円 → 3万円 statutory difference', () => {
       const taxpayerIncome = 9_700_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([elderlySpouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([elderlySpouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 30,000 (elderly spouse) = 80,000
       expect(result.personalDeductionDifference).toBe(80_000)
@@ -149,9 +149,9 @@ describe('Adjustment Credit - Spouse Special Deduction (配偶者特別控除)',
     it('statutory difference is 0 (mutually exclusive income ranges)', () => {
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
+      const dependents = calculateDependentDeductions([spouse], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 0 (spouse special) = 50,000
       // Spouse special deduction has NO statutory difference per Article 314-6(7)
@@ -185,9 +185,9 @@ describe('Adjustment Credit - Spouse Special Deduction (配偶者特別控除)',
 
         const taxpayerIncome = 8_000_000
         const socialInsurance = 1_000_000
-        const dependents = calculateDependentDeductions([spouse], undefined, 2026)
+        const dependents = calculateDependentDeductions([spouse], 2026)
         
-        const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+        const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
         
         // All spouse special deduction cases have 0 statutory difference
         expect(result.personalDeductionDifference).toBe(50_000)
@@ -213,9 +213,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) = 100,000
       expect(result.personalDeductionDifference).toBe(100_000)
@@ -236,9 +236,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) = 100,000
       expect(result.personalDeductionDifference).toBe(100_000)
@@ -261,9 +261,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 180,000 (special dependent) = 230,000
       expect(result.personalDeductionDifference).toBe(230_000)
@@ -286,9 +286,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 100,000 (elderly dependent) = 150,000
       expect(result.personalDeductionDifference).toBe(150_000)
@@ -309,9 +309,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 130,000 (elderly cohabiting) = 180,000
       expect(result.personalDeductionDifference).toBe(180_000)
@@ -332,9 +332,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 130,000 (elderly cohabiting) = 180,000
       expect(result.personalDeductionDifference).toBe(180_000)
@@ -359,9 +359,9 @@ describe('Adjustment Credit - Disability Deductions (障害者控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) + 10,000 (regular disability) = 110,000
       expect(result.personalDeductionDifference).toBe(110_000)
@@ -384,9 +384,9 @@ describe('Adjustment Credit - Disability Deductions (障害者控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) + 100,000 (special disability) = 200,000
       expect(result.personalDeductionDifference).toBe(200_000)
@@ -407,9 +407,9 @@ describe('Adjustment Credit - Disability Deductions (障害者控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+      const dependents = calculateDependentDeductions([dependent], 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) + 220,000 (special cohabiting disability) = 320,000
       expect(result.personalDeductionDifference).toBe(320_000)
@@ -457,9 +457,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([spouse, child1, child2], undefined, 2026)
+    const dependents = calculateDependentDeductions([spouse, child1, child2], 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -498,9 +498,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([spouse, parent], undefined, 2026)
+    const dependents = calculateDependentDeductions([spouse, parent], 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -539,9 +539,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
     // Test with taxpayer income in 950-1000万円 bracket
     const taxpayerIncome = 9_700_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([spouse, child], undefined, 2026)
+    const dependents = calculateDependentDeductions([spouse, child], 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -581,9 +581,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependentResults = calculateDependentDeductions(dependents, undefined, 2026)
+    const dependentResults = calculateDependentDeductions(dependents, 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependentResults, 0, 2026)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependentResults, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -633,12 +633,12 @@ describe('Specific Relative Special Deduction (特定親族特別控除)', () =>
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([dependent], undefined, 2026)
+    const dependents = calculateDependentDeductions([dependent], 2026)
 
     expect(dependents.breakdown).toHaveLength(1)
     expect(dependents.breakdown[0]!.deductionType).toBe(DEDUCTION_TYPES.SPECIFIC_RELATIVE_SPECIAL)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000

--- a/src/__tests__/adjustment-credit.test.ts
+++ b/src/__tests__/adjustment-credit.test.ts
@@ -34,9 +34,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income ≤ 900万円 → 5万円 statutory difference', () => {
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse])
+      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (spouse) = 100,000
       expect(result.personalDeductionDifference).toBe(100_000)
@@ -53,9 +53,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 900-950万円 → 4万円 statutory difference', () => {
       const taxpayerIncome = 9_200_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse])
+      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 40,000 (spouse) = 90,000
       expect(result.personalDeductionDifference).toBe(90_000)
@@ -64,9 +64,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 950-1000万円 → 2万円 statutory difference', () => {
       const taxpayerIncome = 9_700_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse])
+      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 20,000 (spouse) = 70,000
       expect(result.personalDeductionDifference).toBe(70_000)
@@ -75,9 +75,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income > 1000万円 → 0 statutory difference (no spouse deduction)', () => {
       const taxpayerIncome = 11_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse])
+      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 0 (no spouse deduction) = 50,000
       expect(result.personalDeductionDifference).toBe(50_000)
@@ -100,9 +100,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income ≤ 900万円 → 10万円 statutory difference', () => {
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([elderlySpouse])
+      const dependents = calculateDependentDeductions([elderlySpouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 100,000 (elderly spouse) = 150,000
       expect(result.personalDeductionDifference).toBe(150_000)
@@ -111,9 +111,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 900-950万円 → 6万円 statutory difference', () => {
       const taxpayerIncome = 9_200_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([elderlySpouse])
+      const dependents = calculateDependentDeductions([elderlySpouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 60,000 (elderly spouse) = 110,000
       expect(result.personalDeductionDifference).toBe(110_000)
@@ -122,9 +122,9 @@ describe('Adjustment Credit - Spouse Deduction (配偶者控除)', () => {
     it('taxpayer income 950-1000万円 → 3万円 statutory difference', () => {
       const taxpayerIncome = 9_700_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([elderlySpouse])
+      const dependents = calculateDependentDeductions([elderlySpouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 30,000 (elderly spouse) = 80,000
       expect(result.personalDeductionDifference).toBe(80_000)
@@ -149,9 +149,9 @@ describe('Adjustment Credit - Spouse Special Deduction (配偶者特別控除)',
     it('statutory difference is 0 (mutually exclusive income ranges)', () => {
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([spouse])
+      const dependents = calculateDependentDeductions([spouse], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 0 (spouse special) = 50,000
       // Spouse special deduction has NO statutory difference per Article 314-6(7)
@@ -185,9 +185,9 @@ describe('Adjustment Credit - Spouse Special Deduction (配偶者特別控除)',
 
         const taxpayerIncome = 8_000_000
         const socialInsurance = 1_000_000
-        const dependents = calculateDependentDeductions([spouse])
+        const dependents = calculateDependentDeductions([spouse], undefined, 2026)
         
-        const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+        const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
         
         // All spouse special deduction cases have 0 statutory difference
         expect(result.personalDeductionDifference).toBe(50_000)
@@ -213,9 +213,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) = 100,000
       expect(result.personalDeductionDifference).toBe(100_000)
@@ -236,9 +236,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) = 100,000
       expect(result.personalDeductionDifference).toBe(100_000)
@@ -261,9 +261,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 180,000 (special dependent) = 230,000
       expect(result.personalDeductionDifference).toBe(230_000)
@@ -286,9 +286,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 100,000 (elderly dependent) = 150,000
       expect(result.personalDeductionDifference).toBe(150_000)
@@ -309,9 +309,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 130,000 (elderly cohabiting) = 180,000
       expect(result.personalDeductionDifference).toBe(180_000)
@@ -332,9 +332,9 @@ describe('Adjustment Credit - Dependent Deductions (扶養控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 130,000 (elderly cohabiting) = 180,000
       expect(result.personalDeductionDifference).toBe(180_000)
@@ -359,9 +359,9 @@ describe('Adjustment Credit - Disability Deductions (障害者控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) + 10,000 (regular disability) = 110,000
       expect(result.personalDeductionDifference).toBe(110_000)
@@ -384,9 +384,9 @@ describe('Adjustment Credit - Disability Deductions (障害者控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) + 100,000 (special disability) = 200,000
       expect(result.personalDeductionDifference).toBe(200_000)
@@ -407,9 +407,9 @@ describe('Adjustment Credit - Disability Deductions (障害者控除)', () => {
 
       const taxpayerIncome = 8_000_000
       const socialInsurance = 1_000_000
-      const dependents = calculateDependentDeductions([dependent])
+      const dependents = calculateDependentDeductions([dependent], undefined, 2026)
       
-      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+      const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
       
       // Personal deduction difference = 50,000 (basic) + 50,000 (general dependent) + 220,000 (special cohabiting disability) = 320,000
       expect(result.personalDeductionDifference).toBe(320_000)
@@ -457,9 +457,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([spouse, child1, child2])
+    const dependents = calculateDependentDeductions([spouse, child1, child2], undefined, 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -498,9 +498,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([spouse, parent])
+    const dependents = calculateDependentDeductions([spouse, parent], undefined, 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -539,9 +539,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
     // Test with taxpayer income in 950-1000万円 bracket
     const taxpayerIncome = 9_700_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([spouse, child])
+    const dependents = calculateDependentDeductions([spouse, child], undefined, 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -581,9 +581,9 @@ describe('Adjustment Credit - Combined Scenarios', () => {
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependentResults = calculateDependentDeductions(dependents)
+    const dependentResults = calculateDependentDeductions(dependents, undefined, 2026)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependentResults)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependentResults, 0, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000
@@ -633,12 +633,12 @@ describe('Specific Relative Special Deduction (特定親族特別控除)', () =>
 
     const taxpayerIncome = 8_000_000
     const socialInsurance = 1_000_000
-    const dependents = calculateDependentDeductions([dependent])
+    const dependents = calculateDependentDeductions([dependent], undefined, 2026)
 
     expect(dependents.breakdown).toHaveLength(1)
     expect(dependents.breakdown[0]!.deductionType).toBe(DEDUCTION_TYPES.SPECIFIC_RELATIVE_SPECIAL)
     
-    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents)
+    const result = calculateResidenceTax(taxpayerIncome, socialInsurance, dependents, 0, 2026)
     
     // Personal deduction difference breakdown:
     // - Basic: 50,000

--- a/src/__tests__/capDetection.test.ts
+++ b/src/__tests__/capDetection.test.ts
@@ -2,19 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect } from 'vitest';
-import { detectCaps as detectCapsForYear } from '../utils/capDetection';
+import { detectCaps } from '../utils/capDetection';
 import { calculateNationalHealthInsurancePremiumWithBreakdown } from '../utils/healthInsuranceCalculator';
 import type { TakeHomeResults, ResidenceTaxDetails, FurusatoNozeiDetails } from '../types/tax';
 import { DEFAULT_PROVIDER, NATIONAL_HEALTH_INSURANCE_ID } from '../types/healthInsurance';
 import type { EmployeesHealthInsuranceBonusBreakdownItem } from '../utils/healthInsuranceCalculator';
 
-// detectCaps now requires an income year. A thin wrapper defaults it to 2026 (the suite's prior
-// behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
 const TEST_INCOME_YEAR = 2026;
-const detectCaps = (
-  results: Parameters<typeof detectCapsForYear>[0],
-  healthInsuranceBonusBreakdown?: Parameters<typeof detectCapsForYear>[2], year: number = TEST_INCOME_YEAR,
-) => detectCapsForYear(results, year, healthInsuranceBonusBreakdown);
 
 // Mock TakeHomeResults with necessary fields
 const createMockResults = (overrides: Partial<TakeHomeResults>): TakeHomeResults => ({
@@ -49,7 +43,7 @@ describe('detectCaps', () => {
             healthInsuranceProvider: DEFAULT_PROVIDER,
         });
 
-        const caps = detectCaps(results);
+        const caps = detectCaps(results, TEST_INCOME_YEAR);
 
         expect(caps.healthInsuranceCapped).toBe(false);
         expect(caps.pensionCapped).toBe(false);
@@ -65,7 +59,7 @@ describe('detectCaps', () => {
             healthInsuranceProvider: DEFAULT_PROVIDER,
         });
 
-        const caps = detectCaps(results);
+        const caps = detectCaps(results, TEST_INCOME_YEAR);
 
         expect(caps.healthInsuranceCapped).toBe(true);
         expect(caps.pensionCapped).toBe(true);
@@ -81,7 +75,7 @@ describe('detectCaps', () => {
             isSubjectToLongTermCarePremium: false,
         });
 
-        const caps = detectCaps(results, undefined, 2026);
+        const caps = detectCaps(results, TEST_INCOME_YEAR);
 
         expect(caps.healthInsuranceCapped).toBe(false);
         expect(caps.healthInsuranceCapDetails?.childSupportCapped).toBe(false);
@@ -100,7 +94,7 @@ describe('detectCaps', () => {
             healthInsuranceProvider: DEFAULT_PROVIDER,
         });
 
-        const caps = detectCaps(results);
+        const caps = detectCaps(results, TEST_INCOME_YEAR);
 
         expect(caps.pensionCapped).toBe(false);
         expect(caps.healthInsuranceCapped).toBe(false);
@@ -122,7 +116,7 @@ describe('detectCaps', () => {
             includesLongTermCare: false
         }];
 
-        const caps = detectCaps(results, breakdown);
+        const caps = detectCaps(results, TEST_INCOME_YEAR, breakdown);
 
         expect(caps.healthInsuranceBonusCapped).toBe(true);
     });
@@ -142,7 +136,7 @@ describe('detectCaps', () => {
             includesLongTermCare: false
         }];
 
-        const caps = detectCaps(results, breakdown);
+        const caps = detectCaps(results, TEST_INCOME_YEAR, breakdown);
 
         expect(caps.healthInsuranceBonusCapped).toBe(false);
     });
@@ -169,7 +163,7 @@ describe('NHI cap detection with real calculator output', () => {
             isSubjectToLongTermCarePremium: false,
         });
 
-        const caps = detectCaps(results, undefined, 2026);
+        const caps = detectCaps(results, TEST_INCOME_YEAR);
 
         expect(caps.healthInsuranceCapped).toBe(true);
         expect(caps.healthInsuranceCapDetails?.medicalCapped).toBe(true);
@@ -193,7 +187,7 @@ describe('NHI cap detection with real calculator output', () => {
             isSubjectToLongTermCarePremium: true,
         });
 
-        const caps = detectCaps(results, undefined, 2026);
+        const caps = detectCaps(results, TEST_INCOME_YEAR);
 
         expect(caps.healthInsuranceCapped).toBe(true);
         expect(caps.healthInsuranceCapDetails?.medicalCapped).toBe(true);
@@ -218,7 +212,7 @@ describe('NHI cap detection with real calculator output', () => {
             isSubjectToLongTermCarePremium: false,
         });
 
-        const caps = detectCaps(results, undefined, 2026);
+        const caps = detectCaps(results, TEST_INCOME_YEAR);
 
         expect(caps.healthInsuranceCapped).toBe(false);
         expect(caps.healthInsuranceCapDetails?.medicalCapped).toBe(false);

--- a/src/__tests__/capDetection.test.ts
+++ b/src/__tests__/capDetection.test.ts
@@ -2,11 +2,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect } from 'vitest';
-import { detectCaps } from '../utils/capDetection';
+import { detectCaps as detectCapsForYear } from '../utils/capDetection';
 import { calculateNationalHealthInsurancePremiumWithBreakdown } from '../utils/healthInsuranceCalculator';
 import type { TakeHomeResults, ResidenceTaxDetails, FurusatoNozeiDetails } from '../types/tax';
 import { DEFAULT_PROVIDER, NATIONAL_HEALTH_INSURANCE_ID } from '../types/healthInsurance';
 import type { EmployeesHealthInsuranceBonusBreakdownItem } from '../utils/healthInsuranceCalculator';
+
+// detectCaps now requires an income year. A thin wrapper defaults it to 2026 (the suite's prior
+// behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
+const TEST_INCOME_YEAR = 2026;
+const detectCaps = (
+  results: Parameters<typeof detectCapsForYear>[0],
+  healthInsuranceBonusBreakdown?: Parameters<typeof detectCapsForYear>[1], year: number = TEST_INCOME_YEAR,
+) => detectCapsForYear(results, healthInsuranceBonusBreakdown, year);
 
 // Mock TakeHomeResults with necessary fields
 const createMockResults = (overrides: Partial<TakeHomeResults>): TakeHomeResults => ({

--- a/src/__tests__/capDetection.test.ts
+++ b/src/__tests__/capDetection.test.ts
@@ -13,8 +13,8 @@ import type { EmployeesHealthInsuranceBonusBreakdownItem } from '../utils/health
 const TEST_INCOME_YEAR = 2026;
 const detectCaps = (
   results: Parameters<typeof detectCapsForYear>[0],
-  healthInsuranceBonusBreakdown?: Parameters<typeof detectCapsForYear>[1], year: number = TEST_INCOME_YEAR,
-) => detectCapsForYear(results, healthInsuranceBonusBreakdown, year);
+  healthInsuranceBonusBreakdown?: Parameters<typeof detectCapsForYear>[2], year: number = TEST_INCOME_YEAR,
+) => detectCapsForYear(results, year, healthInsuranceBonusBreakdown);
 
 // Mock TakeHomeResults with necessary fields
 const createMockResults = (overrides: Partial<TakeHomeResults>): TakeHomeResults => ({
@@ -156,7 +156,7 @@ describe('NHI cap detection with real calculator output', () => {
     it('detects all NHI portion caps at very high income (Chiyoda, no LTC)', () => {
         const region = 'Tokyo-Chiyoda';
         const breakdown = calculateNationalHealthInsurancePremiumWithBreakdown(
-            50_000_000, false, region, 2026
+            50_000_000, false, 2026, region
         );
 
         const results = createMockResults({
@@ -180,7 +180,7 @@ describe('NHI cap detection with real calculator output', () => {
     it('detects all NHI portion caps at very high income (Chiyoda, with LTC)', () => {
         const region = 'Tokyo-Chiyoda';
         const breakdown = calculateNationalHealthInsurancePremiumWithBreakdown(
-            50_000_000, true, region, 2026
+            50_000_000, true, 2026, region
         );
 
         const results = createMockResults({
@@ -205,7 +205,7 @@ describe('NHI cap detection with real calculator output', () => {
     it('does not flag caps at moderate income (Chiyoda)', () => {
         const region = 'Tokyo-Chiyoda';
         const breakdown = calculateNationalHealthInsurancePremiumWithBreakdown(
-            5_000_000, false, region, 2026
+            5_000_000, false, 2026, region
         );
 
         const results = createMockResults({

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -3,54 +3,45 @@
 
 import { describe, expect, it } from 'vitest'
 import {
-  calculateDependentDeductions as calculateDependentDeductionsForYear,
-  calculateDependentTotalNetIncome as calculateDependentTotalNetIncomeForYear,
+  calculateDependentDeductions,
+  calculateDependentTotalNetIncome,
   hasIncomeAdjustmentDeductionDependent,
 } from '../utils/dependentDeductions'
 import { calculateIncomeAdjustmentDeductionAmount } from '../data/netEmploymentIncome'
 import { DEDUCTION_TYPES, type Dependent } from '../types/dependents'
 
-// These calculators now require an income year. Thin wrappers default it to 2026 (the suite's
-// prior behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
 const TEST_INCOME_YEAR = 2026;
-type DepDeductionsArgs = Parameters<typeof calculateDependentDeductionsForYear>;
-const calculateDependentDeductions = (
-  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[2], year: number = TEST_INCOME_YEAR,
-) => calculateDependentDeductionsForYear(dependents, year, taxpayerNetIncome);
-const calculateDependentTotalNetIncome = (
-  income: Parameters<typeof calculateDependentTotalNetIncomeForYear>[0], year: number = TEST_INCOME_YEAR,
-) => calculateDependentTotalNetIncomeForYear(income, year);
 
 // --- Helper functions to test internal logic via public API ---
 
 function isEligibleForDependentDeduction(dependent: Dependent, year?: number): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000, year);
+  const result = calculateDependentDeductions([dependent], year ?? TEST_INCOME_YEAR, 5000000);
   return result.nationalTax.dependentDeduction > 0;
 }
 
 function isEligibleForSpouseDeduction(dependent: Dependent, year?: number): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000, year);
+  const result = calculateDependentDeductions([dependent], year ?? TEST_INCOME_YEAR, 5000000);
   return result.nationalTax.spouseDeduction > 0;
 }
 
 function isEligibleForSpouseSpecialDeduction(dependent: Dependent, year?: number): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000, year);
+  const result = calculateDependentDeductions([dependent], year ?? TEST_INCOME_YEAR, 5000000);
   return result.nationalTax.spouseSpecialDeduction > 0;
 }
 
 function isEligibleForSpecificRelativeSpecialDeduction(dependent: Dependent, year?: number): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000, year);
+  const result = calculateDependentDeductions([dependent], year ?? TEST_INCOME_YEAR, 5000000);
   return result.nationalTax.specificRelativeDeduction > 0;
 }
 
 function isSpecialDependent(dependent: Dependent): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000);
+  const result = calculateDependentDeductions([dependent], TEST_INCOME_YEAR, 5000000);
   // Special dependent deduction amount is 630,000
   return result.nationalTax.dependentDeduction === 630000;
 }
 
 function isElderlyDependent(dependent: Dependent): boolean {
-  const result = calculateDependentDeductions([dependent], 5000000);
+  const result = calculateDependentDeductions([dependent], TEST_INCOME_YEAR, 5000000);
   // Elderly dependent deduction amount is 480,000 or 580,000 (cohabiting parent)
   return result.nationalTax.dependentDeduction === 480000 || result.nationalTax.dependentDeduction === 580000;
 }
@@ -67,7 +58,7 @@ function getSpouseSpecialDeduction(spouseNetIncome: number, taxpayerNetIncome: n
       otherNetIncome: spouseNetIncome,
     },
   };
-  const result = calculateDependentDeductions([spouse], taxpayerNetIncome, year);
+  const result = calculateDependentDeductions([spouse], year ?? TEST_INCOME_YEAR, taxpayerNetIncome);
   return {
     national: result.nationalTax.spouseSpecialDeduction,
     residence: result.residenceTax.spouseSpecialDeduction
@@ -86,7 +77,7 @@ function getSpecificRelativeDeduction(dependentNetIncome: number, year?: number)
       otherNetIncome: dependentNetIncome,
     },
   };
-  const result = calculateDependentDeductions([dependent], 5000000, year);
+  const result = calculateDependentDeductions([dependent], year ?? TEST_INCOME_YEAR, 5000000);
   return {
     national: result.nationalTax.specificRelativeDeduction,
     residence: result.residenceTax.specificRelativeDeduction
@@ -109,7 +100,7 @@ function getSpouseDeduction(isElderly: boolean, taxpayerNetIncome: number) {
     },
   };
   
-  const results = calculateDependentDeductions([dependent], taxpayerNetIncome);
+  const results = calculateDependentDeductions([dependent], TEST_INCOME_YEAR, taxpayerNetIncome);
   return {
     national: results.nationalTax.spouseDeduction,
     residence: results.residenceTax.spouseDeduction
@@ -849,7 +840,7 @@ describe('Total Net Income Calculation with Other Income', () => {
       grossEmploymentIncome: 1_000_000, // Net = 260,000
       otherNetIncome: 200_000,
     }
-    expect(calculateDependentTotalNetIncome(income)).toBe(460_000)
+    expect(calculateDependentTotalNetIncome(income, TEST_INCOME_YEAR)).toBe(460_000)
   })
 
   it('threshold applies to total net income (employment + other)', () => {
@@ -1275,25 +1266,25 @@ describe('Integration: calculateDependentDeductions with Taxpayer Income', () =>
     }
 
     it('full deduction when taxpayer income ≤ 9,000,000', () => {
-      const result = calculateDependentDeductions([spouse], 8_000_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 8_000_000)
       expect(result.nationalTax.spouseDeduction).toBe(380_000)
       expect(result.residenceTax.spouseDeduction).toBe(330_000)
     })
 
     it('reduced deduction when taxpayer income 9,000,001 - 9,500,000', () => {
-      const result = calculateDependentDeductions([spouse], 9_200_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 9_200_000)
       expect(result.nationalTax.spouseDeduction).toBe(260_000)
       expect(result.residenceTax.spouseDeduction).toBe(220_000)
     })
 
     it('further reduced when taxpayer income 9,500,001 - 10,000,000', () => {
-      const result = calculateDependentDeductions([spouse], 9_700_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 9_700_000)
       expect(result.nationalTax.spouseDeduction).toBe(130_000)
       expect(result.residenceTax.spouseDeduction).toBe(110_000)
     })
 
     it('no deduction when taxpayer income > 10,000,000', () => {
-      const result = calculateDependentDeductions([spouse], 11_000_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 11_000_000)
       expect(result.nationalTax.spouseDeduction).toBe(0)
       expect(result.residenceTax.spouseDeduction).toBe(0)
     })
@@ -1313,25 +1304,25 @@ describe('Integration: calculateDependentDeductions with Taxpayer Income', () =>
     }
 
     it('full deduction when taxpayer income ≤ 9,000,000', () => {
-      const result = calculateDependentDeductions([spouse], 8_000_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 8_000_000)
       expect(result.nationalTax.spouseSpecialDeduction).toBe(360_000)
       expect(result.residenceTax.spouseSpecialDeduction).toBe(330_000)
     })
 
     it('reduced deduction when taxpayer income 9,000,001 - 9,500,000', () => {
-      const result = calculateDependentDeductions([spouse], 9_200_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 9_200_000)
       expect(result.nationalTax.spouseSpecialDeduction).toBe(240_000)
       expect(result.residenceTax.spouseSpecialDeduction).toBe(220_000)
     })
 
     it('further reduced when taxpayer income 9,500,001 - 10,000,000', () => {
-      const result = calculateDependentDeductions([spouse], 9_700_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 9_700_000)
       expect(result.nationalTax.spouseSpecialDeduction).toBe(120_000)
       expect(result.residenceTax.spouseSpecialDeduction).toBe(110_000)
     })
 
     it('no deduction when taxpayer income > 10,000,000', () => {
-      const result = calculateDependentDeductions([spouse], 11_000_000)
+      const result = calculateDependentDeductions([spouse], TEST_INCOME_YEAR, 11_000_000)
       expect(result.nationalTax.spouseSpecialDeduction).toBe(0)
       expect(result.residenceTax.spouseSpecialDeduction).toBe(0)
     })
@@ -1351,25 +1342,25 @@ describe('Integration: calculateDependentDeductions with Taxpayer Income', () =>
     }
 
     it('full elderly spouse deduction when taxpayer income ≤ 9,000,000', () => {
-      const result = calculateDependentDeductions([elderlySpouse], 8_000_000)
+      const result = calculateDependentDeductions([elderlySpouse], TEST_INCOME_YEAR, 8_000_000)
       expect(result.nationalTax.spouseDeduction).toBe(480_000)
       expect(result.residenceTax.spouseDeduction).toBe(380_000)
     })
 
     it('reduced elderly spouse deduction when taxpayer income 9,000,001 - 9,500,000', () => {
-      const result = calculateDependentDeductions([elderlySpouse], 9_200_000)
+      const result = calculateDependentDeductions([elderlySpouse], TEST_INCOME_YEAR, 9_200_000)
       expect(result.nationalTax.spouseDeduction).toBe(320_000)
       expect(result.residenceTax.spouseDeduction).toBe(260_000)
     })
 
     it('further reduced when taxpayer income 9,500,001 - 10,000,000', () => {
-      const result = calculateDependentDeductions([elderlySpouse], 9_700_000)
+      const result = calculateDependentDeductions([elderlySpouse], TEST_INCOME_YEAR, 9_700_000)
       expect(result.nationalTax.spouseDeduction).toBe(160_000)
       expect(result.residenceTax.spouseDeduction).toBe(130_000)
     })
 
     it('no deduction when taxpayer income > 10,000,000', () => {
-      const result = calculateDependentDeductions([elderlySpouse], 11_000_000)
+      const result = calculateDependentDeductions([elderlySpouse], TEST_INCOME_YEAR, 11_000_000)
       expect(result.nationalTax.spouseDeduction).toBe(0)
       expect(result.residenceTax.spouseDeduction).toBe(0)
     })
@@ -1389,9 +1380,9 @@ describe('Integration: calculateDependentDeductions with Taxpayer Income', () =>
     }
 
     it('dependent deduction remains constant regardless of taxpayer income', () => {
-      const result1 = calculateDependentDeductions([child], 5_000_000)
-      const result2 = calculateDependentDeductions([child], 9_500_000)
-      const result3 = calculateDependentDeductions([child], 11_000_000)
+      const result1 = calculateDependentDeductions([child], TEST_INCOME_YEAR, 5_000_000)
+      const result2 = calculateDependentDeductions([child], TEST_INCOME_YEAR, 9_500_000)
+      const result3 = calculateDependentDeductions([child], TEST_INCOME_YEAR, 11_000_000)
       
       expect(result1.nationalTax.dependentDeduction).toBe(630_000)
       expect(result2.nationalTax.dependentDeduction).toBe(630_000)
@@ -1414,7 +1405,7 @@ describe('Dependent Deductions - Under 16', () => {
       },
     }
 
-    const result = calculateDependentDeductions([dependent], 5000000)
+    const result = calculateDependentDeductions([dependent], TEST_INCOME_YEAR, 5000000)
     
     // Should have 0 deduction
     expect(result.nationalTax.dependentDeduction).toBe(0)
@@ -1438,7 +1429,7 @@ describe('Dependent Deductions - Under 16', () => {
       },
     }
 
-    const result = calculateDependentDeductions([dependent], 5000000)
+    const result = calculateDependentDeductions([dependent], TEST_INCOME_YEAR, 5000000)
     
     // Should have disability deduction
     expect(result.nationalTax.disabilityDeduction).toBeGreaterThan(0)

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -15,8 +15,8 @@ import { DEDUCTION_TYPES, type Dependent } from '../types/dependents'
 const TEST_INCOME_YEAR = 2026;
 type DepDeductionsArgs = Parameters<typeof calculateDependentDeductionsForYear>;
 const calculateDependentDeductions = (
-  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[1], year: number = TEST_INCOME_YEAR,
-) => calculateDependentDeductionsForYear(dependents, taxpayerNetIncome, year);
+  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[2], year: number = TEST_INCOME_YEAR,
+) => calculateDependentDeductionsForYear(dependents, year, taxpayerNetIncome);
 const calculateDependentTotalNetIncome = (
   income: Parameters<typeof calculateDependentTotalNetIncomeForYear>[0], year: number = TEST_INCOME_YEAR,
 ) => calculateDependentTotalNetIncomeForYear(income, year);

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -3,12 +3,23 @@
 
 import { describe, expect, it } from 'vitest'
 import {
-  calculateDependentDeductions,
-  calculateDependentTotalNetIncome,
+  calculateDependentDeductions as calculateDependentDeductionsForYear,
+  calculateDependentTotalNetIncome as calculateDependentTotalNetIncomeForYear,
   hasIncomeAdjustmentDeductionDependent,
 } from '../utils/dependentDeductions'
 import { calculateIncomeAdjustmentDeductionAmount } from '../data/netEmploymentIncome'
 import { DEDUCTION_TYPES, type Dependent } from '../types/dependents'
+
+// These calculators now require an income year. Thin wrappers default it to 2026 (the suite's
+// prior behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
+const TEST_INCOME_YEAR = 2026;
+type DepDeductionsArgs = Parameters<typeof calculateDependentDeductionsForYear>;
+const calculateDependentDeductions = (
+  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[1], year: number = TEST_INCOME_YEAR,
+) => calculateDependentDeductionsForYear(dependents, taxpayerNetIncome, year);
+const calculateDependentTotalNetIncome = (
+  income: Parameters<typeof calculateDependentTotalNetIncomeForYear>[0], year: number = TEST_INCOME_YEAR,
+) => calculateDependentTotalNetIncomeForYear(income, year);
 
 // --- Helper functions to test internal logic via public API ---
 

--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -1,15 +1,10 @@
 // Copyright the original author or authors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { calculateTaxes } from '../utils/taxCalculations';
 import { DEFAULT_PROVIDER } from '../types/healthInsurance';
 import type { FurusatoNozeiDetails } from '../types/tax';
-
-// Pin the clock for any date-dependent defaults. Year-specific rates (insurance,
-// deductions) are driven by each input's incomeYear, not the clock.
-beforeAll(() => { vi.useFakeTimers({ now: new Date(2025, 5, 1) }) })
-afterAll(() => { vi.useRealTimers() })
 
 describe('calculateFurusatoNozeiLimit', () => {
 

--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -6,7 +6,8 @@ import { calculateTaxes } from '../utils/taxCalculations';
 import { DEFAULT_PROVIDER } from '../types/healthInsurance';
 import type { FurusatoNozeiDetails } from '../types/tax';
 
-// Pin the year so employment insurance rate lookups are deterministic.
+// Pin the clock for any date-dependent defaults. Year-specific rates (insurance,
+// deductions) are driven by each input's incomeYear, not the clock.
 beforeAll(() => { vi.useFakeTimers({ now: new Date(2025, 5, 1) }) })
 afterAll(() => { vi.useRealTimers() })
 
@@ -23,24 +24,24 @@ describe('calculateFurusatoNozeiLimit', () => {
   it('calculates furusato nozei for the salary with lower out-of-pocket cost', () => {
     const fn = calculateFNForIncome(6_000_000);
     expect(fn.limit).toBe(77_000);
-    expect(fn.outOfPocketCost).toBe(1_900);
+    expect(fn.outOfPocketCost).toBe(2_100);
     expect(fn.incomeTaxReduction).toBe(7_600);
-    expect(fn.residenceTaxReduction).toBe(67_500);
+    expect(fn.residenceTaxReduction).toBe(67_300);
   });
 
   it('calculates furusato nozei for the salary with slightly higher out-of-pocket cost', () => {
     const fn = calculateFNForIncome(8_800_000);
     expect(fn.limit).toBe(151_000);
-    expect(fn.outOfPocketCost).toBe(2_000);
+    expect(fn.outOfPocketCost).toBe(1_800);
     expect(fn.incomeTaxReduction).toBe(30_500);
-    expect(fn.residenceTaxReduction).toBe(118_500);
+    expect(fn.residenceTaxReduction).toBe(118_700);
   });
 
   it('high-income salary, high out-of-pocket cost', () => {
     const fn = calculateFNForIncome(13_000_000);
-    expect(fn.outOfPocketCost).toBe(35_200);
+    expect(fn.outOfPocketCost).toBe(35_100);
     expect(fn.limit).toBe(327_000);
-    expect(fn.incomeTaxReduction).toBe(76_300);
+    expect(fn.incomeTaxReduction).toBe(76_400);
     expect(fn.residenceTaxReduction).toBe(215_500);
   });
 

--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -327,6 +327,7 @@ describe('calculateFurusatoNozeiLimit', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: true,
       manualSocialInsuranceAmount: 1_000_000, // Higher than standard ~726k
+      incomeYear: 2026,
     }).furusatoNozei;
 
     expect(fnWithHighSocialInsurance.limit).toBeLessThan(62_000);
@@ -341,6 +342,7 @@ describe('calculateFurusatoNozeiLimit', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: true,
       manualSocialInsuranceAmount: 500_000, // Lower than standard ~726k
+      incomeYear: 2026,
     }).furusatoNozei;
 
     expect(fnWithLowSocialInsurance.limit).toBeGreaterThan(62_000);

--- a/src/__tests__/healthInsuranceCalculator.test.ts
+++ b/src/__tests__/healthInsuranceCalculator.test.ts
@@ -3,65 +3,43 @@
 
 import { describe, it, expect } from 'vitest'
 import {
-  calculateHealthInsurancePremium as calculateHealthInsurancePremiumForYear,
-  calculateHealthInsuranceBreakdown as calculateHealthInsuranceBreakdownForYear,
-  calculateEmployeesHealthInsuranceBonusBreakdown as calculateEmployeesHealthInsuranceBonusBreakdownForYear,
+  calculateHealthInsurancePremium,
+  calculateHealthInsuranceBreakdown,
+  calculateEmployeesHealthInsuranceBonusBreakdown,
 } from '../utils/healthInsuranceCalculator'
 import { DEFAULT_PROVIDER_REGION, NATIONAL_HEALTH_INSURANCE_ID, DEFAULT_PROVIDER, CUSTOM_PROVIDER_ID } from '../types/healthInsurance'
 
 const KYOKAI_KENPO_PROVIDER = DEFAULT_PROVIDER;
 const ITS_KENPO_PROVIDER = 'KantoItsKenpo';
 
-// The underlying functions now require an income year. Most cases here assert FY2025 rates, so
-// these thin wrappers default the year to FY2025 (a fake clock used to pin it) so rate lookups
-// don't depend on the run date, while still honoring an explicit year where a case passes one
-// (e.g. the FY2026 time-series tests). Call sites stay unchanged.
 const FY2025 = 2025;
-// The real functions take year right after the required params (income, ltc, provider). These
-// wrappers keep the old call-site argument order (…, region, customRates, bonuses) and forward in
-// the real order, defaulting the year to FY2025 unless a case passes one.
-type PremiumArgs = Parameters<typeof calculateHealthInsurancePremiumForYear>;
-const calculateHealthInsurancePremium = (
-  income: PremiumArgs[0], ltc: PremiumArgs[1], provider: PremiumArgs[2],
-  region?: PremiumArgs[4], customRates?: PremiumArgs[5], bonuses?: PremiumArgs[6], year: number = FY2025,
-): number => calculateHealthInsurancePremiumForYear(income, ltc, provider, year, region, customRates, bonuses);
-type BreakdownArgs = Parameters<typeof calculateHealthInsuranceBreakdownForYear>;
-const calculateHealthInsuranceBreakdown = (
-  income: BreakdownArgs[0], ltc: BreakdownArgs[1], provider: BreakdownArgs[2],
-  region?: BreakdownArgs[4], customRates?: BreakdownArgs[5], bonuses?: BreakdownArgs[6], year: number = FY2025,
-) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, year, region, customRates, bonuses);
-type BonusArgs = Parameters<typeof calculateEmployeesHealthInsuranceBonusBreakdownForYear>;
-const calculateEmployeesHealthInsuranceBonusBreakdown = (
-  bonuses: BonusArgs[0], providerOrRates: BonusArgs[1], regionOrLTC: BonusArgs[2],
-  ltc?: BonusArgs[4], year: number = FY2025,
-) => calculateEmployeesHealthInsuranceBonusBreakdownForYear(bonuses, providerOrRates, regionOrLTC, year, ltc);
 
 describe('calculateHealthInsurancePremium for employees', () => {
   describe('Kyokai Kenpo (Tokyo)', () => {
     it('calculates premium for people under 40', () => {
-      expect(calculateHealthInsurancePremium(5_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo")).toBe(243_780)
+      expect(calculateHealthInsurancePremium(5_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toBe(243_780)
     })
 
     it('calculates employees health insurance premium for people under 40 with cap', () => {
-      expect(calculateHealthInsurancePremium(20_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo")).toBe(826_488)
+      expect(calculateHealthInsurancePremium(20_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toBe(826_488)
     })
 
     it('calculates employees health insurance premium with nursing care for people over 40', () => {
-      expect(calculateHealthInsurancePremium(5_000_000, true, KYOKAI_KENPO_PROVIDER, "Tokyo")).toBe(282_900)
+      expect(calculateHealthInsurancePremium(5_000_000, true, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toBe(282_900)
     })
 
     it('calculates employees health insurance premium with nursing care for people over 40 with cap', () => {
-      expect(calculateHealthInsurancePremium(20_000_000, true, KYOKAI_KENPO_PROVIDER, "Tokyo")).toBe(959_100)
+      expect(calculateHealthInsurancePremium(20_000_000, true, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toBe(959_100)
     })
 
     it('handles zero income correctly', () => {
-      expect(calculateHealthInsurancePremium(0, false, KYOKAI_KENPO_PROVIDER, "Tokyo")).toBe(34_488)
-      expect(calculateHealthInsurancePremium(0, true, KYOKAI_KENPO_PROVIDER, "Tokyo")).toBe(40_020)
+      expect(calculateHealthInsurancePremium(0, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toBe(34_488)
+      expect(calculateHealthInsurancePremium(0, true, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toBe(40_020)
     })
 
     it('handles negative income correctly', () => {
-      expect(() => calculateHealthInsurancePremium(-1_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo")).toThrowError('Income cannot be negative.')
-      expect(() => calculateHealthInsurancePremium(-1_000_000, true, KYOKAI_KENPO_PROVIDER, "Tokyo")).toThrowError('Income cannot be negative.')
+      expect(() => calculateHealthInsurancePremium(-1_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toThrowError('Income cannot be negative.')
+      expect(() => calculateHealthInsurancePremium(-1_000_000, true, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo")).toThrowError('Income cannot be negative.')
     })
   });
 
@@ -69,62 +47,62 @@ describe('calculateHealthInsurancePremium for employees', () => {
     // Annual income 5,000,000 / 12 = 416,666.67. SMR: 410,000円
     // Employee No LTC: 19,475. Employee With LTC: 19,475 + 3,690 (LTC for 410k) = 23,165
     it('calculates premium for people under 40', () => {
-      expect(calculateHealthInsurancePremium(5_000_000, false, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toBe(19475 * 12); // 233_700
+      expect(calculateHealthInsurancePremium(5_000_000, false, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toBe(19475 * 12); // 233_700
     });
 
     // Annual income 20,000,000 / 12 = 1,666,666.67. SMR: 1,390,000円 (Max)
     // Employee No LTC: 66,025. Employee With LTC: 66,025 + 12,510 (LTC for 1.39M) = 78,535
     it('calculates premium for people under 40 with cap', () => {
-      expect(calculateHealthInsurancePremium(20_000_000, false, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toBe(66025 * 12); // 792_300
+      expect(calculateHealthInsurancePremium(20_000_000, false, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toBe(66025 * 12); // 792_300
     });
 
     it('calculates premium with nursing care for people over 40', () => {
-      expect(calculateHealthInsurancePremium(5_000_000, true, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toBe(23165 * 12); // 277_980
+      expect(calculateHealthInsurancePremium(5_000_000, true, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toBe(23165 * 12); // 277_980
     });
 
     it('calculates premium with nursing care for people over 40 with cap', () => {
-      expect(calculateHealthInsurancePremium(20_000_000, true, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toBe(78535 * 12); // 942_420
+      expect(calculateHealthInsurancePremium(20_000_000, true, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toBe(78535 * 12); // 942_420
     });
 
     // Annual income 0 / 12 = 0. SMR: 58,000円
     // Employee No LTC: 2,755. Employee With LTC: 2,755 + 522 (LTC for 58k) = 3,277
     it('handles zero income correctly', () => {
-      expect(calculateHealthInsurancePremium(0, false, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toBe(2755 * 12); // 33_060
-      expect(calculateHealthInsurancePremium(0, true, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toBe(3277 * 12); // 39_324
+      expect(calculateHealthInsurancePremium(0, false, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toBe(2755 * 12); // 33_060
+      expect(calculateHealthInsurancePremium(0, true, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toBe(3277 * 12); // 39_324
     });
 
     it('handles negative income correctly', () => {
-      expect(() => calculateHealthInsurancePremium(-1_000_000, false, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toThrowError('Income cannot be negative.');
-      expect(() => calculateHealthInsurancePremium(-1_000_000, true, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION)).toThrowError('Income cannot be negative.');
+      expect(() => calculateHealthInsurancePremium(-1_000_000, false, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toThrowError('Income cannot be negative.');
+      expect(() => calculateHealthInsurancePremium(-1_000_000, true, ITS_KENPO_PROVIDER, FY2025, DEFAULT_PROVIDER_REGION)).toThrowError('Income cannot be negative.');
     });
   });
 })
 
 describe('calculateHealthInsurancePremium for non-employees', () => {
   it('calculates NHI premium', () => {
-    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(539_380)
+    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(539_380)
   })
 
   it('calculates NHI premium with cap', () => {
-    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(920_000)
+    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(920_000)
   })
 
   it('calculates NHI premium with nursing care', () => {
-    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(658_805)
+    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(658_805)
   })
 
   it('calculates NHI premium with nursing care and cap', () => {
-    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(1_090_000)
+    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(1_090_000)
   })
 
   it('handles zero income correctly', () => {
-    expect(calculateHealthInsurancePremium(0, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(64_100)
-    expect(calculateHealthInsurancePremium(0, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(80_700)
+    expect(calculateHealthInsurancePremium(0, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(64_100)
+    expect(calculateHealthInsurancePremium(0, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(80_700)
   })
 
   it('handles negative income correctly', () => {
-    expect(() => calculateHealthInsurancePremium(-1_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toThrowError('Income cannot be negative.')
-    expect(() => calculateHealthInsurancePremium(-1_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toThrowError('Income cannot be negative.')
+    expect(() => calculateHealthInsurancePremium(-1_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toThrowError('Income cannot be negative.')
+    expect(() => calculateHealthInsurancePremium(-1_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toThrowError('Income cannot be negative.')
   })
 })
 
@@ -132,24 +110,24 @@ describe('calculateHealthInsurancePremium for employees with NHI', () => {
   // Test cases for employment income workers who are on NHI
   // (e.g., small employers, part-time workers, low income thresholds)
   it('calculates NHI premium for employment income', () => {
-    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(539_380)
+    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(539_380)
   })
 
   it('calculates NHI premium for employment income with nursing care', () => {
-    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(658_805)
+    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(658_805)
   })
 
   it('calculates NHI premium for employment income with cap', () => {
-    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(920_000)
+    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(920_000)
   })
 
   it('calculates NHI premium for employment income with nursing care and cap', () => {
-    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(1_090_000)
+    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(1_090_000)
   })
 
   it('handles zero employment income correctly', () => {
-    expect(calculateHealthInsurancePremium(0, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(64_100)
-    expect(calculateHealthInsurancePremium(0, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo')).toBe(80_700)
+    expect(calculateHealthInsurancePremium(0, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(64_100)
+    expect(calculateHealthInsurancePremium(0, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo')).toBe(80_700)
   })
 })
 
@@ -164,7 +142,7 @@ describe('calculateHealthInsurancePremium for Osaka (with household flat rate)',
     // Support: (5M - 430k) * 3.02% + 11,034 + 10,761 = 138,030 + 11,034 + 10,761 = 159,825 (under cap 240k)
     // LTC: 0 (not applicable)
     // Total: 492,978 + 159,825 = 652,803 (adjusted for rounding: 652,817)
-    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka')).toBe(652_817)
+    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Osaka')).toBe(652_817)
   })
 
   it('calculates Osaka NHI premium with nursing care', () => {
@@ -173,7 +151,7 @@ describe('calculateHealthInsurancePremium for Osaka (with household flat rate)',
     // Support: Same as above = 159,825  
     // LTC: (5M - 430k) * 2.56% + 18,784 + 0 = 116,915 + 18,784 = 135,699 (under cap 170k)
     // Total: 492,978 + 159,825 + 135,699 = 788,502 (adjusted for rounding: 788,593)
-    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka')).toBe(788_593)
+    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Osaka')).toBe(788_593)
   })
 
   it('calculates Osaka NHI premium with caps applied', () => {
@@ -181,40 +159,40 @@ describe('calculateHealthInsurancePremium for Osaka (with household flat rate)',
     // Medical: Capped at 650,000
     // Support: Capped at 240,000  
     // LTC: Capped at 170,000 (if applicable)
-    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka')).toBe(890_000) // 650k + 240k
-    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka')).toBe(1_060_000) // 650k + 240k + 170k
+    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Osaka')).toBe(890_000) // 650k + 240k
+    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Osaka')).toBe(1_060_000) // 650k + 240k + 170k
   })
 
   it('handles zero income correctly for Osaka (only per-capita and household flat amounts)', () => {
     // Medical: 0 + 34,424 + 33,574 = 67,998
     // Support: 0 + 11,034 + 10,761 = 21,795
     // Total without LTC: 89,793
-    expect(calculateHealthInsurancePremium(0, false, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka')).toBe(89_793)
+    expect(calculateHealthInsurancePremium(0, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Osaka')).toBe(89_793)
 
     // With LTC: + 18,784 = 108,577
-    expect(calculateHealthInsurancePremium(0, true, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka')).toBe(108_577)
+    expect(calculateHealthInsurancePremium(0, true, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Osaka')).toBe(108_577)
   })
 })
 
 describe('Dependent Coverage', () => {
   it('returns zero premium for dependent coverage regardless of age', () => {
-    expect(calculateHealthInsurancePremium(0, false, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
-    expect(calculateHealthInsurancePremium(0, true, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
-    expect(calculateHealthInsurancePremium(500_000, false, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
-    expect(calculateHealthInsurancePremium(500_000, true, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
-    expect(calculateHealthInsurancePremium(1_299_999, false, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
-    expect(calculateHealthInsurancePremium(1_299_999, true, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(0, false, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(0, true, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(500_000, false, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(500_000, true, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(1_299_999, false, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(1_299_999, true, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
   })
 
   it('returns zero premium for dependent coverage at threshold income', () => {
-    expect(calculateHealthInsurancePremium(1_300_000, false, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
-    expect(calculateHealthInsurancePremium(1_300_000, true, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(1_300_000, false, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(1_300_000, true, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
   })
 
   it('returns zero premium for dependent coverage even above threshold (validation should be in UI)', () => {
     // The calculator itself doesn't enforce the threshold - that's done at the UI level
-    expect(calculateHealthInsurancePremium(2_000_000, false, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
-    expect(calculateHealthInsurancePremium(2_000_000, true, 'DependentCoverage', DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(2_000_000, false, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
+    expect(calculateHealthInsurancePremium(2_000_000, true, 'DependentCoverage', FY2025, DEFAULT_PROVIDER_REGION)).toBe(0)
   })
 })
 
@@ -224,22 +202,22 @@ describe('Custom Provider', () => {
   // Annual income 5,000,000 / 12 = 416,666.67. SMR: 410,000円
   // Employee No LTC: 410,000 * 0.05 = 20,500
   it('calculates premium with custom rates for people under 40', () => {
-    expect(calculateHealthInsurancePremium(5_000_000, false, CUSTOM_PROVIDER_ID, DEFAULT_PROVIDER_REGION, customRates)).toBe(20500 * 12); // 246,000
+    expect(calculateHealthInsurancePremium(5_000_000, false, CUSTOM_PROVIDER_ID, FY2025, DEFAULT_PROVIDER_REGION, customRates)).toBe(20500 * 12); // 246,000
   });
 
   // Employee With LTC: 410,000 * 0.05 + 410,000 * 0.01 = 20,500 + 4,100 = 24,600
   it('calculates premium with custom rates for people over 40', () => {
-    expect(calculateHealthInsurancePremium(5_000_000, true, CUSTOM_PROVIDER_ID, DEFAULT_PROVIDER_REGION, customRates)).toBe(24600 * 12); // 295,200
+    expect(calculateHealthInsurancePremium(5_000_000, true, CUSTOM_PROVIDER_ID, FY2025, DEFAULT_PROVIDER_REGION, customRates)).toBe(24600 * 12); // 295,200
   });
 
   it('returns 0 if custom rates are missing', () => {
-    expect(calculateHealthInsurancePremium(5_000_000, false, CUSTOM_PROVIDER_ID, DEFAULT_PROVIDER_REGION)).toBe(0);
+    expect(calculateHealthInsurancePremium(5_000_000, false, CUSTOM_PROVIDER_ID, FY2025, DEFAULT_PROVIDER_REGION)).toBe(0);
   });
 
   it('handles zero income correctly with custom rates', () => {
     // SMR for 0 income is 58,000 (min bracket)
     // 58,000 * 0.05 = 2,900
-    expect(calculateHealthInsurancePremium(0, false, CUSTOM_PROVIDER_ID, DEFAULT_PROVIDER_REGION, customRates)).toBe(2900 * 12);
+    expect(calculateHealthInsurancePremium(0, false, CUSTOM_PROVIDER_ID, FY2025, DEFAULT_PROVIDER_REGION, customRates)).toBe(2900 * 12);
   });
 });
 
@@ -252,7 +230,7 @@ describe('calculateHealthInsuranceBreakdown with bonuses', () => {
     // Bonus: 1,000,000 => Standard Bonus: 1,000,000
     // Health: 1,000,000 * 0.04955 = 49,550
     const bonuses = [{ amount: 1_000_000, id: '1', type: 'bonus' as const, month: 6 }];
-    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo", undefined, bonuses);
+    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo", undefined, bonuses);
     expect(result.bonusPortion).toBe(49_550);
 
     // Total should include monthly premium (243,780 from previous test) + bonus (49,550)
@@ -265,7 +243,7 @@ describe('calculateHealthInsuranceBreakdown with bonuses', () => {
     // Health: 5,730,000 * 0.04955 = 283,921.5 -> 283,921
     // Total: 283,921
     const bonuses = [{ amount: 10_000_000, id: '1', type: 'bonus' as const, month: 6 }];
-    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo", undefined, bonuses);
+    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo", undefined, bonuses);
     expect(result.bonusPortion).toBe(283_921);
   });
 
@@ -278,7 +256,7 @@ describe('calculateHealthInsuranceBreakdown with bonuses', () => {
       { amount: 1_000_000, id: '1', type: 'bonus' as const, month: 6 },
       { amount: 2_000_000, id: '2', type: 'bonus' as const, month: 12 }
     ];
-    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo", undefined, bonuses);
+    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo", undefined, bonuses);
     expect(result.bonusPortion).toBe(148_650);
   });
 
@@ -292,7 +270,7 @@ describe('calculateHealthInsuranceBreakdown with bonuses', () => {
       { amount: 3_000_000, id: '1', type: 'bonus' as const, month: 6 },
       { amount: 3_000_000, id: '2', type: 'bonus' as const, month: 12 }
     ];
-    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo", undefined, bonuses);
+    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo", undefined, bonuses);
     expect(result.bonusPortion).toBe(283_921);
   });
 
@@ -305,7 +283,7 @@ describe('calculateHealthInsuranceBreakdown with bonuses', () => {
       { amount: 100_500, id: '1', type: 'bonus' as const, month: 6 },
       { amount: 200_999, id: '2', type: 'bonus' as const, month: 12 }
     ];
-    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, "Tokyo", undefined, bonuses);
+    const result = calculateHealthInsuranceBreakdown(5_000_000, false, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo", undefined, bonuses);
     expect(result.bonusPortion).toBe(14_865);
   });
 
@@ -315,7 +293,7 @@ describe('calculateHealthInsuranceBreakdown with bonuses', () => {
     // LTC: 1,000,000 * 0.00795 = 7,950
     // Total Bonus Premium: 57,500
     const bonuses = [{ amount: 1_000_000, id: '1', type: 'bonus' as const, month: 6 }];
-    const result = calculateHealthInsuranceBreakdown(5_000_000, true, KYOKAI_KENPO_PROVIDER, "Tokyo", undefined, bonuses);
+    const result = calculateHealthInsuranceBreakdown(5_000_000, true, KYOKAI_KENPO_PROVIDER, FY2025, "Tokyo", undefined, bonuses);
     expect(result.bonusPortion).toBe(57_500);
   });
 });
@@ -332,7 +310,7 @@ describe('calculateHealthInsuranceBonusBreakdown details', () => {
 
   it('returns correct breakdown for single bonus below cap', () => {
     const bonuses = [{ amount: 1_000_500, id: '1', type: 'bonus' as const, month: 6 }];
-    const breakdown = calculateEmployeesHealthInsuranceBonusBreakdown(bonuses, rates, true);
+    const breakdown = calculateEmployeesHealthInsuranceBonusBreakdown(bonuses, rates, true, FY2025);
 
     expect(breakdown).toHaveLength(1);
     expect(breakdown[0]!.bonusAmount).toBe(1_000_500);
@@ -350,7 +328,7 @@ describe('calculateHealthInsuranceBonusBreakdown details', () => {
       { amount: 4_000_000, id: '1', type: 'bonus' as const, month: 6 },
       { amount: 3_000_000, id: '2', type: 'bonus' as const, month: 12 }
     ];
-    const breakdown = calculateEmployeesHealthInsuranceBonusBreakdown(bonuses, rates, false);
+    const breakdown = calculateEmployeesHealthInsuranceBonusBreakdown(bonuses, rates, false, FY2025);
 
     expect(breakdown).toHaveLength(2);
 
@@ -384,7 +362,7 @@ describe('FY2026 time-series rate support', () => {
     // Apr (1 month):       410,000 × 0.04925 = 20,192.5 → 20,192
     // May-Dec (8 months):  410,000 × 0.05040 = 20,664.0 → 20,664 each → 165,312
     // Annual: 60,945 + 20,192 + 165,312 = 246,449
-    expect(calculateHealthInsurancePremium(5_000_000, false, KYOKAI_KENPO_PROVIDER, 'Tokyo', undefined, [], 2026)).toBe(246_449);
+    expect(calculateHealthInsurancePremium(5_000_000, false, KYOKAI_KENPO_PROVIDER, 2026, 'Tokyo')).toBe(246_449);
   });
 
   it('calculates split-year premium for Kyokai Kenpo Tokyo in 2026 (with LTC)', () => {
@@ -392,26 +370,20 @@ describe('FY2026 time-series rate support', () => {
     // Apr (1 month):       410,000 × (0.04925 + 0.00810) = 410,000 × 0.05735 = 23,513.5 → 23,513
     // May-Dec (8 months):  410,000 × (0.05040 + 0.00810) = 410,000 × 0.05850 = 23,985.0 → 23,985 each → 191,880
     // Annual: 70,725 + 23,513 + 191,880 = 286,118
-    expect(calculateHealthInsurancePremium(5_000_000, true, KYOKAI_KENPO_PROVIDER, 'Tokyo', undefined, [], 2026)).toBe(286_118);
-  });
-
-  it('FY2025 year parameter produces same result as default for 2025', () => {
-    // Passing year=2025 explicitly should match the default (pinned to 2025)
-    expect(calculateHealthInsurancePremium(5_000_000, false, KYOKAI_KENPO_PROVIDER, 'Tokyo', undefined, [], 2025))
-      .toBe(calculateHealthInsurancePremium(5_000_000, false, KYOKAI_KENPO_PROVIDER, 'Tokyo'));
+    expect(calculateHealthInsurancePremium(5_000_000, true, KYOKAI_KENPO_PROVIDER, 2026, 'Tokyo')).toBe(286_118);
   });
 
   it('applies correct rate to bonuses based on month in 2026', () => {
     // Bonus in March (month 2) → FY2025 rate: 0.04955
     // 500,000 × 0.04955 = 24,775
     const marchBonus = [{ amount: 500_000, id: 'b1', type: 'bonus' as const, month: 2 }];
-    const marchResult = calculateHealthInsuranceBreakdown(0, false, KYOKAI_KENPO_PROVIDER, 'Tokyo', undefined, marchBonus, 2026);
+    const marchResult = calculateHealthInsuranceBreakdown(0, false, KYOKAI_KENPO_PROVIDER, 2026, 'Tokyo', undefined, marchBonus);
     expect(marchResult.bonusPortion).toBe(24_775);
 
     // Bonus in May (month 4) → FY2026 with contribution rate: 0.05040
     // 500,000 × 0.05040 = 25,200
     const mayBonus = [{ amount: 500_000, id: 'b2', type: 'bonus' as const, month: 4 }];
-    const mayResult = calculateHealthInsuranceBreakdown(0, false, KYOKAI_KENPO_PROVIDER, 'Tokyo', undefined, mayBonus, 2026);
+    const mayResult = calculateHealthInsuranceBreakdown(0, false, KYOKAI_KENPO_PROVIDER, 2026, 'Tokyo', undefined, mayBonus);
     expect(mayResult.bonusPortion).toBe(25_200);
   });
 
@@ -419,7 +391,7 @@ describe('FY2026 time-series rate support', () => {
     // ITS in 2026:
     // All months: 4.75% (FY2025: 4.75%, FY2026 Apr: 4.75%, FY2026 May+: 4.635% + 0.115% contribution = 4.75%)
     // 410,000 × 0.0475 = 19,475 × 12 = 233,700
-    expect(calculateHealthInsurancePremium(5_000_000, false, ITS_KENPO_PROVIDER, DEFAULT_PROVIDER_REGION, undefined, [], 2026)).toBe(233_700);
+    expect(calculateHealthInsurancePremium(5_000_000, false, ITS_KENPO_PROVIDER, 2026, DEFAULT_PROVIDER_REGION)).toBe(233_700);
   });
 });
 
@@ -433,7 +405,7 @@ describe('NHI split-year blending (3/10 prev FY + 7/10 curr FY)', () => {
 
   it('year=2025 uses single FY (both Jan and Apr resolve to same FY2025 params)', () => {
     // No blending needed — FY2024 has no separate entry, falls back to FY2025
-    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo-Nakano', undefined, [], 2025)).toBe(554_903);
+    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, FY2025, 'Tokyo-Nakano')).toBe(554_903);
   });
 
   it('year=2026 blends FY2025 and FY2026 for Nakano (no LTC)', () => {
@@ -443,7 +415,7 @@ describe('NHI split-year blending (3/10 prev FY + 7/10 curr FY)', () => {
     //          support round(147,359×0.3 + 151,758×0.7) = 150,438
     //          child   round(0×0.3 + 12,412×0.7)        = 8,688
     //          total: 412,113 + 150,438 + 8,688          = 571,239
-    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo-Nakano', undefined, [], 2026)).toBe(571_239);
+    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 2026, 'Tokyo-Nakano')).toBe(571_239);
   });
 
   it('year=2026 blends FY2025 and FY2026 for Nakano (with LTC)', () => {
@@ -451,7 +423,7 @@ describe('NHI split-year blending (3/10 prev FY + 7/10 curr FY)', () => {
     // FY2026 LTC (rate 2.53%, per-capita 17,700): 133,321
     // Blended LTC: round(117,940×0.3 + 133,321×0.7) = 128,707
     // Total: 571,239 + 128,707 = 699,946
-    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo-Nakano', undefined, [], 2026)).toBe(699_946);
+    expect(calculateHealthInsurancePremium(5_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 2026, 'Tokyo-Nakano')).toBe(699_946);
   });
 
   it('year=2026 blends Osaka FY2025 and FY2026 (no LTC)', () => {
@@ -461,7 +433,7 @@ describe('NHI split-year blending (3/10 prev FY + 7/10 curr FY)', () => {
     //          support round(159,809×0.3 + 161,878×0.7) = 161,257
     //          child   round(0×0.3 + 14,637×0.7)        = 10,246
     //          total: 500,036 + 161,257 + 10,246         = 671,539
-    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka', undefined, [], 2026)).toBe(671_539);
+    expect(calculateHealthInsurancePremium(5_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 2026, 'Osaka')).toBe(671_539);
   });
 
   it('year=2026 blends caps correctly for Osaka at high income', () => {
@@ -472,7 +444,7 @@ describe('NHI split-year blending (3/10 prev FY + 7/10 curr FY)', () => {
     //          LTC: 170,000 (same both FYs)
     //          child round(0×0.3 + 30k×0.7) = 21,000
     //          total: 657,000 + 254,000 + 170,000 + 21,000 = 1,102,000
-    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 'Osaka', undefined, [], 2026)).toBe(1_102_000);
+    expect(calculateHealthInsurancePremium(20_000_000, true, NATIONAL_HEALTH_INSURANCE_ID, 2026, 'Osaka')).toBe(1_102_000);
   });
 
   it('year=2026 blends caps correctly for Nakano at high income (no LTC)', () => {
@@ -482,6 +454,6 @@ describe('NHI split-year blending (3/10 prev FY + 7/10 curr FY)', () => {
     //          support: 260,000 (same both FYs)
     //          child round(0×0.3 + 30,000×0.7) = 21,000
     //          total: 667,000 + 260,000 + 21,000 = 948,000
-    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 'Tokyo-Nakano', undefined, [], 2026)).toBe(948_000);
+    expect(calculateHealthInsurancePremium(20_000_000, false, NATIONAL_HEALTH_INSURANCE_ID, 2026, 'Tokyo-Nakano')).toBe(948_000);
   });
 });

--- a/src/__tests__/healthInsuranceCalculator.test.ts
+++ b/src/__tests__/healthInsuranceCalculator.test.ts
@@ -12,20 +12,26 @@ import { DEFAULT_PROVIDER_REGION, NATIONAL_HEALTH_INSURANCE_ID, DEFAULT_PROVIDER
 const KYOKAI_KENPO_PROVIDER = DEFAULT_PROVIDER;
 const ITS_KENPO_PROVIDER = 'KantoItsKenpo';
 
-// Most cases here assert FY2025 rates. These thin wrappers default the income year to FY2025
-// (a fake clock used to pin it) so rate lookups don't depend on the run date, while still
-// honoring an explicit year where a case passes one (e.g. the FY2026 time-series tests). The
-// wrappers keep the originals' signatures, so call sites stay unchanged.
+// The underlying functions now require an income year. Most cases here assert FY2025 rates, so
+// these thin wrappers default the year to FY2025 (a fake clock used to pin it) so rate lookups
+// don't depend on the run date, while still honoring an explicit year where a case passes one
+// (e.g. the FY2026 time-series tests). Call sites stay unchanged.
 const FY2025 = 2025;
-const calculateHealthInsurancePremium: typeof calculateHealthInsurancePremiumForYear =
-  (income, ltc, provider, region, customRates, bonuses, year) =>
-    calculateHealthInsurancePremiumForYear(income, ltc, provider, region, customRates, bonuses, year ?? FY2025);
-const calculateHealthInsuranceBreakdown: typeof calculateHealthInsuranceBreakdownForYear =
-  (income, ltc, provider, region, customRates, bonuses, year) =>
-    calculateHealthInsuranceBreakdownForYear(income, ltc, provider, region, customRates, bonuses, year ?? FY2025);
-const calculateEmployeesHealthInsuranceBonusBreakdown: typeof calculateEmployeesHealthInsuranceBonusBreakdownForYear =
-  (bonuses, providerOrRates, regionOrLTC, ltc, year) =>
-    calculateEmployeesHealthInsuranceBonusBreakdownForYear(bonuses, providerOrRates, regionOrLTC, ltc, year ?? FY2025);
+type PremiumArgs = Parameters<typeof calculateHealthInsurancePremiumForYear>;
+const calculateHealthInsurancePremium = (
+  income: PremiumArgs[0], ltc: PremiumArgs[1], provider: PremiumArgs[2],
+  region?: PremiumArgs[3], customRates?: PremiumArgs[4], bonuses?: PremiumArgs[5], year: number = FY2025,
+): number => calculateHealthInsurancePremiumForYear(income, ltc, provider, region, customRates, bonuses, year);
+type BreakdownArgs = Parameters<typeof calculateHealthInsuranceBreakdownForYear>;
+const calculateHealthInsuranceBreakdown = (
+  income: BreakdownArgs[0], ltc: BreakdownArgs[1], provider: BreakdownArgs[2],
+  region?: BreakdownArgs[3], customRates?: BreakdownArgs[4], bonuses?: BreakdownArgs[5], year: number = FY2025,
+) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, region, customRates, bonuses, year);
+type BonusArgs = Parameters<typeof calculateEmployeesHealthInsuranceBonusBreakdownForYear>;
+const calculateEmployeesHealthInsuranceBonusBreakdown = (
+  bonuses: BonusArgs[0], providerOrRates: BonusArgs[1], regionOrLTC: BonusArgs[2],
+  ltc?: BonusArgs[3], year: number = FY2025,
+) => calculateEmployeesHealthInsuranceBonusBreakdownForYear(bonuses, providerOrRates, regionOrLTC, ltc, year);
 
 describe('calculateHealthInsurancePremium for employees', () => {
   describe('Kyokai Kenpo (Tokyo)', () => {

--- a/src/__tests__/healthInsuranceCalculator.test.ts
+++ b/src/__tests__/healthInsuranceCalculator.test.ts
@@ -1,17 +1,31 @@
 // Copyright the original author or authors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
-import { calculateHealthInsurancePremium, calculateHealthInsuranceBreakdown, calculateEmployeesHealthInsuranceBonusBreakdown } from '../utils/healthInsuranceCalculator'
+import { describe, it, expect } from 'vitest'
+import {
+  calculateHealthInsurancePremium as calculateHealthInsurancePremiumForYear,
+  calculateHealthInsuranceBreakdown as calculateHealthInsuranceBreakdownForYear,
+  calculateEmployeesHealthInsuranceBonusBreakdown as calculateEmployeesHealthInsuranceBonusBreakdownForYear,
+} from '../utils/healthInsuranceCalculator'
 import { DEFAULT_PROVIDER_REGION, NATIONAL_HEALTH_INSURANCE_ID, DEFAULT_PROVIDER, CUSTOM_PROVIDER_ID } from '../types/healthInsurance'
 
 const KYOKAI_KENPO_PROVIDER = DEFAULT_PROVIDER;
 const ITS_KENPO_PROVIDER = 'KantoItsKenpo';
 
-// Pin to June 2025 — well within FY2025 rate period for all providers.
-// This ensures rate lookups are deterministic regardless of when tests run.
-beforeAll(() => { vi.useFakeTimers({ now: new Date(2025, 5, 1) }) });
-afterAll(() => { vi.useRealTimers() });
+// Most cases here assert FY2025 rates. These thin wrappers default the income year to FY2025
+// (a fake clock used to pin it) so rate lookups don't depend on the run date, while still
+// honoring an explicit year where a case passes one (e.g. the FY2026 time-series tests). The
+// wrappers keep the originals' signatures, so call sites stay unchanged.
+const FY2025 = 2025;
+const calculateHealthInsurancePremium: typeof calculateHealthInsurancePremiumForYear =
+  (income, ltc, provider, region, customRates, bonuses, year) =>
+    calculateHealthInsurancePremiumForYear(income, ltc, provider, region, customRates, bonuses, year ?? FY2025);
+const calculateHealthInsuranceBreakdown: typeof calculateHealthInsuranceBreakdownForYear =
+  (income, ltc, provider, region, customRates, bonuses, year) =>
+    calculateHealthInsuranceBreakdownForYear(income, ltc, provider, region, customRates, bonuses, year ?? FY2025);
+const calculateEmployeesHealthInsuranceBonusBreakdown: typeof calculateEmployeesHealthInsuranceBonusBreakdownForYear =
+  (bonuses, providerOrRates, regionOrLTC, ltc, year) =>
+    calculateEmployeesHealthInsuranceBonusBreakdownForYear(bonuses, providerOrRates, regionOrLTC, ltc, year ?? FY2025);
 
 describe('calculateHealthInsurancePremium for employees', () => {
   describe('Kyokai Kenpo (Tokyo)', () => {

--- a/src/__tests__/healthInsuranceCalculator.test.ts
+++ b/src/__tests__/healthInsuranceCalculator.test.ts
@@ -17,21 +17,24 @@ const ITS_KENPO_PROVIDER = 'KantoItsKenpo';
 // don't depend on the run date, while still honoring an explicit year where a case passes one
 // (e.g. the FY2026 time-series tests). Call sites stay unchanged.
 const FY2025 = 2025;
+// The real functions take year right after the required params (income, ltc, provider). These
+// wrappers keep the old call-site argument order (…, region, customRates, bonuses) and forward in
+// the real order, defaulting the year to FY2025 unless a case passes one.
 type PremiumArgs = Parameters<typeof calculateHealthInsurancePremiumForYear>;
 const calculateHealthInsurancePremium = (
   income: PremiumArgs[0], ltc: PremiumArgs[1], provider: PremiumArgs[2],
-  region?: PremiumArgs[3], customRates?: PremiumArgs[4], bonuses?: PremiumArgs[5], year: number = FY2025,
-): number => calculateHealthInsurancePremiumForYear(income, ltc, provider, region, customRates, bonuses, year);
+  region?: PremiumArgs[4], customRates?: PremiumArgs[5], bonuses?: PremiumArgs[6], year: number = FY2025,
+): number => calculateHealthInsurancePremiumForYear(income, ltc, provider, year, region, customRates, bonuses);
 type BreakdownArgs = Parameters<typeof calculateHealthInsuranceBreakdownForYear>;
 const calculateHealthInsuranceBreakdown = (
   income: BreakdownArgs[0], ltc: BreakdownArgs[1], provider: BreakdownArgs[2],
-  region?: BreakdownArgs[3], customRates?: BreakdownArgs[4], bonuses?: BreakdownArgs[5], year: number = FY2025,
-) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, region, customRates, bonuses, year);
+  region?: BreakdownArgs[4], customRates?: BreakdownArgs[5], bonuses?: BreakdownArgs[6], year: number = FY2025,
+) => calculateHealthInsuranceBreakdownForYear(income, ltc, provider, year, region, customRates, bonuses);
 type BonusArgs = Parameters<typeof calculateEmployeesHealthInsuranceBonusBreakdownForYear>;
 const calculateEmployeesHealthInsuranceBonusBreakdown = (
   bonuses: BonusArgs[0], providerOrRates: BonusArgs[1], regionOrLTC: BonusArgs[2],
-  ltc?: BonusArgs[3], year: number = FY2025,
-) => calculateEmployeesHealthInsuranceBonusBreakdownForYear(bonuses, providerOrRates, regionOrLTC, ltc, year);
+  ltc?: BonusArgs[4], year: number = FY2025,
+) => calculateEmployeesHealthInsuranceBonusBreakdownForYear(bonuses, providerOrRates, regionOrLTC, year, ltc);
 
 describe('calculateHealthInsurancePremium for employees', () => {
   describe('Kyokai Kenpo (Tokyo)', () => {

--- a/src/__tests__/pensionCalculator.test.ts
+++ b/src/__tests__/pensionCalculator.test.ts
@@ -2,7 +2,22 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect } from 'vitest'
-import { calculatePensionPremium, calculatePensionBreakdown, calculatePensionBonusBreakdown } from '../utils/pensionCalculator'
+import { calculatePensionPremium as calculatePensionPremiumForYear, calculatePensionBreakdown as calculatePensionBreakdownForYear, calculatePensionBonusBreakdown } from '../utils/pensionCalculator'
+
+// calculatePensionPremium/Breakdown now require an income year. Thin wrappers default it to 2026
+// (the suite's prior behavior under a 2026 clock) while honoring an explicit year, so call sites
+// stay unchanged.
+const TEST_INCOME_YEAR = 2026;
+type PenPremiumArgs = Parameters<typeof calculatePensionPremiumForYear>;
+const calculatePensionPremium = (
+  isEmployeesPension?: PenPremiumArgs[0], monthlyIncome?: PenPremiumArgs[1], isHalfAmount?: PenPremiumArgs[2],
+  bonuses?: PenPremiumArgs[3], year: number = TEST_INCOME_YEAR,
+) => calculatePensionPremiumForYear(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year);
+type PenBreakdownArgs = Parameters<typeof calculatePensionBreakdownForYear>;
+const calculatePensionBreakdown = (
+  isEmployeesPension?: PenBreakdownArgs[0], monthlyIncome?: PenBreakdownArgs[1], isHalfAmount?: PenBreakdownArgs[2],
+  bonuses?: PenBreakdownArgs[3], year: number = TEST_INCOME_YEAR,
+) => calculatePensionBreakdownForYear(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year);
 
 describe('calculatePensionPremium', () => {
   it('calculates employees pension correctly for employment income below cap', () => {

--- a/src/__tests__/pensionCalculator.test.ts
+++ b/src/__tests__/pensionCalculator.test.ts
@@ -2,30 +2,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, it, expect } from 'vitest'
-import { calculatePensionPremium as calculatePensionPremiumForYear, calculatePensionBreakdown as calculatePensionBreakdownForYear, calculatePensionBonusBreakdown } from '../utils/pensionCalculator'
+import { calculatePensionPremium, calculatePensionBreakdown, calculatePensionBonusBreakdown } from '../utils/pensionCalculator'
 
-// calculatePensionPremium/Breakdown now require an income year. Thin wrappers default it to 2026
-// (the suite's prior behavior under a 2026 clock) while honoring an explicit year, so call sites
-// stay unchanged.
 const TEST_INCOME_YEAR = 2026;
-type PenPremiumArgs = Parameters<typeof calculatePensionPremiumForYear>;
-const calculatePensionPremium = (
-  isEmployeesPension?: PenPremiumArgs[0], monthlyIncome?: PenPremiumArgs[1], isHalfAmount?: PenPremiumArgs[2],
-  bonuses?: PenPremiumArgs[3], year: number = TEST_INCOME_YEAR,
-) => calculatePensionPremiumForYear(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year);
-type PenBreakdownArgs = Parameters<typeof calculatePensionBreakdownForYear>;
-const calculatePensionBreakdown = (
-  isEmployeesPension?: PenBreakdownArgs[0], monthlyIncome?: PenBreakdownArgs[1], isHalfAmount?: PenBreakdownArgs[2],
-  bonuses?: PenBreakdownArgs[3], year: number = TEST_INCOME_YEAR,
-) => calculatePensionBreakdownForYear(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year);
 
 describe('calculatePensionPremium', () => {
   it('calculates employees pension correctly for employment income below cap', () => {
-    expect(calculatePensionPremium(true, 5_000_000 / 12, true)).toBe(450_180)
+    expect(calculatePensionPremium(true, 5_000_000 / 12, true, [], TEST_INCOME_YEAR)).toBe(450_180)
   })
 
   it('respects maximum cap for high employment income', () => {
-    expect(calculatePensionPremium(true, 10_000_000 / 12, true)).toBe(713_700) // Capped at 59,475 * 12
+    expect(calculatePensionPremium(true, 10_000_000 / 12, true, [], TEST_INCOME_YEAR)).toBe(713_700) // Capped at 59,475 * 12
   })
 
   it('calculates fixed national pension for non-employment income (2026)', () => {
@@ -41,13 +28,13 @@ describe('calculatePensionPremium', () => {
   })
 
   it('handles zero income correctly', () => {
-    expect(calculatePensionPremium(true, 0, true)).toBe(96_624)
+    expect(calculatePensionPremium(true, 0, true, [], TEST_INCOME_YEAR)).toBe(96_624)
     expect(calculatePensionPremium(false, 0, true, [], 2026)).toBe(213_810) // Fixed amount (2026)
     expect(calculatePensionPremium(false, 0, true, [], 2025)).toBe(208_530) // Fixed amount (2025)
   })
 
   it('handles negative income correctly', () => {
-    expect(() => calculatePensionPremium(true, -1_000_000, true)).toThrow('Monthly income must be a positive number')
+    expect(() => calculatePensionPremium(true, -1_000_000, true, [], TEST_INCOME_YEAR)).toThrow('Monthly income must be a positive number')
     expect(calculatePensionPremium(false, -1_000_000, true, [], 2026)).toBe(213_810) // Still pays fixed amount
   })
 })
@@ -59,7 +46,7 @@ describe('calculatePensionBreakdown with bonuses', () => {
     // Bonus: 1,000,000 => Standard: 1,000,000
     // Premium: 1,000,000 * 0.0915 = 91,500
     const bonuses = [{ amount: 1_000_000, id: '1', type: 'bonus' as const, month: 6 }];
-    const result = calculatePensionBreakdown(true, 300_000, true, bonuses);
+    const result = calculatePensionBreakdown(true, 300_000, true, bonuses, TEST_INCOME_YEAR);
     expect(result.bonusPortion).toBe(91_500);
   });
 
@@ -67,7 +54,7 @@ describe('calculatePensionBreakdown with bonuses', () => {
     // Bonus: 2,000,000 => Capped at 1,500,000
     // Premium: 1,500,000 * 0.0915 = 137,250
     const bonuses = [{ amount: 2_000_000, id: '1', type: 'bonus' as const, month: 6 }];
-    const result = calculatePensionBreakdown(true, 300_000, true, bonuses);
+    const result = calculatePensionBreakdown(true, 300_000, true, bonuses, TEST_INCOME_YEAR);
     expect(result.bonusPortion).toBe(137_250);
   });
 
@@ -80,7 +67,7 @@ describe('calculatePensionBreakdown with bonuses', () => {
       { amount: 1_000_000, id: '1', type: 'bonus' as const, month: 6 },
       { amount: 1_000_000, id: '2', type: 'bonus' as const, month: 6 }
     ];
-    const result = calculatePensionBreakdown(true, 300_000, true, bonuses);
+    const result = calculatePensionBreakdown(true, 300_000, true, bonuses, TEST_INCOME_YEAR);
     expect(result.bonusPortion).toBe(137_250);
   });
 
@@ -92,7 +79,7 @@ describe('calculatePensionBreakdown with bonuses', () => {
       { amount: 1_000_000, id: '1', type: 'bonus' as const, month: 6 },
       { amount: 1_000_000, id: '2', type: 'bonus' as const, month: 12 }
     ];
-    const result = calculatePensionBreakdown(true, 300_000, true, bonuses);
+    const result = calculatePensionBreakdown(true, 300_000, true, bonuses, TEST_INCOME_YEAR);
     expect(result.bonusPortion).toBe(183_000);
   });
 
@@ -104,7 +91,7 @@ describe('calculatePensionBreakdown with bonuses', () => {
       { amount: 2_000_000, id: '1', type: 'bonus' as const, month: 6 },
       { amount: 1_000_000, id: '2', type: 'bonus' as const, month: 12 }
     ];
-    const result = calculatePensionBreakdown(true, 300_000, true, bonuses);
+    const result = calculatePensionBreakdown(true, 300_000, true, bonuses, TEST_INCOME_YEAR);
     expect(result.bonusPortion).toBe(228_750);
   });
 
@@ -112,7 +99,7 @@ describe('calculatePensionBreakdown with bonuses', () => {
     // Bonus: 100,999 => Standard: 100,000
     // Premium: 100,000 * 0.0915 = 9,150
     const bonuses = [{ amount: 100_999, id: '1', type: 'bonus' as const, month: 6 }];
-    const result = calculatePensionBreakdown(true, 300_000, true, bonuses);
+    const result = calculatePensionBreakdown(true, 300_000, true, bonuses, TEST_INCOME_YEAR);
     expect(result.bonusPortion).toBe(9_150);
   });
 })

--- a/src/__tests__/residencetax.test.ts
+++ b/src/__tests__/residencetax.test.ts
@@ -11,12 +11,12 @@ const TEST_INCOME_YEAR = 2026;
 type ResTaxArgs = Parameters<typeof calculateResidenceTaxForYear>;
 const calculateResidenceTax = (
   netIncome: ResTaxArgs[0], nonBasicDeductions: ResTaxArgs[1], dependentDeductions: ResTaxArgs[2],
-  taxCredit: ResTaxArgs[3] = 0, year: number = TEST_INCOME_YEAR,
-) => calculateResidenceTaxForYear(netIncome, nonBasicDeductions, dependentDeductions, taxCredit, year);
+  taxCredit: ResTaxArgs[4] = 0, year: number = TEST_INCOME_YEAR,
+) => calculateResidenceTaxForYear(netIncome, nonBasicDeductions, dependentDeductions, year, taxCredit);
 type DepDeductionsArgs = Parameters<typeof calculateDependentDeductionsForYear>;
 const calculateDependentDeductions = (
-  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[1], year: number = TEST_INCOME_YEAR,
-) => calculateDependentDeductionsForYear(dependents, taxpayerNetIncome, year);
+  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[2], year: number = TEST_INCOME_YEAR,
+) => calculateDependentDeductionsForYear(dependents, year, taxpayerNetIncome);
 import type { DependentDeductionResults, Dependent } from "../types/dependents"
 
 /**

--- a/src/__tests__/residencetax.test.ts
+++ b/src/__tests__/residencetax.test.ts
@@ -2,8 +2,21 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest"
-import { calculateResidenceTax, calculateResidenceTaxBasicDeduction, NON_TAXABLE_RESIDENCE_TAX_DETAIL } from "../utils/residenceTax"
-import { calculateDependentDeductions } from "../utils/dependentDeductions"
+import { calculateResidenceTax as calculateResidenceTaxForYear, calculateResidenceTaxBasicDeduction, NON_TAXABLE_RESIDENCE_TAX_DETAIL } from "../utils/residenceTax"
+import { calculateDependentDeductions as calculateDependentDeductionsForYear } from "../utils/dependentDeductions"
+
+// These calculators now require an income year. Thin wrappers default it to 2026 (the suite's
+// prior behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
+const TEST_INCOME_YEAR = 2026;
+type ResTaxArgs = Parameters<typeof calculateResidenceTaxForYear>;
+const calculateResidenceTax = (
+  netIncome: ResTaxArgs[0], nonBasicDeductions: ResTaxArgs[1], dependentDeductions: ResTaxArgs[2],
+  taxCredit: ResTaxArgs[3] = 0, year: number = TEST_INCOME_YEAR,
+) => calculateResidenceTaxForYear(netIncome, nonBasicDeductions, dependentDeductions, taxCredit, year);
+type DepDeductionsArgs = Parameters<typeof calculateDependentDeductionsForYear>;
+const calculateDependentDeductions = (
+  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[1], year: number = TEST_INCOME_YEAR,
+) => calculateDependentDeductionsForYear(dependents, taxpayerNetIncome, year);
 import type { DependentDeductionResults, Dependent } from "../types/dependents"
 
 /**

--- a/src/__tests__/residencetax.test.ts
+++ b/src/__tests__/residencetax.test.ts
@@ -2,22 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest"
-import { calculateResidenceTax as calculateResidenceTaxForYear, calculateResidenceTaxBasicDeduction, NON_TAXABLE_RESIDENCE_TAX_DETAIL } from "../utils/residenceTax"
-import { calculateDependentDeductions as calculateDependentDeductionsForYear } from "../utils/dependentDeductions"
-
-// These calculators now require an income year. Thin wrappers default it to 2026 (the suite's
-// prior behavior under a 2026 clock) while honoring an explicit year, so call sites stay unchanged.
-const TEST_INCOME_YEAR = 2026;
-type ResTaxArgs = Parameters<typeof calculateResidenceTaxForYear>;
-const calculateResidenceTax = (
-  netIncome: ResTaxArgs[0], nonBasicDeductions: ResTaxArgs[1], dependentDeductions: ResTaxArgs[2],
-  taxCredit: ResTaxArgs[4] = 0, year: number = TEST_INCOME_YEAR,
-) => calculateResidenceTaxForYear(netIncome, nonBasicDeductions, dependentDeductions, year, taxCredit);
-type DepDeductionsArgs = Parameters<typeof calculateDependentDeductionsForYear>;
-const calculateDependentDeductions = (
-  dependents: DepDeductionsArgs[0], taxpayerNetIncome?: DepDeductionsArgs[2], year: number = TEST_INCOME_YEAR,
-) => calculateDependentDeductionsForYear(dependents, year, taxpayerNetIncome);
+import { calculateResidenceTax, calculateResidenceTaxBasicDeduction, NON_TAXABLE_RESIDENCE_TAX_DETAIL } from "../utils/residenceTax"
+import { calculateDependentDeductions } from "../utils/dependentDeductions"
 import type { DependentDeductionResults, Dependent } from "../types/dependents"
+
+const TEST_INCOME_YEAR = 2026;
 
 /**
  * An empty dependent deduction result object with all values set to zero.
@@ -77,7 +66,7 @@ describe('calculateResidenceTax', () => {
     // Per Article 314-6: Basic deduction difference = 50,000 (fixed for income ≤ 25M)
     // Adjustment credit: max((50K - (3.57M - 2M)) * 0.05, 50K * 0.05) = 2,500
     // Tax: 3,570,000 * 0.1 - 2,500 + 5,000 = 359,500
-    expect(calculateResidenceTax(5_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(359_500)
+    expect(calculateResidenceTax(5_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(359_500)
   })
 
   it('calculates tax correctly for income with partial basic deduction', () => {
@@ -86,7 +75,7 @@ describe('calculateResidenceTax', () => {
     // Per Article 314-6: Basic deduction difference = 50,000 (fixed for income ≤ 25M)
     // Adjustment credit: max((50K - (22.91M - 2M)) * 0.05, 50K * 0.05) = 2,500
     // Tax: 22,910,000 * 0.1 - 2,500 + 5,000 = 2,293,500
-    expect(calculateResidenceTax(24_200_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(2_293_500)
+    expect(calculateResidenceTax(24_200_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(2_293_500)
   })
 
   it('calculates tax correctly for income with minimum basic deduction', () => {
@@ -95,35 +84,35 @@ describe('calculateResidenceTax', () => {
     // Per Article 314-6: Basic deduction difference = 50,000 (fixed for income ≤ 25M)
     // Adjustment credit: max((50K - (23.55M - 2M)) * 0.05, 50K * 0.05) = 2,500
     // Tax: 23,550,000 * 0.1 - 2,500 + 5,000 = 2,357,500
-    expect(calculateResidenceTax(24_700_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(2_357_500)
+    expect(calculateResidenceTax(24_700_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(2_357_500)
   })
 
   it('calculates tax correctly for income with no basic deduction', () => {
     // Example: 26M income, 1M social insurance
-    expect(calculateResidenceTax(26_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(2_505_000) // (26M - 1M - 0) * 0.1 + 5000
+    expect(calculateResidenceTax(26_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(2_505_000) // (26M - 1M - 0) * 0.1 + 5000
   })
 
   it('returns minimum tax amount when deductions exceed net income', () => {
     // Example: 1M income, 2M social insurance
-    expect(calculateResidenceTax(1_000_000, 2_000_000, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(5_000) // Only 5000 yen 均等割 when taxable income is 0
+    expect(calculateResidenceTax(1_000_000, 2_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(5_000) // Only 5000 yen 均等割 when taxable income is 0
   })
 
   it('returns 0 yen when net income is 450,000 yen or less due to 非課税制度', () => {
-    expect(calculateResidenceTax(449_999, 0, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(0)
-    expect(calculateResidenceTax(450_000, 0, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(0)
+    expect(calculateResidenceTax(449_999, 0, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(0)
+    expect(calculateResidenceTax(450_000, 0, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(0)
   })
 
   it('returns 5000 yen 均等割 when taxable income is 0', () => {
-    expect(calculateResidenceTax(450_001, 20_001, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(5_000)
-    expect(calculateResidenceTax(1_000_000, 600_000, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(5_000)
+    expect(calculateResidenceTax(450_001, 20_001, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(5_000)
+    expect(calculateResidenceTax(1_000_000, 600_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(5_000)
   })
 
   it('handles zero income correctly', () => {
-    expect(calculateResidenceTax(0, 0, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(0)
+    expect(calculateResidenceTax(0, 0, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(0)
   })
 
   it('handles negative income correctly', () => {
-    expect(calculateResidenceTax(-1_000_000, 0, EMPTY_DEPENDENT_DEDUCTIONS).totalResidenceTax).toBe(0)
+    expect(calculateResidenceTax(-1_000_000, 0, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR).totalResidenceTax).toBe(0)
   })
 })
 
@@ -133,7 +122,7 @@ describe('calculateResidenceTax - 調整控除額 (Adjustment Credit)', () => {
     // Per Article 314-6: Basic deduction difference = 50,000 (fixed for income ≤ 25M)
     // Taxable income: 2,020,000 - 450,000 - 430,000 = 1,140,000
     // Adjustment credit: Math.min(50,000 * 0.05, 1,140,000 * 0.05) = Math.min(2,500, 57,000) = 2,500
-    const result = calculateResidenceTax(2_020_000, 450_000, EMPTY_DEPENDENT_DEDUCTIONS);
+    const result = calculateResidenceTax(2_020_000, 450_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR);
     expect(result.city.cityAdjustmentCredit).toBe(2_500 * 0.6); // 1,500
     expect(result.prefecture.prefecturalAdjustmentCredit).toBe(2_500 * 0.4); // 1,000
   })
@@ -145,7 +134,7 @@ describe('calculateResidenceTax - 調整控除額 (Adjustment Credit)', () => {
     // Adjustment credit: Math.max((50,000 - (2,510,000 - 2,000,000)) * 0.05, 50,000 * 0.05)
     //                  = Math.max((50,000 - 510,000) * 0.05, 2,500)
     //                  = Math.max(-23,000, 2,500) = 2,500
-    const result = calculateResidenceTax(3_640_000, 700_000, EMPTY_DEPENDENT_DEDUCTIONS);
+    const result = calculateResidenceTax(3_640_000, 700_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR);
     expect(result.city.cityAdjustmentCredit).toBe(2_500 * 0.6); // 1,500
     expect(result.prefecture.prefecturalAdjustmentCredit).toBe(2_500 * 0.4); // 1,000
   })
@@ -153,7 +142,7 @@ describe('calculateResidenceTax - 調整控除額 (Adjustment Credit)', () => {
   it('calculates adjustment credit as zero for netIncome > 25M yen', () => {
     // Net income: 28,050,000, Social insurance: 2,000,000
     // Should have zero adjustment credit because netIncome > 25M (no basic deduction)
-    const result = calculateResidenceTax(28_050_000, 2_000_000, EMPTY_DEPENDENT_DEDUCTIONS);
+    const result = calculateResidenceTax(28_050_000, 2_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR);
     expect(result.city.cityAdjustmentCredit).toBe(0);
     expect(result.prefecture.prefecturalAdjustmentCredit).toBe(0);
   })
@@ -163,7 +152,7 @@ describe('calculateResidenceTax - 調整控除額 (Adjustment Credit)', () => {
     // Per Article 314-6: Basic deduction difference = 50,000 (fixed for income ≤ 25M)
     // Taxable income: 2,860,000 - 430,000 - 430,000 = 2,000,000 (exactly at boundary)
     // Adjustment credit: Math.min(50,000 * 0.05, 2,000,000 * 0.05) = Math.min(2,500, 100,000) = 2,500
-    const result = calculateResidenceTax(2_860_000, 430_000, EMPTY_DEPENDENT_DEDUCTIONS);
+    const result = calculateResidenceTax(2_860_000, 430_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR);
     expect(result.city.cityAdjustmentCredit).toBe(2_500 * 0.6); // 1,500
     expect(result.prefecture.prefecturalAdjustmentCredit).toBe(2_500 * 0.4); // 1,000
   })
@@ -175,7 +164,7 @@ describe('calculateResidenceTax - 調整控除額 (Adjustment Credit)', () => {
     // Adjustment credit: Math.max((50,000 - (2,001,000 - 2,000,000)) * 0.05, 50,000 * 0.05)
     //                  = Math.max((50,000 - 1,000) * 0.05, 2,500)
     //                  = Math.max(2,450, 2,500) = 2,500
-    const result = calculateResidenceTax(2_861_000, 430_000, EMPTY_DEPENDENT_DEDUCTIONS);
+    const result = calculateResidenceTax(2_861_000, 430_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR);
     expect(result.city.cityAdjustmentCredit).toBe(2_500 * 0.6); // 1,500
     expect(result.prefecture.prefecturalAdjustmentCredit).toBe(2_500 * 0.4); // 1,000
   })
@@ -183,12 +172,12 @@ describe('calculateResidenceTax - 調整控除額 (Adjustment Credit)', () => {
 
 describe('Residence Tax - Non-Taxable Limit', () => {
   it('should be non-taxable for single person with income <= 450,000', () => {
-    const result = calculateResidenceTax(450_000, 0, calculateDependentDeductions([]))
+    const result = calculateResidenceTax(450_000, 0, calculateDependentDeductions([], TEST_INCOME_YEAR), TEST_INCOME_YEAR)
     expect(result).toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
   it('should be taxable for single person with income > 450,000', () => {
-    const result = calculateResidenceTax(450_001, 0, calculateDependentDeductions([]))
+    const result = calculateResidenceTax(450_001, 0, calculateDependentDeductions([], TEST_INCOME_YEAR), TEST_INCOME_YEAR)
     expect(result).not.toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
@@ -202,9 +191,9 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
     }
-    const dependents = calculateDependentDeductions([spouse])
+    const dependents = calculateDependentDeductions([spouse], TEST_INCOME_YEAR)
     
-    const result = calculateResidenceTax(1_010_000, 0, dependents)
+    const result = calculateResidenceTax(1_010_000, 0, dependents, TEST_INCOME_YEAR)
     expect(result).toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
@@ -217,9 +206,9 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
     }
-    const dependents = calculateDependentDeductions([spouse])
+    const dependents = calculateDependentDeductions([spouse], TEST_INCOME_YEAR)
     
-    const result = calculateResidenceTax(1_010_001, 0, dependents)
+    const result = calculateResidenceTax(1_010_001, 0, dependents, TEST_INCOME_YEAR)
     expect(result).not.toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
   
@@ -233,9 +222,9 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
     }
-    const dependents = calculateDependentDeductions([child])
+    const dependents = calculateDependentDeductions([child], TEST_INCOME_YEAR)
     
-    const result = calculateResidenceTax(1_010_000, 0, dependents)
+    const result = calculateResidenceTax(1_010_000, 0, dependents, TEST_INCOME_YEAR)
     expect(result).toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
@@ -257,9 +246,9 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
     }
-    const dependents = calculateDependentDeductions([spouse, child])
+    const dependents = calculateDependentDeductions([spouse, child], TEST_INCOME_YEAR)
     
-    const result = calculateResidenceTax(1_360_000, 0, dependents)
+    const result = calculateResidenceTax(1_360_000, 0, dependents, TEST_INCOME_YEAR)
     expect(result).toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
@@ -280,9 +269,9 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
     }
-    const dependents = calculateDependentDeductions([spouse, child])
+    const dependents = calculateDependentDeductions([spouse, child], TEST_INCOME_YEAR)
     
-    const result = calculateResidenceTax(1_360_001, 0, dependents)
+    const result = calculateResidenceTax(1_360_001, 0, dependents, TEST_INCOME_YEAR)
     expect(result).not.toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
@@ -298,12 +287,12 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 1_000_000 },
     }
-    const dependents = calculateDependentDeductions([spouse])
+    const dependents = calculateDependentDeductions([spouse], TEST_INCOME_YEAR)
     
     // If spouse counted: Limit would be 350k*(1+1)+310k = 1,010,000 -> 500,000 would be non-taxable
     // If spouse NOT counted: Limit is 450,000 -> 500,000 is taxable
     
-    const result = calculateResidenceTax(500_000, 0, dependents)
+    const result = calculateResidenceTax(500_000, 0, dependents, TEST_INCOME_YEAR)
     expect(result).not.toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
@@ -318,13 +307,13 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
     }
-    const dependents = calculateDependentDeductions([child])
+    const dependents = calculateDependentDeductions([child], TEST_INCOME_YEAR)
     
     // Verify deduction is actually 0 first
     expect(dependents.residenceTax.dependentDeduction).toBe(0)
     
     // Should be non-taxable at 1,000,000
-    const result = calculateResidenceTax(1_000_000, 0, dependents)
+    const result = calculateResidenceTax(1_000_000, 0, dependents, TEST_INCOME_YEAR)
     expect(result).toEqual(NON_TAXABLE_RESIDENCE_TAX_DETAIL)
   })
 
@@ -341,10 +330,10 @@ describe('Residence Tax - Non-Taxable Limit', () => {
       disability: 'none',
       income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
     }
-    const dependents = calculateDependentDeductions([spouse])
+    const dependents = calculateDependentDeductions([spouse], TEST_INCOME_YEAR)
     
     // Test income: 1,050,000 (Between 1,010,000 and 1,120,000)
-    const result = calculateResidenceTax(1_050_000, 0, dependents)
+    const result = calculateResidenceTax(1_050_000, 0, dependents, TEST_INCOME_YEAR)
     
     // Should have 0 income tax
     expect(result.city.cityIncomeTax).toBe(0)
@@ -361,12 +350,12 @@ describe('Residence Tax - Non-Taxable Limit', () => {
 
 describe('calculateResidenceTax - Personal Deduction Difference', () => {
   it('returns correct personal deduction difference for income <= 25M', () => {
-    const result = calculateResidenceTax(25_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS);
+    const result = calculateResidenceTax(25_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR);
     expect(result.personalDeductionDifference).toBe(50_000);
   })
 
   it('returns correct personal deduction difference for income > 25M', () => {
-    const result = calculateResidenceTax(26_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS);
+    const result = calculateResidenceTax(26_000_000, 1_000_000, EMPTY_DEPENDENT_DEDUCTIONS, TEST_INCOME_YEAR);
     expect(result.personalDeductionDifference).toBe(50_000);
   })
 })

--- a/src/__tests__/socialInsuranceRounding.test.ts
+++ b/src/__tests__/socialInsuranceRounding.test.ts
@@ -41,7 +41,6 @@ describe('Social Insurance Rounding', () => {
                 bonuses,
                 regionalRates,
                 false,
-                undefined,
                 2026
             );
 
@@ -64,7 +63,6 @@ describe('Social Insurance Rounding', () => {
                 bonuses,
                 regionalRates,
                 true,
-                undefined,
                 2026
             );
 

--- a/src/__tests__/socialInsuranceRounding.test.ts
+++ b/src/__tests__/socialInsuranceRounding.test.ts
@@ -40,7 +40,9 @@ describe('Social Insurance Rounding', () => {
             const result = calculateEmployeesHealthInsuranceBonusBreakdown(
                 bonuses,
                 regionalRates,
-                false
+                false,
+                undefined,
+                2026
             );
 
             expect(result[0]?.premium).toBe(1);
@@ -61,7 +63,9 @@ describe('Social Insurance Rounding', () => {
             const result = calculateEmployeesHealthInsuranceBonusBreakdown(
                 bonuses,
                 regionalRates,
-                true
+                true,
+                undefined,
+                2026
             );
 
             expect(result[0]?.premium).toBe(2);

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -128,13 +128,12 @@ describe('calculateTaxes', () => {
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(0)
     expect(result.residenceTax.totalResidenceTax).toBe(13_200)
-    expect(result.healthInsurance).toBe(74_916)
+    expect(result.healthInsurance).toBe(75_734)
     expect(result.pensionPayments).toBe(138_348)
-    // 1,500,000 / 12 = 125,000 per month
-    // 125,000 * 0.55% = 687.5 per month → 687 yen (exactly 0.5 yen → round down)
-    // 687 * 12 = 8,244 yen annually
-    expect(result.employmentInsurance).toBe(8_244)
-    expect(result.takeHomeIncome).toBe(1_265_292)
+    // Employment insurance for calendar 2026 blends fiscal-year rates per month:
+    // Jan–Mar at FY2025 (5.5‰), Apr–Dec at FY2026 (5.0‰).
+    expect(result.employmentInsurance).toBe(7_686)
+    expect(result.takeHomeIncome).toBe(1_265_032)
   })
 
   it('calculates taxes correctly for income between 1,950,000 and 3,300,000 yen', () => {
@@ -149,13 +148,12 @@ describe('calculateTaxes', () => {
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(14_100)
     expect(result.residenceTax.totalResidenceTax).toBe(91_100)
-    expect(result.healthInsurance).toBe(118_920)
+    expect(result.healthInsurance).toBe(120_220)
     expect(result.pensionPayments).toBe(219_600)
-    // 2,500,000 / 12 ≈ 208,333.33 per month
-    // 208,333.33 * 0.55% ≈ 1,145.83 per month → 1,146 yen (round up)
-    // 1,146 * 12 = 13,752 yen annually
-    expect(result.employmentInsurance).toBe(13_752)
-    expect(result.takeHomeIncome).toBe(2_042_528)
+    // Employment insurance for calendar 2026 blends fiscal-year rates per month:
+    // Jan–Mar at FY2025 (5.5‰), Apr–Dec at FY2026 (5.0‰).
+    expect(result.employmentInsurance).toBe(12_816)
+    expect(result.takeHomeIncome).toBe(2_042_164)
   })
 
   it('calculates taxes correctly for income between 3,300,000 and 6,950,000 yen', () => {
@@ -169,14 +167,13 @@ describe('calculateTaxes', () => {
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(91_700)
-    expect(result.residenceTax.totalResidenceTax).toBe(243_200)
-    expect(result.healthInsurance).toBe(243_780) // 410k * 4.955% = 20,315.5 -> 20,315 * 12
+    expect(result.residenceTax.totalResidenceTax).toBe(243_100)
+    expect(result.healthInsurance).toBe(246_449) // 410k SMR at the FY2026 employee rate
     expect(result.pensionPayments).toBe(450_180)
-    // 5,000,000 / 12 ≈ 416,666.67 per month
-    // 416,666.67 * 0.55% ≈ 2,291.67 per month → 2,292 yen (round up)
-    // 2,292 * 12 = 27,504 yen annually
-    expect(result.employmentInsurance).toBe(27_504)
-    expect(result.takeHomeIncome).toBe(3_943_636)
+    // Employment insurance for calendar 2026 blends fiscal-year rates per month:
+    // Jan–Mar at FY2025 (5.5‰), Apr–Dec at FY2026 (5.0‰).
+    expect(result.employmentInsurance).toBe(25_623)
+    expect(result.takeHomeIncome).toBe(3_942_948)
   })
 
   // Test cases for high income brackets
@@ -190,15 +187,14 @@ describe('calculateTaxes', () => {
       incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
-    expect(result.nationalIncomeTax).toBe(16_345_400) // 50M - 1.95M (employment deduction) - 1.815192M (social insurance) - 0 (basic deduction, income > 25M)
-    expect(result.residenceTax.totalResidenceTax).toBe(4_628_300)
-    expect(result.healthInsurance).toBe(826_488) // Capped at 68,874.5 -> 68,874 * 12
+    expect(result.nationalIncomeTax).toBe(16_350_000) // 50M − 1.95M employment deduction − social insurance − 0 basic deduction (income > 25M)
+    expect(result.residenceTax.totalResidenceTax).toBe(4_629_300)
+    expect(result.healthInsurance).toBe(835_527) // Capped at the FY2026 max monthly premium × 12
     expect(result.pensionPayments).toBe(713_700) // Capped at 59,475 * 12
-    // 50,000,000 / 12 ≈ 4,166,666.67 per month
-    // 4,166,666.67 * 0.55% = 22,916.67 per month → 22,917 yen (round up)
-    // 22,917 * 12 = 275,004 yen annually
-    expect(result.employmentInsurance).toBe(275_004)
-    expect(result.takeHomeIncome).toBe(27_211_108)
+    // Employment insurance for calendar 2026 blends fiscal-year rates per month:
+    // Jan–Mar at FY2025 (5.5‰), Apr–Dec at FY2026 (5.0‰).
+    expect(result.employmentInsurance).toBe(256_248)
+    expect(result.takeHomeIncome).toBe(27_215_225)
   })
 
   // Test edge cases
@@ -248,12 +244,12 @@ describe('calculateTaxes', () => {
       incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
-    expect(result.nationalIncomeTax).toBe(293_700)
-    expect(result.residenceTax.totalResidenceTax).toBe(384_000)
-    expect(result.healthInsurance).toBe(539_380)
+    expect(result.nationalIncomeTax).toBe(292_100)
+    expect(result.residenceTax.totalResidenceTax).toBe(383_200)
+    expect(result.healthInsurance).toBe(547_219)
     expect(result.pensionPayments).toBe(213_810)
     expect(result.employmentInsurance).toBe(0)
-    expect(result.takeHomeIncome).toBe(3_569_110)
+    expect(result.takeHomeIncome).toBe(3_563_671)
   })
 
   it('calculates taxes correctly for employment income with NHI', () => {
@@ -270,23 +266,23 @@ describe('calculateTaxes', () => {
     const result = calculateTaxes(inputs);
 
     // Should pay employment insurance (since it's employment income)
-    expect(result.employmentInsurance).toBe(27_504);
+    expect(result.employmentInsurance).toBe(25_623);
 
     // Should pay NHI premiums (not employee health insurance)
     // NHI should be calculated on net employment income (3,560,000) not gross (5,000,000)
-    expect(result.healthInsurance).toBe(389_620)
+    expect(result.healthInsurance).toBe(395_645)
 
     // Should pay national pension (not employee pension, since they're on NHI)
     expect(result.pensionPayments).toBe(213_810)
 
     // Tax calculations should use employment income deduction
     expect(result.netEmploymentIncome).toBe(3_560_000)
-    expect(result.nationalIncomeTax).toBe(96_400)
-    expect(result.residenceTax.totalResidenceTax).toBe(252_300)
+    expect(result.nationalIncomeTax).toBe(96_100)
+    expect(result.residenceTax.totalResidenceTax).toBe(251_800)
 
     // Total take-home should reflect employment income with NHI and National Pension
     // NHI calculated on net employment income results in lower premiums and higher take-home
-    expect(result.takeHomeIncome).toBe(4_020_366)
+    expect(result.takeHomeIncome).toBe(4_017_022)
   })
 
   it('calculates taxes correctly with DC plan contributions', () => {
@@ -322,7 +318,7 @@ describe('calculateTaxes', () => {
 
     // With 240,000 yen contribution at ~5% marginal tax rate (basic deduction increase reduces taxable income into lower bracket)
     // and around 24,000 yen in residence tax savings (10% rate)
-    expect(incomeTaxSavings).equals(12_200);
+    expect(incomeTaxSavings).equals(12_300);
     expect(residenceTaxSavings).equals(24_000);
   });
 
@@ -647,16 +643,14 @@ describe('calculateTaxes with Dependent Coverage', () => {
     expect(result.healthInsurance).toBe(0)
     expect(result.pensionPayments).toBe(0)
 
-    // Employment insurance should still be calculated
-    // 1,000,000 / 12 = 83,333.33 per month
-    // 83,333.33 * 0.55% = 458.33 per month → 458 yen (round down)
-    // 458 * 12 = 5,496 yen annually
-    expect(result.employmentInsurance).toBe(5_496)
+    // Employment insurance is still calculated (FY-blended across calendar 2026:
+    // Jan–Mar at FY2025 5.5‰, Apr–Dec at FY2026 5.0‰).
+    expect(result.employmentInsurance).toBe(5_127)
 
     // Income tax and residence tax should still be calculated normally
     // Net income: 1,000,000 - 740,000 = 260,000 (R8 minimum deduction)
-    // Social insurance deduction: 0 + 0 + 5,496 = 5,496
-    // Taxable income: 260,000 - 5,496 - 1,040,000 = negative, so 0
+    // Social insurance deduction: 0 + 0 + 5,127 = 5,127
+    // Taxable income: 260,000 - 5,127 - 1,040,000 = negative, so 0
     expect(result.nationalIncomeTax).toBe(0)
   })
 
@@ -678,11 +672,9 @@ describe('calculateTaxes with Dependent Coverage', () => {
     expect(result.healthInsurance).toBe(0)
     expect(result.pensionPayments).toBe(0)
 
-    // Employment insurance should still be calculated
-    // 1,299,999 / 12 = 108,333.25 per month
-    // 108,333.25 * 0.55% = 595.83 per month → 596 yen (round up)
-    // 596 * 12 = 7,152 yen annually
-    expect(result.employmentInsurance).toBe(7_152)
+    // Employment insurance is still calculated (FY-blended across calendar 2026:
+    // Jan–Mar at FY2025 5.5‰, Apr–Dec at FY2026 5.0‰).
+    expect(result.employmentInsurance).toBe(6_666)
   })
 
   it('calculates taxes correctly with dependent coverage and long-term care premium eligibility', () => {
@@ -1063,8 +1055,8 @@ describe('RSU (Restricted Stock Unit) income', () => {
     expect(result.pensionPayments).toBeLessThan(300_000);
 
     // 6. Employment insurance should be based on salary only
-    // 3M / 12 * 0.55% * 12 ≈ 16.5k
-    expect(result.employmentInsurance).toBe(16_500);
+    // 3M salary base, FY-blended 2026 employment insurance (≈ 15.4k)
+    expect(result.employmentInsurance).toBe(15_375);
 
     // 7. Income tax should be applied to full net income
     expect(result.nationalIncomeTax).toBeGreaterThan(0);

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -209,6 +209,7 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(0)
@@ -226,6 +227,7 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
     expect(result.nationalIncomeTax).toBe(0)
@@ -338,6 +340,7 @@ describe('calculateTaxes', () => {
       healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
 
@@ -636,6 +639,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
 
@@ -666,6 +670,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
 
@@ -690,6 +695,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
 
@@ -708,6 +714,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
       customEHIRates: {
         healthInsuranceRate: 5, // 5%
         longTermCareRate: 1, // 1%
@@ -731,6 +738,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: true,
       manualSocialInsuranceAmount: 500_000,
+      incomeYear: 2026,
     };
     const result = calculateTaxes(inputs);
 
@@ -754,6 +762,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
       dcPlanContributions: 0,
       manualSocialInsuranceEntry: false,
       manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
       incomeStreams: [
         {
           id: '1',
@@ -860,6 +869,7 @@ describe('Commuting Allowance', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
@@ -914,6 +924,7 @@ describe('Commuting Allowance', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);
@@ -963,6 +974,7 @@ describe('Commuting Allowance', () => {
       healthInsuranceProvider: DEFAULT_PROVIDER,
       region: "Tokyo",
       dependents: [], dcPlanContributions: 0, manualSocialInsuranceEntry: false, manualSocialInsuranceAmount: 0,
+      incomeYear: 2026,
     };
 
     const result = calculateTaxes(inputs);

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -378,12 +378,12 @@ describe('calculateEmploymentInsurance', () => {
     // 1,200,000 / 12 = 100,000 per month
     // 100,000 * 0.55% = 550 yen per month
     // 550 * 12 = 6,600 yen annually
-    expect(calculateEmploymentInsurance(1_200_000, [], 2025)).toBe(6_600)
+    expect(calculateEmploymentInsurance(1_200_000, 2025)).toBe(6_600)
 
     // 2,400,000 / 12 = 200,000 per month
     // 200,000 * 0.55% = 1,100 yen per month
     // 1,100 * 12 = 13,200 yen annually
-    expect(calculateEmploymentInsurance(2_400_000, [], 2025)).toBe(13_200)
+    expect(calculateEmploymentInsurance(2_400_000, 2025)).toBe(13_200)
   })
 
   // Test cases with non-even monthly amounts to verify rounding
@@ -392,39 +392,39 @@ describe('calculateEmploymentInsurance', () => {
     // 83,333.33 * 0.55% ≈ 458.33 per month
     // Rounded to 458 yen per month (decimal .33 < .50 → round down)
     // 458 * 12 = 5,496 yen annually
-    expect(calculateEmploymentInsurance(1_000_000, [], 2025)).toBe(5_496)
+    expect(calculateEmploymentInsurance(1_000_000, 2025)).toBe(5_496)
 
     // 1,100,000 / 12 ≈ 91,666.67 per month
     // 91,666.67 * 0.55% ≈ 504.17 per month
     // Rounded to 504 yen per month (decimal .17 < .50 → round down)
     // 504 * 12 = 6,048 yen annually
-    expect(calculateEmploymentInsurance(1_100_000, [], 2025)).toBe(6_048)
+    expect(calculateEmploymentInsurance(1_100_000, 2025)).toBe(6_048)
 
     // 1,111,111 / 12 ≈ 92,592.58 per month
     // 92,592.58 * 0.55% ≈ 509.26 per month
     // Rounded to 509 yen per month (decimal .26 < .50 → round down)
     // 509 * 12 = 6,108 yen annually
-    expect(calculateEmploymentInsurance(1_111_111, [], 2025)).toBe(6_108)
+    expect(calculateEmploymentInsurance(1_111_111, 2025)).toBe(6_108)
 
     // 1,200,001 / 12 = 100,000.083 per month
     // 100,000.083 * 0.55% ≈ 550.00046 per month
     // Rounded to 550 yen per month (decimal .00046 < .50 → round down)
     // 550 * 12 = 6,600 yen annually
-    expect(calculateEmploymentInsurance(1_200_001, [], 2025)).toBe(6_600)
+    expect(calculateEmploymentInsurance(1_200_001, 2025)).toBe(6_600)
 
     // 1,999,999 / 12 ≈ 166,666.58 per month
     // 166,666.58 * 0.55% ≈ 916.67 per month
     // Rounded to 917 yen per month (decimal .67 > .50 → round up)
     // 917 * 12 = 11,004 yen annually
-    expect(calculateEmploymentInsurance(1_999_999, [], 2025)).toBe(11_004)
+    expect(calculateEmploymentInsurance(1_999_999, 2025)).toBe(11_004)
   })
 
   it('returns 0 for zero income', () => {
-    expect(calculateEmploymentInsurance(0, [], 2025)).toBe(0)
+    expect(calculateEmploymentInsurance(0, 2025)).toBe(0)
   })
 
   it('returns 0 for negative income', () => {
-    expect(calculateEmploymentInsurance(-1_000_000, [], 2025)).toBe(0)
+    expect(calculateEmploymentInsurance(-1_000_000, 2025)).toBe(0)
   })
 
   // Test with very small amounts to ensure rounding works correctly
@@ -433,13 +433,13 @@ describe('calculateEmploymentInsurance', () => {
     // 833.33 * 0.55% ≈ 4.58 per month
     // Rounded to 5 yen per month (decimal .58 > .50 → round up)
     // 5 * 12 = 60 yen annually
-    expect(calculateEmploymentInsurance(10_000, [], 2025)).toBe(60)
+    expect(calculateEmploymentInsurance(10_000, 2025)).toBe(60)
 
     // 9,090 / 12 = 757.5 per month
     // 757.5 * 0.55% ≈ 4.17 per month
     // Rounded to 4 yen per month (decimal .17 < .50 → round down)
     // 4 * 12 = 48 yen annually
-    expect(calculateEmploymentInsurance(9_090, [], 2025)).toBe(48)
+    expect(calculateEmploymentInsurance(9_090, 2025)).toBe(48)
   })
 
   it('applies split rates when the rate changes mid-year (2026: 0.55% Jan-Mar, 0.50% Apr-Dec)', () => {
@@ -447,31 +447,31 @@ describe('calculateEmploymentInsurance', () => {
     // Jan-Mar: 100,000 * 0.55% = 550 × 3 = 1,650
     // Apr-Dec: 100,000 * 0.50% = 500 × 9 = 4,500
     // Total: 6,150
-    expect(calculateEmploymentInsurance(1_200_000, [], 2026)).toBe(6_150)
+    expect(calculateEmploymentInsurance(1_200_000, 2026)).toBe(6_150)
 
     // 5,000,000 / 12 ≈ 416,666.67 per month
     // Jan-Mar: 416,666.67 * 0.55% = 2,291.67 → 2,292 × 3 = 6,876
     // Apr-Dec: 416,666.67 * 0.50% = 2,083.33 → 2,083 × 9 = 18,747
     // Total: 25,623
-    expect(calculateEmploymentInsurance(5_000_000, [], 2026)).toBe(25_623)
+    expect(calculateEmploymentInsurance(5_000_000, 2026)).toBe(25_623)
   })
 
   it('uses uniform rate for years within a single fiscal year period', () => {
     // Year 2025: all 12 months use 0.55% (FY2025: Apr 2025 – Mar 2026)
-    expect(calculateEmploymentInsurance(1_200_000, [], 2025)).toBe(6_600)
+    expect(calculateEmploymentInsurance(1_200_000, 2025)).toBe(6_600)
 
     // Year 2027: all 12 months use 0.50% (FY2026 rate applies to Jan-Mar, FY2026 also Apr-Dec)
-    expect(calculateEmploymentInsurance(1_200_000, [], 2027)).toBe(6_000)
+    expect(calculateEmploymentInsurance(1_200_000, 2027)).toBe(6_000)
   })
 
   it('applies the correct rate for bonuses based on their month (2026)', () => {
     // Bonus in February (month 1) → 0.55% rate
     // 500,000 * 0.55% = 2,750
-    expect(calculateEmploymentInsurance(0, [{ id: 'b1', type: 'bonus', amount: 500_000, month: 1 }], 2026)).toBe(2_750)
+    expect(calculateEmploymentInsurance(0, 2026, [{ id: 'b1', type: 'bonus', amount: 500_000, month: 1 }])).toBe(2_750)
 
     // Bonus in June (month 5) → 0.50% rate
     // 500,000 * 0.50% = 2,500
-    expect(calculateEmploymentInsurance(0, [{ id: 'b2', type: 'bonus', amount: 500_000, month: 5 }], 2026)).toBe(2_500)
+    expect(calculateEmploymentInsurance(0, 2026, [{ id: 'b2', type: 'bonus', amount: 500_000, month: 5 }])).toBe(2_500)
   })
 })
 

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -821,7 +821,7 @@ describe('calculateTotalNetIncome', () => {
   it('calculates total net income correctly for business only', () => {
     // Business 5M, Deduction 650k -> Taxable Business Income = 4.35M
     const incomeStreams = [{ type: 'business' as const, amount: 5_000_000, blueFilerDeduction: 650_000, id: 'test' }];
-    expect(calculateTotalNetIncome(incomeStreams)).toBe(4_350_000);
+    expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(4_350_000);
   });
 
   it('calculates total net income correctly for mixed income', () => {

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1,15 +1,10 @@
 // Copyright the original author or authors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { calculateTaxes, calculateNetEmploymentIncome, calculateEmploymentInsurance, calculateNationalIncomeTaxBasicDeduction, calculateNationalIncomeTax, calculateTotalNetIncome } from '../utils/taxCalculations'
 import { DEFAULT_PROVIDER, NATIONAL_HEALTH_INSURANCE_ID, CUSTOM_PROVIDER_ID } from '../types/healthInsurance'
 import type { Dependent } from '../types/dependents'
-
-// Pin the year so employment insurance rate lookups are deterministic.
-// Year 2025: all 12 months use the FY2025 rate (0.55%).
-beforeAll(() => { vi.useFakeTimers({ now: new Date(2025, 5, 1) }) })
-afterAll(() => { vi.useRealTimers() })
 
 describe('calculateNetEmploymentIncome', () => {
   describe('2026 tiers (R8)', () => {
@@ -374,17 +369,21 @@ describe('calculateTaxes', () => {
 })
 
 describe('calculateEmploymentInsurance', () => {
+  // These rounding tests pass an explicit year 2025, whose 12 months all fall under
+  // the uniform FY2025 rate (5.5‰), so the per-month rounding can be checked against a
+  // single rate. (FY2026 onward blends rates within the calendar year — see the
+  // fiscal-year tests below.)
   // Test cases with annual amounts that divide evenly by 12
   it('calculates insurance for employment income with even monthly amounts', () => {
     // 1,200,000 / 12 = 100,000 per month
     // 100,000 * 0.55% = 550 yen per month
     // 550 * 12 = 6,600 yen annually
-    expect(calculateEmploymentInsurance(1_200_000)).toBe(6_600)
+    expect(calculateEmploymentInsurance(1_200_000, [], 2025)).toBe(6_600)
 
     // 2,400,000 / 12 = 200,000 per month
     // 200,000 * 0.55% = 1,100 yen per month
     // 1,100 * 12 = 13,200 yen annually
-    expect(calculateEmploymentInsurance(2_400_000)).toBe(13_200)
+    expect(calculateEmploymentInsurance(2_400_000, [], 2025)).toBe(13_200)
   })
 
   // Test cases with non-even monthly amounts to verify rounding
@@ -393,39 +392,39 @@ describe('calculateEmploymentInsurance', () => {
     // 83,333.33 * 0.55% ≈ 458.33 per month
     // Rounded to 458 yen per month (decimal .33 < .50 → round down)
     // 458 * 12 = 5,496 yen annually
-    expect(calculateEmploymentInsurance(1_000_000)).toBe(5_496)
+    expect(calculateEmploymentInsurance(1_000_000, [], 2025)).toBe(5_496)
 
     // 1,100,000 / 12 ≈ 91,666.67 per month
     // 91,666.67 * 0.55% ≈ 504.17 per month
     // Rounded to 504 yen per month (decimal .17 < .50 → round down)
     // 504 * 12 = 6,048 yen annually
-    expect(calculateEmploymentInsurance(1_100_000)).toBe(6_048)
+    expect(calculateEmploymentInsurance(1_100_000, [], 2025)).toBe(6_048)
 
     // 1,111,111 / 12 ≈ 92,592.58 per month
     // 92,592.58 * 0.55% ≈ 509.26 per month
     // Rounded to 509 yen per month (decimal .26 < .50 → round down)
     // 509 * 12 = 6,108 yen annually
-    expect(calculateEmploymentInsurance(1_111_111)).toBe(6_108)
+    expect(calculateEmploymentInsurance(1_111_111, [], 2025)).toBe(6_108)
 
     // 1,200,001 / 12 = 100,000.083 per month
     // 100,000.083 * 0.55% ≈ 550.00046 per month
     // Rounded to 550 yen per month (decimal .00046 < .50 → round down)
     // 550 * 12 = 6,600 yen annually
-    expect(calculateEmploymentInsurance(1_200_001)).toBe(6_600)
+    expect(calculateEmploymentInsurance(1_200_001, [], 2025)).toBe(6_600)
 
     // 1,999,999 / 12 ≈ 166,666.58 per month
     // 166,666.58 * 0.55% ≈ 916.67 per month
     // Rounded to 917 yen per month (decimal .67 > .50 → round up)
     // 917 * 12 = 11,004 yen annually
-    expect(calculateEmploymentInsurance(1_999_999)).toBe(11_004)
+    expect(calculateEmploymentInsurance(1_999_999, [], 2025)).toBe(11_004)
   })
 
   it('returns 0 for zero income', () => {
-    expect(calculateEmploymentInsurance(0)).toBe(0)
+    expect(calculateEmploymentInsurance(0, [], 2025)).toBe(0)
   })
 
   it('returns 0 for negative income', () => {
-    expect(calculateEmploymentInsurance(-1_000_000)).toBe(0)
+    expect(calculateEmploymentInsurance(-1_000_000, [], 2025)).toBe(0)
   })
 
   // Test with very small amounts to ensure rounding works correctly
@@ -434,13 +433,13 @@ describe('calculateEmploymentInsurance', () => {
     // 833.33 * 0.55% ≈ 4.58 per month
     // Rounded to 5 yen per month (decimal .58 > .50 → round up)
     // 5 * 12 = 60 yen annually
-    expect(calculateEmploymentInsurance(10_000)).toBe(60)
+    expect(calculateEmploymentInsurance(10_000, [], 2025)).toBe(60)
 
     // 9,090 / 12 = 757.5 per month
     // 757.5 * 0.55% ≈ 4.17 per month
     // Rounded to 4 yen per month (decimal .17 < .50 → round down)
     // 4 * 12 = 48 yen annually
-    expect(calculateEmploymentInsurance(9_090)).toBe(48)
+    expect(calculateEmploymentInsurance(9_090, [], 2025)).toBe(48)
   })
 
   it('applies split rates when the rate changes mid-year (2026: 0.55% Jan-Mar, 0.50% Apr-Dec)', () => {

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -39,7 +39,8 @@ interface AdditionalDeductionsModalProps {
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
   onHomeLoanTaxCreditChange: (input: HomeLoanTaxCreditInput | undefined) => void;
   homeLoanTaxCreditResult?: HomeLoanTaxCreditResult | undefined;
-  currentYear: number;
+  /** Income year being modeled; upper bound for the home-loan move-in-year dropdown. */
+  incomeYear: number;
 }
 
 const SectionHeader: React.FC<{ children: React.ReactNode; tooltip?: string }> = ({ children, tooltip }) => (
@@ -66,22 +67,22 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
   homeLoanTaxCredit,
   onHomeLoanTaxCreditChange,
   homeLoanTaxCreditResult,
-  currentYear,
+  incomeYear,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const effectiveHomeLoan: HomeLoanTaxCreditInput = homeLoanTaxCredit ?? {
-    moveInYear: currentYear,
+    moveInYear: incomeYear,
     creditAmount: 0,
   };
 
   const moveInYearOptions = React.useMemo(() => {
-    const floor = earliestEligibleMoveInYear(currentYear);
+    const floor = earliestEligibleMoveInYear(incomeYear);
     const years: number[] = [];
-    for (let y = currentYear; y >= floor; y--) years.push(y);
+    for (let y = incomeYear; y >= floor; y--) years.push(y);
     return years;
-  }, [currentYear]);
+  }, [incomeYear]);
 
   const updateHomeLoan = (patch: Partial<HomeLoanTaxCreditInput>) => {
     onHomeLoanTaxCreditChange({ ...effectiveHomeLoan, ...patch });

--- a/src/components/TakeHomeCalculator/Dependents/DependentForm.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/DependentForm.tsx
@@ -377,7 +377,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
                 };
                 
                 // Calculate all deductions for this dependent
-                const results = calculateDependentDeductions([tempDependent], undefined, incomeYear);
+                const results = calculateDependentDeductions([tempDependent], incomeYear);
                 const rows: React.ReactNode[] = [];
                 
                 // Dependent Deduction

--- a/src/components/TakeHomeCalculator/Dependents/DependentForm.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/DependentForm.tsx
@@ -48,6 +48,8 @@ interface DependentFormProps {
   dependent: OtherDependent | null;
   onSave: (dependent: OtherDependent) => void;
   onCancel: () => void;
+  /** Income year for the net-income and deduction preview calculations. */
+  incomeYear: number;
 }
 
 /**
@@ -57,6 +59,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
   dependent,
   onSave,
   onCancel,
+  incomeYear,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -168,7 +171,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <Typography variant="caption" color="text.secondary">Net (所得)</Typography>
                 <Typography variant="body2">
-                  {formatJPY(calculateNetEmploymentIncome(income.grossEmploymentIncome))}
+                  {formatJPY(calculateNetEmploymentIncome(income.grossEmploymentIncome, incomeYear))}
                 </Typography>
               </Box>
             </Box>
@@ -207,7 +210,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
                   Total (合計所得金額)
                 </Typography>
                 <Typography variant="body2" sx={{ fontWeight: "bold" }}>
-                  {formatJPY(calculateDependentTotalNetIncome(income))}
+                  {formatJPY(calculateDependentTotalNetIncome(income, incomeYear))}
                 </Typography>
               </Box>
             </Box>
@@ -243,7 +246,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
                   </TableCell>
                   <TableCell align="right">
                     <Typography variant="body2">
-                      {formatJPY(calculateNetEmploymentIncome(income.grossEmploymentIncome))}
+                      {formatJPY(calculateNetEmploymentIncome(income.grossEmploymentIncome, incomeYear))}
                     </Typography>
                   </TableCell>
                 </TableRow>
@@ -276,7 +279,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
                   <TableCell align="right"></TableCell>
                   <TableCell align="right">
                     <Typography variant="body2" sx={{ fontWeight: "bold" }}>
-                      {formatJPY(calculateDependentTotalNetIncome(income))}
+                      {formatJPY(calculateDependentTotalNetIncome(income, incomeYear))}
                     </Typography>
                   </TableCell>
                 </TableRow>
@@ -374,7 +377,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
                 };
                 
                 // Calculate all deductions for this dependent
-                const results = calculateDependentDeductions([tempDependent]);
+                const results = calculateDependentDeductions([tempDependent], undefined, incomeYear);
                 const rows: React.ReactNode[] = [];
                 
                 // Dependent Deduction

--- a/src/components/TakeHomeCalculator/Dependents/DependentsModal.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/DependentsModal.tsx
@@ -358,7 +358,7 @@ export const DependentsModal: React.FC<DependentsModalProps> = ({
                           );
                         }
 
-                        const deductionResults = calculateDependentDeductions(allDependents, taxpayerNetIncome, incomeYear);
+                        const deductionResults = calculateDependentDeductions(allDependents, incomeYear, taxpayerNetIncome);
 
                         // Group deductions by type and amount
                         interface DeductionGroup {

--- a/src/components/TakeHomeCalculator/Dependents/DependentsModal.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/DependentsModal.tsx
@@ -110,7 +110,7 @@ export const DependentsModal: React.FC<DependentsModalProps> = ({
   const getDependentSummary = (dependent: OtherDependent): string => {
     const relationship = RELATIONSHIPS.find(r => r.value === dependent.relationship)?.label || 'Unknown';
     const ageLabel = DEPENDENT_AGE_CATEGORIES.find(a => a.value === dependent.ageCategory)?.label || 'Unknown';
-    const totalNetIncome = calculateDependentTotalNetIncome(dependent.income);
+    const totalNetIncome = calculateDependentTotalNetIncome(dependent.income, incomeYear);
     const incomeLabel = totalNetIncome === 0 ? 'No income' : `Net income: ¥${totalNetIncome.toLocaleString()}`;
     return `${relationship}, Age: ${ageLabel}, ${incomeLabel}`;
   };
@@ -221,6 +221,7 @@ export const DependentsModal: React.FC<DependentsModalProps> = ({
             dependent={editingDependent}
             onSave={editingDependent ? handleUpdateDependent : handleAddDependent}
             onCancel={handleCancelForm}
+            incomeYear={incomeYear}
           />
         ) : (
           <Box>
@@ -229,6 +230,7 @@ export const DependentsModal: React.FC<DependentsModalProps> = ({
             <SpouseSection
               spouse={spouse || null}
               onChange={handleSpouseChange}
+              incomeYear={incomeYear}
             />
 
             <Divider sx={{ my: 3 }} />

--- a/src/components/TakeHomeCalculator/Dependents/DependentsModal.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/DependentsModal.tsx
@@ -42,6 +42,8 @@ interface DependentsModalProps {
   dependents: Dependent[];
   onDependentsChange: (dependents: Dependent[]) => void;
   taxpayerNetIncome: number;
+  /** Income year used for the dependent-deduction eligibility/threshold lookup. */
+  incomeYear: number;
 }
 
 /**
@@ -54,6 +56,7 @@ export const DependentsModal: React.FC<DependentsModalProps> = ({
   dependents,
   onDependentsChange,
   taxpayerNetIncome,
+  incomeYear,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -353,7 +356,7 @@ export const DependentsModal: React.FC<DependentsModalProps> = ({
                           );
                         }
 
-                        const deductionResults = calculateDependentDeductions(allDependents, taxpayerNetIncome);
+                        const deductionResults = calculateDependentDeductions(allDependents, taxpayerNetIncome, incomeYear);
 
                         // Group deductions by type and amount
                         interface DeductionGroup {

--- a/src/components/TakeHomeCalculator/Dependents/SpouseSection.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/SpouseSection.tsx
@@ -40,9 +40,11 @@ import Divider from '@mui/material/Divider';
 interface SpouseSectionProps {
   spouse: Spouse | null;
   onChange: (spouse: Spouse | null) => void;
+  /** Income year for the net-income preview calculations. */
+  incomeYear: number;
 }
 
-export default function SpouseSection({ spouse, onChange }: SpouseSectionProps) {
+export default function SpouseSection({ spouse, onChange, incomeYear }: SpouseSectionProps) {
   const [hasSpouse, setHasSpouse] = useState(spouse !== null);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -129,7 +131,7 @@ export default function SpouseSection({ spouse, onChange }: SpouseSectionProps) 
                   <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <Typography variant="caption" color="text.secondary">Net (所得)</Typography>
                     <Typography variant="body2">
-                      {formatJPY(calculateNetEmploymentIncome(spouse.income.grossEmploymentIncome))}
+                      {formatJPY(calculateNetEmploymentIncome(spouse.income.grossEmploymentIncome, incomeYear))}
                     </Typography>
                   </Box>
                 </Box>
@@ -170,7 +172,7 @@ export default function SpouseSection({ spouse, onChange }: SpouseSectionProps) 
                       Total (合計所得金額)
                     </Typography>
                     <Typography variant="body2" sx={{ fontWeight: "bold" }}>
-                      {formatJPY(calculateDependentTotalNetIncome(spouse.income))}
+                      {formatJPY(calculateDependentTotalNetIncome(spouse.income, incomeYear))}
                     </Typography>
                   </Box>
                 </Box>
@@ -208,7 +210,7 @@ export default function SpouseSection({ spouse, onChange }: SpouseSectionProps) 
                       </TableCell>
                       <TableCell align="right">
                         <Typography variant="body2">
-                          {formatJPY(calculateNetEmploymentIncome(spouse.income.grossEmploymentIncome))}
+                          {formatJPY(calculateNetEmploymentIncome(spouse.income.grossEmploymentIncome, incomeYear))}
                         </Typography>
                       </TableCell>
                     </TableRow>
@@ -243,7 +245,7 @@ export default function SpouseSection({ spouse, onChange }: SpouseSectionProps) 
                       <TableCell align="right"></TableCell>
                       <TableCell align="right">
                         <Typography variant="body2" sx={{ fontWeight: "bold" }}>
-                          {formatJPY(calculateDependentTotalNetIncome(spouse.income))}
+                          {formatJPY(calculateDependentTotalNetIncome(spouse.income, incomeYear))}
                         </Typography>
                       </TableCell>
                     </TableRow>

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -1001,7 +1001,7 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({ inputs, onInput
         homeLoanTaxCredit={inputs.homeLoanTaxCredit}
         onHomeLoanTaxCreditChange={handleHomeLoanTaxCreditChange}
         homeLoanTaxCreditResult={homeLoanTaxCreditResult}
-        currentYear={new Date().getFullYear()}
+        incomeYear={inputs.incomeYear}
       />
     </Box>
   );

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -449,7 +449,7 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({ inputs, onInput
 
   // We only need the total net income for the dependents modal. Pass dependents so the
   // 所得金額調整控除 is reflected, keeping the modal's eligibility hints consistent with the results.
-  const taxpayerNetIncome = React.useMemo(() => calculateTotalNetIncome(inputs.incomeStreams, undefined, inputs.dependents), [inputs.incomeStreams, inputs.dependents]);
+  const taxpayerNetIncome = React.useMemo(() => calculateTotalNetIncome(inputs.incomeStreams, inputs.incomeYear, inputs.dependents), [inputs.incomeStreams, inputs.incomeYear, inputs.dependents]);
 
   return (
     <Box className="form-container" sx={{ p: { xs: 1.2, sm: 2 }, bgcolor: 'background.paper', borderRadius: 3, boxShadow: 2 }}>
@@ -983,6 +983,7 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({ inputs, onInput
         dependents={inputs.dependents}
         onDependentsChange={handleDependentsChange}
         taxpayerNetIncome={taxpayerNetIncome}
+        incomeYear={inputs.incomeYear}
       />
 
       <IncomeDetailsModal

--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -308,7 +308,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
                   const taxResults = calculateTaxes(taxInputs);
 
                   // Use the calculated results for cap detection
-                  const capStatus = detectCaps(taxResults, undefined, incomeYear);
+                  const capStatus = detectCaps(taxResults, incomeYear);
 
                   if (capStatus.healthInsuranceCapped || capStatus.pensionCapped) {
                     const cappedItems: string[] = [];

--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -308,7 +308,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
                   const taxResults = calculateTaxes(taxInputs);
 
                   // Use the calculated results for cap detection
-                  const capStatus = detectCaps(taxResults);
+                  const capStatus = detectCaps(taxResults, undefined, incomeYear);
 
                   if (capStatus.healthInsuranceCapped || capStatus.pensionCapped) {
                     const cappedItems: string[] = [];

--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -101,6 +101,7 @@ ChartJS.register(
 
 interface TakeHomeChartProps {
   currentIncome: number;
+  incomeYear: number;
   isEmploymentIncome: boolean;
   isSubjectToLongTermCarePremium: boolean;
   healthInsuranceProvider: HealthInsuranceProviderId;
@@ -181,6 +182,7 @@ const getPercentileBand = (income: number): { label: string; color: string } => 
 
 const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
   currentIncome,
+  incomeYear,
   isEmploymentIncome,
   isSubjectToLongTermCarePremium,
   healthInsuranceProvider,
@@ -251,6 +253,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
   const chartData = useMemo<ChartData<'bar' | 'line'>>(
     () => generateChartData(chartRange, {
       isEmploymentIncome,
+      incomeYear,
       isSubjectToLongTermCarePremium,
       healthInsuranceProvider,
       region,
@@ -261,7 +264,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
       manualSocialInsuranceAmount,
       incomeStreams
     }),
-    [chartRange, isEmploymentIncome, isSubjectToLongTermCarePremium, healthInsuranceProvider, region, dcPlanContributions, dependents, customEHIRates, manualSocialInsuranceEntry, manualSocialInsuranceAmount, incomeStreams]
+    [chartRange, isEmploymentIncome, incomeYear, isSubjectToLongTermCarePremium, healthInsuranceProvider, region, dcPlanContributions, dependents, customEHIRates, manualSocialInsuranceEntry, manualSocialInsuranceAmount, incomeStreams]
   );
 
   // Get chart options using the utility function
@@ -288,6 +291,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
                   // Calculate full tax results for this income level to get cap status
                   const taxInputs = {
                     annualIncome: income,
+                    incomeYear,
                     isEmploymentIncome,
                     isSubjectToLongTermCarePremium,
                     healthInsuranceProvider,
@@ -322,7 +326,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
         },
       };
     },
-    [chartRange, currentIncome, useCompactLabelFormat, isEmploymentIncome, isSubjectToLongTermCarePremium, healthInsuranceProvider, region, dcPlanContributions, dependents, customEHIRates, manualSocialInsuranceEntry, manualSocialInsuranceAmount]
+    [chartRange, currentIncome, incomeYear, useCompactLabelFormat, isEmploymentIncome, isSubjectToLongTermCarePremium, healthInsuranceProvider, region, dcPlanContributions, dependents, customEHIRates, manualSocialInsuranceEntry, manualSocialInsuranceAmount]
   );
 
   // Use media query to determine if we should show minor marks

--- a/src/components/TakeHomeCalculator/tabs/EmploymentInsuranceRateTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/EmploymentInsuranceRateTooltip.tsx
@@ -20,11 +20,11 @@ const totalStyle = { ...rightCellStyle, borderTop: '1px solid var(--divider)', f
 
 interface SalaryTooltipProps {
     monthlyIncome: number;
+    /** Income year whose fiscal-year rates to display. */
+    year: number;
 }
 
-const SalaryBreakdownTooltip: React.FC<SalaryTooltipProps> = ({ monthlyIncome }) => {
-    const year = new Date().getFullYear();
-
+const SalaryBreakdownTooltip: React.FC<SalaryTooltipProps> = ({ monthlyIncome, year }) => {
     const months = Array.from({ length: 12 }, (_, month) => {
         const rate = getEmploymentInsuranceRate(year, month);
         const premium = roundSocialInsurancePremium(monthlyIncome * rate);
@@ -68,11 +68,11 @@ const SalaryBreakdownTooltip: React.FC<SalaryTooltipProps> = ({ monthlyIncome })
 
 interface BonusTooltipProps {
     bonuses: BonusIncomeStream[];
+    /** Income year whose fiscal-year rates to display. */
+    year: number;
 }
 
-const BonusBreakdownTooltip: React.FC<BonusTooltipProps> = ({ bonuses }) => {
-    const year = new Date().getFullYear();
-
+const BonusBreakdownTooltip: React.FC<BonusTooltipProps> = ({ bonuses, year }) => {
     const rows = bonuses.map((bonus) => {
         const rate = getEmploymentInsuranceRate(year, bonus.month);
         const premium = roundSocialInsurancePremium(bonus.amount * rate);

--- a/src/components/TakeHomeCalculator/tabs/HealthInsuranceBonusTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/HealthInsuranceBonusTooltip.tsx
@@ -20,7 +20,7 @@ const HealthInsuranceBonusTooltip: React.FC<HealthInsuranceBonusTooltipProps> = 
   const provider = inputs.healthInsuranceProvider;
   const region = inputs.region;
   const includeLTC = inputs.isSubjectToLongTermCarePremium;
-  const year = new Date().getFullYear();
+  const year = inputs.incomeYear;
 
   let providerLabel = '';
   let sourceUrl: string | undefined;
@@ -29,7 +29,8 @@ const HealthInsuranceBonusTooltip: React.FC<HealthInsuranceBonusTooltipProps> = 
     providerLabel = "Custom Provider";
   } else {
     const providerDef = PROVIDER_DEFINITIONS[provider];
-    const regionalRates = getRegionalRatesForMonth(provider, region, new Date().getFullYear(), new Date().getMonth());
+    // April (month 3) → the income year's fiscal-year rates; this lookup only needs the source URL.
+    const regionalRates = getRegionalRatesForMonth(provider, region, year, 3);
     if (regionalRates) {
       sourceUrl = regionalRates.source;
     }

--- a/src/components/TakeHomeCalculator/tabs/HealthInsurancePremiumTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/HealthInsurancePremiumTooltip.tsx
@@ -133,7 +133,7 @@ const PortionBreakdown: React.FC<{
 
 export const NHIPortionTooltip: React.FC<NHIPortionTooltipProps> = ({ portion, results, inputs }) => {
   const region = inputs.region;
-  const year = new Date().getFullYear();
+  const year = inputs.incomeYear;
   const prevFYData = getNHIParamsForMonth(region, year, 0);  // Jan → previous FY
   const currFYData = getNHIParamsForMonth(region, year, 3);  // Apr → current FY
 
@@ -308,7 +308,7 @@ const HealthInsurancePremiumTooltip: React.FC<HealthInsurancePremiumTooltipProps
 
   if (provider === NATIONAL_HEALTH_INSURANCE_ID) {
     // National Health Insurance - overview tooltip on the heading
-    const year = new Date().getFullYear();
+    const year = inputs.incomeYear;
     const prevFYData = getNHIParamsForMonth(region, year, 0);  // Jan → previous FY
     const currFYData = getNHIParamsForMonth(region, year, 3);  // Apr → current FY
     const regionData = currFYData;
@@ -386,7 +386,7 @@ const HealthInsurancePremiumTooltip: React.FC<HealthInsurancePremiumTooltipProps
       throw new Error('standardMonthlyRemuneration is required for the Employee Health Insurance tooltip');
     }
 
-    const year = new Date().getFullYear();
+    const year = inputs.incomeYear;
 
     if (provider === CUSTOM_PROVIDER_ID) {
       employeeRate = (inputs.customEHIRates?.healthInsuranceRate ?? 0) / 100;
@@ -394,9 +394,8 @@ const HealthInsurancePremiumTooltip: React.FC<HealthInsurancePremiumTooltipProps
       // For custom provider, we don't know the employer rate, so we leave it undefined.
       providerLabel = "Custom Provider";
     } else {
-      // Use the current month's rates for display
-      const now = new Date();
-      const regionalRates = getRegionalRatesForMonth(provider, region, now.getFullYear(), now.getMonth());
+      // Use a representative month of the income year (April = fiscal-year start) for the headline rate.
+      const regionalRates = getRegionalRatesForMonth(provider, region, year, 3);
       const providerDef = PROVIDER_DEFINITIONS[provider];
 
       if (regionalRates) {

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -537,14 +537,14 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
             label="Salary Premium"
             value={formatJPY((results.employmentInsurance ?? 0) - (results.employmentInsuranceOnBonus ?? 0))}
             type="indented"
-            labelSuffix={<SalaryBreakdownTooltip monthlyIncome={rawMonthlyRemuneration} />}
+            labelSuffix={<SalaryBreakdownTooltip monthlyIncome={rawMonthlyRemuneration} year={inputs.incomeYear} />}
           />
           {results.employmentInsuranceOnBonus !== undefined && results.employmentInsuranceOnBonus > 0 && (
             <ResultRow
               label="Bonus Premium"
               value={formatJPY(results.employmentInsuranceOnBonus)}
               type="indented"
-              labelSuffix={<BonusBreakdownTooltip bonuses={bonuses} />}
+              labelSuffix={<BonusBreakdownTooltip bonuses={bonuses} year={inputs.incomeYear} />}
             />
           )}
           <ResultRow

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -63,20 +63,23 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
       healthInsuranceBreakdown = calculateEmployeesHealthInsuranceBonusBreakdown(
         bonuses,
         rates,
-        inputs.isSubjectToLongTermCarePremium
+        inputs.isSubjectToLongTermCarePremium,
+        undefined,
+        inputs.incomeYear
       );
     } else {
       healthInsuranceBreakdown = calculateEmployeesHealthInsuranceBonusBreakdown(
         bonuses,
         provider,
         region,
-        inputs.isSubjectToLongTermCarePremium
+        inputs.isSubjectToLongTermCarePremium,
+        inputs.incomeYear
       );
     }
   }
 
   // Detect if any caps are applied
-  const capStatus = detectCaps(results, healthInsuranceBreakdown);
+  const capStatus = detectCaps(results, healthInsuranceBreakdown, inputs.incomeYear);
 
   if (results.socialInsuranceOverride !== undefined) {
     return (

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -186,7 +186,7 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
                     grossEmploymentIncome={grossEmploymentIncome}
                     netEmploymentIncome={results.netEmploymentIncome}
                     incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
-                    year={inputs.incomeYear ?? new Date().getFullYear()}
+                    year={inputs.incomeYear}
                   />
                 </span>
               }
@@ -497,7 +497,7 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
           labelSuffix={isNationalHealthInsurance ? (
             <DetailedTooltip
               title="Pension Contribution">
-              <NationalPensionTooltip year={inputs.incomeYear ?? new Date().getFullYear()} />
+              <NationalPensionTooltip year={inputs.incomeYear} />
             </DetailedTooltip>
           ) : undefined}
           value={formatJPY(results.pensionPayments)}

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -64,7 +64,6 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
         bonuses,
         rates,
         inputs.isSubjectToLongTermCarePremium,
-        undefined,
         inputs.incomeYear
       );
     } else {
@@ -72,14 +71,14 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
         bonuses,
         provider,
         region,
-        inputs.isSubjectToLongTermCarePremium,
-        inputs.incomeYear
+        inputs.incomeYear,
+        inputs.isSubjectToLongTermCarePremium
       );
     }
   }
 
   // Detect if any caps are applied
-  const capStatus = detectCaps(results, healthInsuranceBreakdown, inputs.incomeYear);
+  const capStatus = detectCaps(results, inputs.incomeYear, healthInsuranceBreakdown);
 
   if (results.socialInsuranceOverride !== undefined) {
     return (

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -111,7 +111,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
   // Almost taxable income but before applying the basic deduction
   const subtotalIncome = (results.totalNetIncome ?? results.annualIncome) - totalSocialInsurance - (results.dcPlanContributions ?? 0);
   const totalTaxes = results.nationalIncomeTax + results.residenceTax.totalResidenceTax;
-  const incomeYear = inputs.incomeYear ?? new Date().getFullYear();
+  const incomeYear = inputs.incomeYear;
   const basicDeductionTiers = getNationalBasicDeductionTiers(incomeYear);
 
   // Calculate separated gross income

--- a/src/data/employeesHealthInsurance/providerRates.ts
+++ b/src/data/employeesHealthInsurance/providerRates.ts
@@ -107,15 +107,15 @@ export function generatePremiumTableFromRates(
  * Generate a premium table for display purposes
  *
  * @param providerId Provider key
- * @param region Region key
  * @param year Calendar year for rate lookup
  * @param month 0-indexed month for rate lookup
+ * @param region Region key
  */
 export function generateHealthInsurancePremiumTable(
   providerId: string,
-  region: string = 'DEFAULT',
   year: number,
-  month: number
+  month: number,
+  region: string = 'DEFAULT'
 ): Array<{
   minIncomeInclusive: number;
   maxIncomeExclusive: number;

--- a/src/data/employeesHealthInsurance/providerRates.ts
+++ b/src/data/employeesHealthInsurance/providerRates.ts
@@ -39,18 +39,6 @@ export function getRegionalRatesForMonth(
 }
 
 /**
- * Get regional rates for a specific provider and region using the current date.
- * Convenience wrapper around getRegionalRatesForMonth.
- */
-export function getRegionalRates(
-  providerId: string,
-  region: string = 'DEFAULT'
-): RegionalRates | undefined {
-  const now = new Date();
-  return getRegionalRatesForMonth(providerId, region, now.getFullYear(), now.getMonth());
-}
-
-/**
  * Calculate monthly premium for an employee based on SMR and regional rates
  */
 export function calculateMonthlyEmployeePremium(
@@ -120,14 +108,14 @@ export function generatePremiumTableFromRates(
  *
  * @param providerId Provider key
  * @param region Region key
- * @param year Optional calendar year for rate lookup (defaults to current year)
- * @param month Optional 0-indexed month for rate lookup (defaults to current month)
+ * @param year Calendar year for rate lookup
+ * @param month 0-indexed month for rate lookup
  */
 export function generateHealthInsurancePremiumTable(
   providerId: string,
   region: string = 'DEFAULT',
-  year?: number,
-  month?: number
+  year: number,
+  month: number
 ): Array<{
   minIncomeInclusive: number;
   maxIncomeExclusive: number;
@@ -136,12 +124,7 @@ export function generateHealthInsurancePremiumTable(
   fullPremiumNoLTC: number;
   fullPremiumWithLTC: number;
 }> | undefined {
-  let regionalRates: RegionalRates | undefined;
-  if (year !== undefined && month !== undefined) {
-    regionalRates = getRegionalRatesForMonth(providerId, region, year, month);
-  } else {
-    regionalRates = getRegionalRates(providerId, region);
-  }
+  const regionalRates = getRegionalRatesForMonth(providerId, region, year, month);
   if (!regionalRates) return undefined;
 
   return generatePremiumTableFromRates(regionalRates);

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -95,9 +95,27 @@ export interface HomeLoanTaxCreditResult {
   warnings: ReadonlyArray<string>;
 }
 
+/**
+ * The most recent income (tax) year the calculator has data and rules for, and the
+ * default written into form state.
+ *
+ * Pinned deliberately rather than derived from `new Date().getFullYear()`: Japanese
+ * tax-year changes are frequently not finalized until ~April of that year, and the
+ * data tables (e.g. NATIONAL_BASIC_DEDUCTION_TIER_PERIODS) are newest-first lookups
+ * that silently reuse the latest authored period for any later year. Rolling over
+ * automatically on Jan 1 would therefore present a not-yet-implemented year using the
+ * prior year's rules. Bump this when the data tables gain a newer effective year.
+ */
+export const DEFAULT_INCOME_YEAR = 2026;
+
 /** Interface for the UI Form State */
 export interface TakeHomeFormState {
   annualIncome: number;
+  /**
+   * Calendar year the income is taxed in. Single source of truth for the income year,
+   * defaulted to {@link DEFAULT_INCOME_YEAR} in App. A future year-picker UI writes here.
+   */
+  incomeYear: number;
   incomeMode: IncomeMode;
   incomeStreams: IncomeStream[];
   isSubjectToLongTermCarePremium: boolean;

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -141,7 +141,12 @@ export interface TakeHomeInputs {
   manualSocialInsuranceEntry: boolean;
   manualSocialInsuranceAmount: number;
   customEHIRates?: CustomEmployeesHealthInsuranceRates | undefined;
-  incomeYear?: number;
+  /**
+   * Calendar year the income is taxed in. Required: every caller threads it through from
+   * {@link TakeHomeFormState.incomeYear} (defaulted to {@link DEFAULT_INCOME_YEAR}), so the
+   * calculation never has to fall back to a guessed year.
+   */
+  incomeYear: number;
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
 }
 

--- a/src/utils/capDetection.ts
+++ b/src/utils/capDetection.ts
@@ -27,8 +27,8 @@ export interface CapStatus {
  */
 export function detectCaps(
   results: TakeHomeResults,
-  healthInsuranceBonusBreakdown: EmployeesHealthInsuranceBonusBreakdownItem[] | undefined = undefined,
-  year: number
+  year: number,
+  healthInsuranceBonusBreakdown?: EmployeesHealthInsuranceBonusBreakdownItem[]
 ): CapStatus {
   // Use salary + commuter allowance for social insurance cap detection (Standard Monthly Remuneration basis)
   // instead of total annual income which might include business/misc income or bonuses.
@@ -184,7 +184,9 @@ function checkHealthInsuranceCap(results: TakeHomeResults, monthlyRemuneration: 
       };
       premiumTable = generatePremiumTableFromRates(customRates);
     } else {
-      premiumTable = generateHealthInsurancePremiumTable(results.healthInsuranceProvider, results.region);
+      // Month is immaterial here — cap detection reads the (year-invariant) SMR bracket structure,
+      // not the premium values — so April (fiscal-year start) stands in for the income year.
+      premiumTable = generateHealthInsurancePremiumTable(results.healthInsuranceProvider, results.region, year, 3);
     }
 
     if (!premiumTable || premiumTable.length === 0) {

--- a/src/utils/capDetection.ts
+++ b/src/utils/capDetection.ts
@@ -186,7 +186,7 @@ function checkHealthInsuranceCap(results: TakeHomeResults, monthlyRemuneration: 
     } else {
       // Month is immaterial here — cap detection reads the (year-invariant) SMR bracket structure,
       // not the premium values — so April (fiscal-year start) stands in for the income year.
-      premiumTable = generateHealthInsurancePremiumTable(results.healthInsuranceProvider, results.region, year, 3);
+      premiumTable = generateHealthInsurancePremiumTable(results.healthInsuranceProvider, year, 3, results.region);
     }
 
     if (!premiumTable || premiumTable.length === 0) {

--- a/src/utils/capDetection.ts
+++ b/src/utils/capDetection.ts
@@ -27,8 +27,8 @@ export interface CapStatus {
  */
 export function detectCaps(
   results: TakeHomeResults,
-  healthInsuranceBonusBreakdown?: EmployeesHealthInsuranceBonusBreakdownItem[],
-  year: number = new Date().getFullYear()
+  healthInsuranceBonusBreakdown: EmployeesHealthInsuranceBonusBreakdownItem[] | undefined = undefined,
+  year: number
 ): CapStatus {
   // Use salary + commuter allowance for social insurance cap detection (Standard Monthly Remuneration basis)
   // instead of total annual income which might include business/misc income or bonuses.
@@ -82,7 +82,7 @@ function checkPensionCap(isNationalPension: boolean, monthlyRemuneration: number
  * @param monthlyRemuneration - The monthly remuneration, as needed for EHI/EPI calculations
  * @returns An object containing the cap status and details
  */
-function checkHealthInsuranceCap(results: TakeHomeResults, monthlyRemuneration: number, year: number = new Date().getFullYear()): {
+function checkHealthInsuranceCap(results: TakeHomeResults, monthlyRemuneration: number, year: number): {
   capped: boolean;
   details?: {
     medicalCapped?: boolean;

--- a/src/utils/chartConfig.ts
+++ b/src/utils/chartConfig.ts
@@ -141,7 +141,7 @@ export const generateChartData = (
     }
 
     const result = calculateTaxes(inputsForCalc);
-    const caps = detectCaps(result, undefined, currentInputs.incomeYear);
+    const caps = detectCaps(result, currentInputs.incomeYear);
     return { result, caps, breakdown };
   });
 

--- a/src/utils/chartConfig.ts
+++ b/src/utils/chartConfig.ts
@@ -141,7 +141,7 @@ export const generateChartData = (
     }
 
     const result = calculateTaxes(inputsForCalc);
-    const caps = detectCaps(result);
+    const caps = detectCaps(result, undefined, currentInputs.incomeYear);
     return { result, caps, breakdown };
   });
 

--- a/src/utils/dependentDeductions.ts
+++ b/src/utils/dependentDeductions.ts
@@ -48,7 +48,7 @@ const SPECIFIC_RELATIVE_DEDUCTION_MAX_INCOME = 1_230_000;
  * @param income  The dependent's income breakdown
  * @param year    Income year for the employment income deduction lookup; defaults to current year
  */
-export function calculateDependentTotalNetIncome(income: DependentIncome, year: number = new Date().getFullYear()): number {
+export function calculateDependentTotalNetIncome(income: DependentIncome, year: number): number {
   const { grossEmploymentIncome, otherNetIncome } = income;
 
   // Calculate net employment income using employment income deduction formula
@@ -566,7 +566,7 @@ function calculateSpouseDeduction(dependent: Dependent, taxpayerNetIncome: numbe
 export function calculateDependentDeductions(
   dependents: Dependent[],
   taxpayerNetIncome: number = 0,
-  year: number = new Date().getFullYear()
+  year: number
 ): DependentDeductionResults {
   const results: DependentDeductionResults = {
     nationalTax: {

--- a/src/utils/dependentDeductions.ts
+++ b/src/utils/dependentDeductions.ts
@@ -556,7 +556,7 @@ function calculateSpouseDeduction(dependent: Dependent, taxpayerNetIncome: numbe
 
 /**
  * Calculate all dependent-related deductions
- * 
+ *
  * @param dependents - user input array of dependents
  * @param taxpayerNetIncome - Taxpayer's total net income (合計所得金額)
  * @returns Detailed breakdown of all deductions
@@ -565,8 +565,8 @@ function calculateSpouseDeduction(dependent: Dependent, taxpayerNetIncome: numbe
  */
 export function calculateDependentDeductions(
   dependents: Dependent[],
-  taxpayerNetIncome: number = 0,
-  year: number
+  year: number,
+  taxpayerNetIncome: number = 0
 ): DependentDeductionResults {
   const results: DependentDeductionResults = {
     nationalTax: {

--- a/src/utils/healthInsuranceCalculator.ts
+++ b/src/utils/healthInsuranceCalculator.ts
@@ -35,10 +35,10 @@ export function calculateHealthInsuranceBreakdown(
     annualIncome: number,
     isSubjectToLongTermCarePremium: boolean,
     provider: HealthInsuranceProviderId,
+    year: number,
     region: ProviderRegion = DEFAULT_PROVIDER_REGION,
-    customRates: { healthRate: number, ltcRate: number } | undefined = undefined,
-    bonuses: BonusIncomeStream[] = [],
-    year: number
+    customRates?: { healthRate: number, ltcRate: number },
+    bonuses: BonusIncomeStream[] = []
 ): HealthInsuranceBreakdown {
     if (annualIncome < 0) {
         throw new Error('Income cannot be negative.');
@@ -51,7 +51,7 @@ export function calculateHealthInsuranceBreakdown(
 
     if (provider === NATIONAL_HEALTH_INSURANCE_ID) {
         // For NHI, bonuses are part of the total net income.
-        const total = calculateNationalHealthInsurancePremiumWithBreakdown(annualIncome, isSubjectToLongTermCarePremium, region, year).total;
+        const total = calculateNationalHealthInsurancePremiumWithBreakdown(annualIncome, isSubjectToLongTermCarePremium, year, region).total;
         return { total, bonusPortion: 0 };
     } else {
         const monthlyIncome = annualIncome / 12;
@@ -88,7 +88,6 @@ export function calculateHealthInsuranceBreakdown(
                     bonuses,
                     staticRates,
                     isSubjectToLongTermCarePremium,
-                    undefined,
                     year
                 );
                 bonusPortion = bonusDetails.reduce((sum, item) => sum + item.premium, 0);
@@ -118,8 +117,8 @@ export function calculateHealthInsuranceBreakdown(
                 bonuses,
                 provider,
                 region,
-                isSubjectToLongTermCarePremium,
-                year
+                year,
+                isSubjectToLongTermCarePremium
             );
 
             bonusPortion = bonusDetails.reduce((sum, item) => sum + item.premium, 0);
@@ -159,8 +158,8 @@ export function calculateEmployeesHealthInsuranceBonusBreakdown(
     bonuses: BonusIncomeStream[],
     providerOrRates: string | { employeeHealthInsuranceRate: number, employeeLongTermCareRate: number },
     regionOrLTC: string | boolean,
-    isSubjectToLongTermCarePremium: boolean | undefined = undefined,
-    year: number
+    year: number,
+    isSubjectToLongTermCarePremium?: boolean
 ): EmployeesHealthInsuranceBonusBreakdownItem[] {
     // Determine whether we're using time-series lookup or static rates
     const useTimeSeries = typeof providerOrRates === 'string';
@@ -236,19 +235,19 @@ export function calculateHealthInsurancePremium(
     annualIncome: number,
     isSubjectToLongTermCarePremium: boolean,
     provider: HealthInsuranceProviderId,
+    year: number,
     region: ProviderRegion = DEFAULT_PROVIDER_REGION,
-    customRates: { healthRate: number, ltcRate: number } | undefined = undefined,
-    bonuses: BonusIncomeStream[] = [],
-    year: number
+    customRates?: { healthRate: number, ltcRate: number },
+    bonuses: BonusIncomeStream[] = []
 ): number {
     return calculateHealthInsuranceBreakdown(
         annualIncome,
         isSubjectToLongTermCarePremium,
         provider,
+        year,
         region,
         customRates,
-        bonuses,
-        year
+        bonuses
     ).total;
 }
 
@@ -323,8 +322,8 @@ function calculateNationalHealthInsurancePremiumBreakdown(
 export function calculateNationalHealthInsurancePremiumWithBreakdown(
     annualIncome: number,
     isSubjectToLongTermCarePremium: boolean,
-    region: string | undefined = undefined,
-    year: number
+    year: number,
+    region?: string
 ): NationalHealthInsuranceBreakdown {
     const regionKey = region as string;
 

--- a/src/utils/healthInsuranceCalculator.ts
+++ b/src/utils/healthInsuranceCalculator.ts
@@ -36,9 +36,9 @@ export function calculateHealthInsuranceBreakdown(
     isSubjectToLongTermCarePremium: boolean,
     provider: HealthInsuranceProviderId,
     region: ProviderRegion = DEFAULT_PROVIDER_REGION,
-    customRates?: { healthRate: number, ltcRate: number },
+    customRates: { healthRate: number, ltcRate: number } | undefined = undefined,
     bonuses: BonusIncomeStream[] = [],
-    year: number = new Date().getFullYear()
+    year: number
 ): HealthInsuranceBreakdown {
     if (annualIncome < 0) {
         throw new Error('Income cannot be negative.');
@@ -87,7 +87,9 @@ export function calculateHealthInsuranceBreakdown(
                 const bonusDetails = calculateEmployeesHealthInsuranceBonusBreakdown(
                     bonuses,
                     staticRates,
-                    isSubjectToLongTermCarePremium
+                    isSubjectToLongTermCarePremium,
+                    undefined,
+                    year
                 );
                 bonusPortion = bonusDetails.reduce((sum, item) => sum + item.premium, 0);
                 totalPremium += bonusPortion;
@@ -157,8 +159,8 @@ export function calculateEmployeesHealthInsuranceBonusBreakdown(
     bonuses: BonusIncomeStream[],
     providerOrRates: string | { employeeHealthInsuranceRate: number, employeeLongTermCareRate: number },
     regionOrLTC: string | boolean,
-    isSubjectToLongTermCarePremium?: boolean,
-    year?: number
+    isSubjectToLongTermCarePremium: boolean | undefined = undefined,
+    year: number
 ): EmployeesHealthInsuranceBonusBreakdownItem[] {
     // Determine whether we're using time-series lookup or static rates
     const useTimeSeries = typeof providerOrRates === 'string';
@@ -166,7 +168,6 @@ export function calculateEmployeesHealthInsuranceBonusBreakdown(
     const region = useTimeSeries ? regionOrLTC as string : undefined;
     const staticRates = useTimeSeries ? undefined : providerOrRates as { employeeHealthInsuranceRate: number, employeeLongTermCareRate: number };
     const includeLTC = useTimeSeries ? isSubjectToLongTermCarePremium! : regionOrLTC as boolean;
-    const lookupYear = year ?? new Date().getFullYear();
 
     // Sort bonuses by month to apply cumulative cap correctly
     const sortedBonuses = [...bonuses].sort((a, b) => a.month - b.month);
@@ -188,7 +189,7 @@ export function calculateEmployeesHealthInsuranceBonusBreakdown(
 
         // Look up rates for this bonus's month (or use static rates)
         const rates = useTimeSeries
-            ? getRegionalRatesForMonth(providerId!, region!, lookupYear, bonus.month)
+            ? getRegionalRatesForMonth(providerId!, region!, year, bonus.month)
             : staticRates!;
 
         if (!rates) {
@@ -236,9 +237,9 @@ export function calculateHealthInsurancePremium(
     isSubjectToLongTermCarePremium: boolean,
     provider: HealthInsuranceProviderId,
     region: ProviderRegion = DEFAULT_PROVIDER_REGION,
-    customRates?: { healthRate: number, ltcRate: number },
+    customRates: { healthRate: number, ltcRate: number } | undefined = undefined,
     bonuses: BonusIncomeStream[] = [],
-    year?: number
+    year: number
 ): number {
     return calculateHealthInsuranceBreakdown(
         annualIncome,
@@ -322,8 +323,8 @@ function calculateNationalHealthInsurancePremiumBreakdown(
 export function calculateNationalHealthInsurancePremiumWithBreakdown(
     annualIncome: number,
     isSubjectToLongTermCarePremium: boolean,
-    region?: string,
-    year: number = new Date().getFullYear()
+    region: string | undefined = undefined,
+    year: number
 ): NationalHealthInsuranceBreakdown {
     const regionKey = region as string;
 

--- a/src/utils/pensionCalculator.ts
+++ b/src/utils/pensionCalculator.ts
@@ -81,7 +81,7 @@ export function calculatePensionBreakdown(
   monthlyIncome: number = 0,
   isHalfAmount: boolean = true,
   bonuses: BonusIncomeStream[] = [],
-  year: number = new Date().getFullYear()
+  year: number
 ): PensionBreakdown {
   if (!isEmployeesPension) {
     return { total: getNationalPensionAnnualTotal(year), bonusPortion: 0 };
@@ -183,7 +183,7 @@ export function calculatePensionPremium(
   monthlyIncome: number = 0,
   isHalfAmount: boolean = true,
   bonuses: BonusIncomeStream[] = [],
-  year: number = new Date().getFullYear()
+  year: number
 ): number {
   return calculatePensionBreakdown(isEmployeesPension, monthlyIncome, isHalfAmount, bonuses, year).total;
 }

--- a/src/utils/residenceTax.ts
+++ b/src/utils/residenceTax.ts
@@ -79,7 +79,7 @@ export const calculateResidenceTax = (
     nonBasicDeductions: number,
     dependentDeductions: DependentDeductionResults,
     taxCredit: number = 0,
-    year: number = new Date().getFullYear()
+    year: number
 ): ResidenceTaxDetails => {
     const qualifiedDependentsCount = countQualifiedDependents(dependentDeductions, year);
     const { perCapitaLimit, incomeBasedLimit } = getResidenceTaxExemptionLimits(qualifiedDependentsCount);

--- a/src/utils/residenceTax.ts
+++ b/src/utils/residenceTax.ts
@@ -78,8 +78,8 @@ export const calculateResidenceTax = (
     netIncome: number,
     nonBasicDeductions: number,
     dependentDeductions: DependentDeductionResults,
-    taxCredit: number = 0,
-    year: number
+    year: number,
+    taxCredit: number = 0
 ): ResidenceTaxDetails => {
     const qualifiedDependentsCount = countQualifiedDependents(dependentDeductions, year);
     const { perCapitaLimit, incomeBasedLimit } = getResidenceTaxExemptionLimits(qualifiedDependentsCount);

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -391,10 +391,8 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
                 netIncome,
                 inputs.isSubjectToLongTermCarePremium,
                 inputs.healthInsuranceProvider,
-                inputs.region,
-                undefined,
-                [],
-                incomeYear
+                incomeYear,
+                inputs.region
             );
             healthInsurance = hiResult.total;
             healthInsuranceOnBonus = hiResult.bonusPortion;
@@ -403,8 +401,8 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
             nhiBreakdown = calculateNationalHealthInsurancePremiumWithBreakdown(
                 netIncome,
                 inputs.isSubjectToLongTermCarePremium,
-                inputs.region as string,
-                incomeYear
+                incomeYear,
+                inputs.region as string
             );
         } else { // Employee Health Insurance
             // For Employee Health Insurance, the premiums are based on standard monthly remuneration,
@@ -413,13 +411,13 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
                 salaryIncome + commutingAllowance,
                 inputs.isSubjectToLongTermCarePremium,
                 inputs.healthInsuranceProvider,
+                incomeYear,
                 inputs.region,
                 inputs.healthInsuranceProvider === CUSTOM_PROVIDER_ID && inputs.customEHIRates ? {
                     healthRate: inputs.customEHIRates.healthInsuranceRate,
                     ltcRate: inputs.customEHIRates.longTermCareRate
                 } : undefined,
-                bonusIncome,
-                incomeYear
+                bonusIncome
             );
             healthInsurance = hiResult.total;
             healthInsuranceOnBonus = hiResult.bonusPortion;

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -361,7 +361,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     const taxableCommutingAllowance = Math.max(0, commutingAllowance - COMMUTING_ALLOWANCE_NONTAXABLE_ANNUAL_CAP);
 
     const grossEmploymentIncome = salaryIncome + taxableCommutingAllowance + bonusIncome.reduce((sum, b) => sum + b.amount, 0) + stockCompensationIncome;
-    const incomeYear = inputs.incomeYear ?? new Date().getFullYear();
+    const incomeYear = inputs.incomeYear;
 
     const netEmploymentIncome = calculateNetEmploymentIncome(grossEmploymentIncome, incomeYear, inputs.dependents);
     const incomeAdjustmentDeduction = calculateIncomeAdjustmentDeduction(grossEmploymentIncome, inputs.dependents, incomeYear);

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -72,7 +72,7 @@ const calculateIncomeAdjustmentDeduction = (
  */
 export const calculateNetEmploymentIncome = (
     grossEmploymentIncome: number,
-    year: number = new Date().getFullYear(),
+    year: number,
     dependents: Dependent[] = []
 ): number => calculateNetEmploymentIncomeForPeriod(
     grossEmploymentIncome,
@@ -94,7 +94,7 @@ export interface EmploymentInsuranceBreakdown {
 const calculateEmploymentInsuranceBreakdown = (
     salaryIncome: number,
     bonuses: BonusIncomeStream[],
-    year: number = new Date().getFullYear()
+    year: number
 ): EmploymentInsuranceBreakdown => {
     // If no employment income, no employment insurance is required
     if (salaryIncome <= 0 && !bonuses.some(b => b.amount > 0)) {
@@ -142,7 +142,7 @@ const calculateEmploymentInsuranceBreakdown = (
 export const calculateEmploymentInsurance = (
     salaryIncome: number,
     bonuses: BonusIncomeStream[] = [],
-    year?: number
+    year: number
 ): number => {
     return calculateEmploymentInsuranceBreakdown(salaryIncome, bonuses, year).total;
 }
@@ -154,7 +154,7 @@ export const calculateEmploymentInsurance = (
  * @param netIncome Taxpayer's net income (合計所得金額) in yen
  * @param year Income year (calendar year the income was earned); defaults to current year
  */
-export const calculateNationalIncomeTaxBasicDeduction = (netIncome: number, year: number = new Date().getFullYear()): number => {
+export const calculateNationalIncomeTaxBasicDeduction = (netIncome: number, year: number): number => {
     for (const { maxIncomeInclusive, deduction } of getNationalBasicDeductionTiers(year)) {
         if (netIncome <= maxIncomeInclusive) return deduction;
     }
@@ -317,7 +317,7 @@ const calculateIncomeBreakdown = (incomeStreams: IncomeStream[]): IncomeBreakdow
  */
 export const calculateTotalNetIncome = (
     incomeStreams: IncomeStream[],
-    year: number = new Date().getFullYear(),
+    year: number,
     dependents: Dependent[] = []
 ): number => {
     const {

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -391,7 +391,10 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
                 netIncome,
                 inputs.isSubjectToLongTermCarePremium,
                 inputs.healthInsuranceProvider,
-                inputs.region
+                inputs.region,
+                undefined,
+                [],
+                incomeYear
             );
             healthInsurance = hiResult.total;
             healthInsuranceOnBonus = hiResult.bonusPortion;
@@ -400,7 +403,8 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
             nhiBreakdown = calculateNationalHealthInsurancePremiumWithBreakdown(
                 netIncome,
                 inputs.isSubjectToLongTermCarePremium,
-                inputs.region as string
+                inputs.region as string,
+                incomeYear
             );
         } else { // Employee Health Insurance
             // For Employee Health Insurance, the premiums are based on standard monthly remuneration,
@@ -414,7 +418,8 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
                     healthRate: inputs.customEHIRates.healthInsuranceRate,
                     ltcRate: inputs.customEHIRates.longTermCareRate
                 } : undefined,
-                bonusIncome
+                bonusIncome,
+                incomeYear
             );
             healthInsurance = hiResult.total;
             healthInsuranceOnBonus = hiResult.bonusPortion;
@@ -442,7 +447,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
 
 
         // Employment Insurance also includes full commuting allowance
-        const eiResult = calculateEmploymentInsuranceBreakdown(salaryIncome + commutingAllowance, bonusIncome);
+        const eiResult = calculateEmploymentInsuranceBreakdown(salaryIncome + commutingAllowance, bonusIncome, incomeYear);
         employmentInsurance = eiResult.total;
         employmentInsuranceOnBonus = eiResult.bonusPortion;
 

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -141,8 +141,8 @@ const calculateEmploymentInsuranceBreakdown = (
 // Only exported for testing
 export const calculateEmploymentInsurance = (
     salaryIncome: number,
-    bonuses: BonusIncomeStream[] = [],
-    year: number
+    year: number,
+    bonuses: BonusIncomeStream[] = []
 ): number => {
     return calculateEmploymentInsuranceBreakdown(salaryIncome, bonuses, year).total;
 }
@@ -455,7 +455,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     // iDeCo and corporate DC contributions are deductible as 小規模企業共済等掛金控除
     const idecoDeduction = Math.max(0, inputs.dcPlanContributions || 0);
 
-    const dependentDeductions = calculateDependentDeductions(inputs.dependents, netIncome, incomeYear);
+    const dependentDeductions = calculateDependentDeductions(inputs.dependents, incomeYear, netIncome);
 
     const nationalIncomeTaxBasicDeduction = calculateNationalIncomeTaxBasicDeduction(netIncome, incomeYear);
 
@@ -475,7 +475,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     // then spilled over to residence tax up to the cap.
     // Calling residence tax with appliedToResidenceTax = 0 first gives us the
     // pre-credit residence tax, needed for the furusato 20% special-deduction cap.
-    const preCreditResidenceTax = calculateResidenceTax(netIncome, socialInsuranceDeduction + idecoDeduction, dependentDeductions, 0, incomeYear);
+    const preCreditResidenceTax = calculateResidenceTax(netIncome, socialInsuranceDeduction + idecoDeduction, dependentDeductions, incomeYear);
 
     const homeLoanTaxCreditResult = inputs.homeLoanTaxCredit
         ? applyHomeLoanTaxCredit(
@@ -494,7 +494,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     const nationalIncomeTax = Math.floor((baseIncomeTaxAfterCredit + reconstructionSurtax) / 100) * 100;
 
     const residenceTax = homeLoanTaxCreditResult && homeLoanTaxCreditResult.appliedToResidenceTax > 0
-        ? calculateResidenceTax(netIncome, socialInsuranceDeduction + idecoDeduction, dependentDeductions, homeLoanTaxCreditResult.appliedToResidenceTax, incomeYear)
+        ? calculateResidenceTax(netIncome, socialInsuranceDeduction + idecoDeduction, dependentDeductions, incomeYear, homeLoanTaxCreditResult.appliedToResidenceTax)
         : preCreditResidenceTax;
 
     // Calculate totals


### PR DESCRIPTION
## What

Makes the income tax year a first-class piece of application state, flowing from a single source of truth (`TakeHomeFormState.incomeYear`) and consistently respected by every year-dependent calculation **and** display. **Plumbing only — no year-picker UI is added.**

## Why

The income year was never represented in app state — it was implicitly the current calendar year via scattered `new Date().getFullYear()` reads that agreed only by coincidence. There was no single source of truth, the form state couldn't express a non-current year, and several calculations/tooltips silently ignored the year. This makes a future "select an arbitrary income year" UI trivial and the app internally consistent for any year.

## Changes

- **`types/tax.ts`** — exported `DEFAULT_INCOME_YEAR`; `incomeYear` is required on both `TakeHomeFormState` and `TakeHomeInputs`.
- **`App.tsx`** — default `incomeYear` to `DEFAULT_INCOME_YEAR` (the one place a future picker writes); pass it to `calculateTaxes`, the effect deps, and the chart.
- **`InputForm.tsx` / `DependentsModal.tsx`** — pass `incomeYear` to `calculateTotalNetIncome` / `calculateDependentDeductions`.
- **`TakeHomeChart.tsx`** — thread `incomeYear` into `generateChartData` and the tooltip `calculateTaxes`.
- **Drop dead fallbacks** — with `incomeYear` required, the `?? new Date().getFullYear()` fallbacks in `calculateTaxes`, `TaxesTab`, and `SocialInsuranceTab` are removed.
- **Thread `incomeYear` into the insurance calcs** — `calculateTaxes` now passes it to `calculateHealthInsuranceBreakdown` (employee + NHI), `calculateNationalHealthInsurancePremiumWithBreakdown`, and `calculateEmploymentInsuranceBreakdown`, which previously defaulted to `new Date().getFullYear()` and so silently ignored a non-current year.
- **Tooltips use the income year** — the social-insurance tooltips (`HealthInsuranceBonusTooltip`, `HealthInsurancePremiumTooltip`, `NHIPortionTooltip`, `EmploymentInsuranceRateTooltip`) now display rates for `inputs.incomeYear` (threaded as a prop where the component lacks `inputs`) instead of `new Date()`. Month-based lookups that used `new Date().getMonth()` now use a deterministic representative month (April / fiscal-year start).
- **No fake timers anywhere in the suite** — every `vi.useFakeTimers` clock pin was removed (taxCalculations, furusato, SocialInsuranceTab, healthInsuranceCalculator, NHICapIndicator, NHIPortionTooltip). Tests now depend only on each input/call's explicit income year, so a re-introduced current-date dependency would break them.
- **Tests** — fixtures set `incomeYear` explicitly; `taxCalculations.test.ts` / `furusato.test.ts` re-baselined to consistent income-year-2026 values.

## Notes for reviewers

- **`DEFAULT_INCOME_YEAR` is pinned to `2026`, not `new Date().getFullYear()`** — Japanese tax-year rules aren't finalized until ~April, and the data tables silently reuse the latest authored period for any later year, so auto-rollover on Jan 1 would present a not-yet-implemented year. Bump it when newer data lands.
- **Removing the fake timers was a deliberate proof.** They were hiding three genuinely clock-dependent things, all now fixed: `calculateEmploymentInsurance`'s direct rounding tests (now pinned to an explicit uniform-rate year 2025), and `HealthInsurancePremiumTooltip`'s headline rate (it read `new Date()` instead of the income year defined right above it). The tests are now self-proving — a re-introduced clock dependency breaks them.
- **Test re-baseline:** `taxCalculations.test.ts` / `furusato.test.ts` previously pinned a clock to June 2025 while their fixtures set `incomeYear: 2026`, so they tested an inconsistent tax@2026 + insurance@2025 mix. With insurance now following `incomeYear`, 34 expected values moved to the correct income-year-2026 figures — e.g. employment insurance for a 5M salary is the FY-blended **25,623** (Jan–Mar FY2025 5.5‰, Apr–Dec FY2026 5.0‰) instead of the all-FY2025 27,504. Stale single-rate comments were updated.
- **The income year is now a required parameter** on every calculation util — the `new Date().getFullYear()` defaults (and the `year ?? new Date()` fallback / `year?` optionals) were removed, so nothing can silently fall back to the current date. tsc then surfaced two display paths (`DependentForm`, `SpouseSection`) that had been computing a dependent's net income from `new Date()`; they now take the income year as a prop threaded from `DependentsModal`. The home-loan *move-in year* dropdown bound (`AdditionalDeductionsModal`) is now driven by `inputs.incomeYear` too (its valid range is relative to the year being taxed, not today), and `getRegionalRates` — a function whose sole purpose was to call its `…ForMonth` variant with `new Date()` — was removed. **There is now no `new Date().getFullYear()` anywhere in the calculation or display path.** The required `year` was also moved ahead of the trailing optional params (rather than defaulting them to `undefined`), so those params stay genuinely optional.
- Behavior is unchanged today — everything resolves to 2026.

