### PR TITLE
Fix bonus-tooltip month-name rollover bug and dedupe helper

### DIFF
--- a/src/__tests__/SocialInsuranceTab.test.tsx
+++ b/src/__tests__/SocialInsuranceTab.test.tsx
@@ -23,12 +23,6 @@ vi.mock('../components/ui/Tooltips', async () => {
     };
 });
 
-// Mock content
-vi.mock('../utils/formatters', () => ({
-    formatJPY: (val: number) => `¥${val.toLocaleString()}`,
-    formatPercent: (val: number) => `${(val * 100).toFixed(3)}%`,
-}));
-
 // Mock scrollTo for JSDOM
 beforeAll(() => {
     Element.prototype.scrollTo = vi.fn();

--- a/src/__tests__/formatters.test.ts
+++ b/src/__tests__/formatters.test.ts
@@ -1,0 +1,28 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { formatMonthShort } from '../utils/formatters';
+
+describe('formatMonthShort', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    it('maps zero-based month indices to short English names', () => {
+        expect(Array.from({ length: 12 }, (_, m) => formatMonthShort(m))).toEqual(MONTHS);
+    });
+
+    // Regression test: the previous helper seeded its date from `new Date()`, inheriting
+    // today's day-of-month. On the 29th-31st, formatting a shorter month (e.g. February)
+    // via setMonth rolled the date over into the following month — so it returned 'Mar'
+    // instead of 'Feb'. The output must not depend on the current date.
+    it('does not roll over when today is the 31st', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2025, 0, 31)); // Jan 31 — longer than Feb/Apr/Jun/Sep/Nov
+        expect(formatMonthShort(1)).toBe('Feb');
+        expect(Array.from({ length: 12 }, (_, m) => formatMonthShort(m))).toEqual(MONTHS);
+    });
+});

--- a/src/components/TakeHomeCalculator/tabs/EmploymentInsuranceRateTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/EmploymentInsuranceRateTooltip.tsx
@@ -6,11 +6,8 @@ import Typography from '@mui/material/Typography';
 import { DetailedTooltip } from '../../ui/Tooltips';
 import { getEmploymentInsuranceRate } from '../../../data/employmentInsurance';
 import { roundSocialInsurancePremium } from '../../../utils/taxCalculations';
-import { formatJPY, formatPercent } from '../../../utils/formatters';
+import { formatJPY, formatPercent, formatMonthShort } from '../../../utils/formatters';
 import type { BonusIncomeStream } from '../../../types/tax';
-
-const formatMonthShort = (month: number): string =>
-    new Date(2000, month).toLocaleString('en', { month: 'short' });
 
 const cellStyle = { padding: '2px 8px 2px 0' } as const;
 const rightCellStyle = { ...cellStyle, textAlign: 'right' as const };

--- a/src/components/TakeHomeCalculator/tabs/HealthInsuranceBonusTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/HealthInsuranceBonusTooltip.tsx
@@ -8,7 +8,7 @@ import type { TakeHomeInputs } from '../../../types/tax';
 import { CUSTOM_PROVIDER_ID, DEFAULT_PROVIDER_REGION } from '../../../types/healthInsurance';
 import { PROVIDER_DEFINITIONS } from '../../../data/employeesHealthInsurance/providerRateData';
 import { getRegionalRatesForMonth } from '../../../data/employeesHealthInsurance/providerRates';
-import { formatJPY, formatPercent } from '../../../utils/formatters';
+import { formatJPY, formatPercent, formatMonthShort } from '../../../utils/formatters';
 import type { EmployeesHealthInsuranceBonusBreakdownItem } from '../../../utils/healthInsuranceCalculator';
 
 interface HealthInsuranceBonusTooltipProps {
@@ -53,13 +53,6 @@ const HealthInsuranceBonusTooltip: React.FC<HealthInsuranceBonusTooltipProps> = 
     return rates.employeeHealthInsuranceRate + (includeLTC ? rates.employeeLongTermCareRate : 0);
   };
 
-  // Helper to format month index to name
-  const getMonthName = (monthIndex: number) => {
-    const date = new Date();
-    date.setMonth(monthIndex);
-    return date.toLocaleString('default', { month: 'short' });
-  };
-
   return (
     <>
       <Typography variant="body2" sx={{ mb: 1 }}>
@@ -91,7 +84,7 @@ const HealthInsuranceBonusTooltip: React.FC<HealthInsuranceBonusTooltipProps> = 
             <tbody>
               {breakdown.map((item, index) => (
                 <tr key={index}>
-                  <td>{getMonthName(item.month)}</td>
+                  <td>{formatMonthShort(item.month)}</td>
                   <td>{formatJPY(item.bonusAmount)}</td>
                   <td>
                     {formatJPY(item.standardBonusAmount)}

--- a/src/components/TakeHomeCalculator/tabs/PensionBonusTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/PensionBonusTooltip.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { EMPLOYEES_PENSION_RATE, type PensionBonusBreakdownItem } from '../../../utils/pensionCalculator';
-import { formatJPY, formatPercent } from '../../../utils/formatters';
+import { formatJPY, formatPercent, formatMonthShort } from '../../../utils/formatters';
 
 interface PensionBonusTooltipProps {
   breakdown?: PensionBonusBreakdownItem[];
@@ -14,13 +14,6 @@ interface PensionBonusTooltipProps {
 const PensionBonusTooltip: React.FC<PensionBonusTooltipProps> = ({ breakdown }) => {
   // Employee share is half
   const employeeRate = EMPLOYEES_PENSION_RATE / 2;
-
-  // Helper to format month index to name
-  const getMonthName = (monthIndex: number) => {
-    const date = new Date();
-    date.setMonth(monthIndex);
-    return date.toLocaleString('default', { month: 'short' });
-  };
 
   return (
     <>
@@ -65,7 +58,7 @@ const PensionBonusTooltip: React.FC<PensionBonusTooltipProps> = ({ breakdown }) 
             <tbody>
               {breakdown.map((item, index) => (
                 <tr key={index}>
-                  <td>{getMonthName(item.month)}</td>
+                  <td>{formatMonthShort(item.month)}</td>
                   <td>{formatJPY(item.totalBonusAmount)}</td>
                   <td>
                     {formatJPY(item.standardBonusAmount)}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -50,3 +50,13 @@ export const formatPercent = (rate: number, decimals: number = 3) => {
     maximumFractionDigits: decimals
   }).format(rate);
 };
+
+/**
+ * Format a zero-based month index (0 = January) as its short English name.
+ * Uses a fixed safe day so it never depends on the current date — seeding
+ * from `new Date()` can roll over to the next month when today's day-of-month
+ * exceeds the target month's length (e.g. the 31st pointing at February).
+ * @param monthIndex Zero-based month index (0 = January, 11 = December).
+ */
+export const formatMonthShort = (monthIndex: number): string =>
+  new Date(2000, monthIndex, 1).toLocaleString('en', { month: 'short' });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -53,10 +53,14 @@ export const formatPercent = (rate: number, decimals: number = 3) => {
 
 /**
  * Format a zero-based month index (0 = January) as its short English name.
- * Uses a fixed safe day so it never depends on the current date — seeding
- * from `new Date()` can roll over to the next month when today's day-of-month
- * exceeds the target month's length (e.g. the 31st pointing at February).
- * @param monthIndex Zero-based month index (0 = January, 11 = December).
+ *
+ * @param monthIndex - Zero-based month index (0 = January, 11 = December).
+ *
+ * @remarks
+ * Builds the date with a fixed safe day (the 1st) so the result never depends
+ * on the current date. Seeding from `new Date()` and calling `setMonth` can
+ * roll into the next month when today's day-of-month exceeds the target
+ * month's length (e.g. the 31st with February), so avoid that pattern here.
  */
 export const formatMonthShort = (monthIndex: number): string =>
   new Date(2000, monthIndex, 1).toLocaleString('en', { month: 'short' });


### PR DESCRIPTION
Fixes a latent, date-dependent bug in the bonus premium tooltips where the displayed month name could be wrong, and removes the duplicated helper behind it.

The `getMonthName` helper was duplicated in `HealthInsuranceBonusTooltip` and `PensionBonusTooltip`:

```js
const getMonthName = (monthIndex: number) => {
  const date = new Date();          // seeds with today's day-of-month
  date.setMonth(monthIndex);
  return date.toLocaleString('default', { month: 'short' });
};
```

Because `new Date()` inherits today's day-of-month, when today is the 29th–31st and `monthIndex` points to a shorter month (e.g. February), `setMonth` rolls the date over into the *following* month — so the bonus-month name shown in the breakdown table could be off by one on those days. Tests didn't catch it because the output is correct on most days.

## Changes

- Extract a single `formatMonthShort` helper into `src/utils/formatters.ts` that builds the date with a fixed safe day (`new Date(2000, monthIndex, 1)`) and no clock dependency. This matches the already-correct pattern that `EmploymentInsuranceRateTooltip` was using inline.
- Use the shared helper in all three tooltips (`HealthInsuranceBonusTooltip`, `PensionBonusTooltip`, `EmploymentInsuranceRateTooltip`), removing the duplication.
- Remove the now-unnecessary `vi.mock('../utils/formatters', ...)` from `SocialInsuranceTab.test.tsx`. The mock didn't actually decouple the test from `Intl` (its `formatJPY` still called `toLocaleString` for grouping), and the real formatters produce the exact strings the test asserts — so the test now exercises the real formatting code.

## Reviewer notes

- The fix changes observable output only on the 29th–31st when a bonus month is shorter than the current month, so a screenshot today wouldn't demonstrate it; the unit tests (which assert the rendered month names) are the meaningful verification.
- A separate follow-up is worth doing to audit whether the `Intl`-based formatters are stable across CI vs local Node/ICU environments — the removed mock implied a determinism concern but never actually solved it. Left out of scope here.