### PR TITLE
DRY up MUI input sizing with a theme-level size=small default

### DIFF
--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -204,7 +204,6 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
 
                 <TextField
                   select
-                  size="small"
                   id="homeLoanMoveInYear"
                   label="Move-in Year"
                   value={effectiveHomeLoan.moveInYear}

--- a/src/components/TakeHomeCalculator/Dependents/DependentForm.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/DependentForm.tsx
@@ -114,7 +114,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
       </Typography>
 
       {/* Relationship */}
-      <FormControl fullWidth size="small">
+      <FormControl fullWidth>
         <InputLabel id="relationship-label">Relationship</InputLabel>
         <Select
           labelId="relationship-label"
@@ -291,7 +291,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
 
       {/* Age and Living Together on same row */}
       <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
-        <FormControl sx={{ flex: 1 }} size="small">
+        <FormControl sx={{ flex: 1 }}>
           <InputLabel id="age-label">Age</InputLabel>
           <Select
             labelId="age-label"
@@ -326,7 +326,7 @@ export const DependentForm: React.FC<DependentFormProps> = ({
       </Box>
 
       {/* Disability Status */}
-      <FormControl fullWidth size="small">
+      <FormControl fullWidth>
         <InputLabel>Disability Status</InputLabel>
         <Select
           value={disability}

--- a/src/components/TakeHomeCalculator/Dependents/SpouseSection.tsx
+++ b/src/components/TakeHomeCalculator/Dependents/SpouseSection.tsx
@@ -257,7 +257,7 @@ export default function SpouseSection({ spouse, onChange, incomeYear }: SpouseSe
 
           {/* Age Category and Living Together on same row */}
           <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
-            <FormControl sx={{ flex: 1 }} size="small">
+            <FormControl sx={{ flex: 1 }}>
               <InputLabel>Age</InputLabel>
               <Select
                 value={spouse.ageCategory}
@@ -292,7 +292,7 @@ export default function SpouseSection({ spouse, onChange, incomeYear }: SpouseSe
           </Box>
 
           {/* Disability Status */}
-          <FormControl fullWidth size="small">
+          <FormControl fullWidth>
             <InputLabel>Disability Status</InputLabel>
             <Select
               value={spouse.disability}

--- a/src/components/ui/SpinnerNumberField.tsx
+++ b/src/components/ui/SpinnerNumberField.tsx
@@ -120,7 +120,6 @@ export const SpinnerNumberField: React.FC<SpinnerNumberFieldProps> = ({
       {...(label && { label })}
       {...(helperText && { helperText })}
       {...(error && { error })}
-      size="small"
       slotProps={{
         htmlInput: {
           inputMode: "numeric",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -47,6 +47,15 @@ export const getTheme = (mode: 'light' | 'dark') => {
           },
         },
       },
+      // Default all input fields to the compact "small" size for visual
+      // consistency. MuiFormControl cascades its size to the Select/Input it
+      // wraps, so every FormControl-wrapped Select inherits this automatically
+      // (no MuiSelect default needed). MuiTextField covers standalone text
+      // fields (e.g. SpinnerNumberField), and MuiAutocomplete keeps the
+      // Autocomplete's internal layout aligned with its small input.
+      MuiTextField: { defaultProps: { size: 'small' } },
+      MuiFormControl: { defaultProps: { size: 'small' } },
+      MuiAutocomplete: { defaultProps: { size: 'small' } },
     },
   });
 };


### PR DESCRIPTION
## What

Centralize MUI input-field sizing with a theme-level `size="small"` default, instead of hand-setting `size="small"` on ~15 components while others fell through to MUI's taller `medium` default.

![Before/after: input fields that previously rendered at MUI's medium size now render at the compact small size](https://github.com/user-attachments/assets/28d7095b-24d9-4553-83c6-50e0de21afdb)

<sub>To-scale reconstruction from input heights measured live in the running app (the headless preview here can't capture real screenshots).</sub>

`src/theme.ts` previously configured only `MuiCssBaseline`. This adds input `defaultProps`:

- `MuiTextField: { defaultProps: { size: 'small' } }`
- `MuiFormControl: { defaultProps: { size: 'small' } }`
- `MuiAutocomplete: { defaultProps: { size: 'small' } }`

`MuiSelect` was deliberately **not** added: every `<Select>` in the app is wrapped in a `<FormControl>` (no bare Selects, no `<TextField select>` outside the cases below), and `MuiFormControl`'s size cascades to the wrapped Select and its label — so a `MuiSelect` default would be redundant. `MuiAutocomplete` is kept because the Autocomplete's internal padding is driven by its own `size`, independent of the wrapping FormControl.

The now-redundant `size="small"` props were removed from **input components only**

`size="small"` on `Table` / `IconButton` / `Checkbox` is a separate concern and intentionally left in place.

## Why

There was no centralized input-size default, so the UI was inconsistent: the Dependents forms used `size="small"`, but the income detail modal Selects and the main-form region Autocomplete fell through to `medium` and rendered taller.

## Blast radius (the intended standardization)

Controls that previously relied on the `medium` default and now render small (measured live):
- Income detail modal Selects (Income/Benefit Type, Frequency, Month Paid, Blue-Filer): **56px → 40px**
- Region Autocomplete: **46px → 40px**
- Health-insurance provider Select: size class flipped medium→small (height stays ~31px, pinned by the existing `sharedInputSx`)

Already-`small` controls (Dependents-modal Selects, all `SpinnerNumberField`s) are pixel-identical. No tax/functional logic changes.