### PR TITLE
Display canonical gross in the Net Employment Income tooltip

### DIFF
--- a/src/__tests__/BlueFilerDisplay.test.tsx
+++ b/src/__tests__/BlueFilerDisplay.test.tsx
@@ -46,6 +46,7 @@ const mockResults: TakeHomeResults = {
     nhiElderlySupportPortion: 50_000,
     nhiLongTermCarePortion: 0,
     salaryIncome: 0,
+    grossEmploymentIncome: 0,
 };
 
 const mockInputs: TakeHomeInputs = {
@@ -109,6 +110,7 @@ describe('Blue-Filer Deduction Display', () => {
             hasEmploymentIncome: true, // Has employment income
             // Mocking other necessary values
             netEmploymentIncome: 2_000_000, // Dummy
+            grossEmploymentIncome: 3_000_000, // Dummy (salary 3M)
             totalNetIncome: 3_900_000, // Dummy total
             salaryIncome: 3_000_000,
         };

--- a/src/__tests__/NHICapIndicator.test.tsx
+++ b/src/__tests__/NHICapIndicator.test.tsx
@@ -41,6 +41,7 @@ function buildNHIScenario(annualIncome: number, region: string, includeLTC: bool
         nhiLongTermCarePortion: breakdown.longTermCarePortion,
         nhiChildSupportPortion: breakdown.childSupportPortion,
         salaryIncome: 0,
+        grossEmploymentIncome: 0,
     };
 
     const inputs: TakeHomeInputs = {

--- a/src/__tests__/NHIPortionTooltip.test.tsx
+++ b/src/__tests__/NHIPortionTooltip.test.tsx
@@ -39,6 +39,7 @@ function buildNHIScenario(annualIncome: number, region: string, includeLTC: bool
         nhiLongTermCarePortion: breakdown.longTermCarePortion,
         nhiChildSupportPortion: breakdown.childSupportPortion,
         salaryIncome: 0,
+        grossEmploymentIncome: 0,
     };
 
     const inputs: TakeHomeInputs = {

--- a/src/__tests__/NetEmploymentIncomeTooltip.test.tsx
+++ b/src/__tests__/NetEmploymentIncomeTooltip.test.tsx
@@ -1,0 +1,49 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NetEmploymentIncomeTooltip from '../components/TakeHomeCalculator/tabs/NetEmploymentIncomeTooltip';
+import { formatJPY } from '../utils/formatters';
+
+// Render the DetailedTooltip body inline so the breakdown is queryable without hovering.
+vi.mock('../components/ui/Tooltips', () => ({
+  DetailedTooltip: ({ children }: { title?: string; children?: ReactNode }) => <div>{children}</div>,
+  SimpleTooltip: () => <div data-testid="info-tooltip" />,
+}));
+
+describe('NetEmploymentIncomeTooltip', () => {
+  it('derives a non-negative 給与所得控除 from the canonical gross and reconciles to net', () => {
+    // Repro shape: salary 6M + foreign RSU 4M → canonical gross 10M, net 8.05M (2026 cap), no adjustment.
+    render(
+      <NetEmploymentIncomeTooltip
+        grossEmploymentIncome={10_000_000}
+        netEmploymentIncome={8_050_000}
+        year={2026}
+      />
+    );
+
+    expect(screen.getByText(formatJPY(10_000_000))).toBeInTheDocument();       // Gross
+    expect(screen.getByText(`-${formatJPY(1_950_000)}`)).toBeInTheDocument();  // 給与所得控除 = gross − net − adjustment
+    expect(screen.getByText(formatJPY(8_050_000))).toBeInTheDocument();        // Net
+    expect(screen.queryByText('Income Adjustment Deduction:')).not.toBeInTheDocument();
+  });
+
+  it('backs the 所得金額調整控除 out of the employment income deduction so the rows reconcile', () => {
+    // gross 10M, net 7.9M, adjustment 150k → 給与所得控除 = 10M − 7.9M − 150k = 1.95M
+    render(
+      <NetEmploymentIncomeTooltip
+        grossEmploymentIncome={10_000_000}
+        netEmploymentIncome={7_900_000}
+        incomeAdjustmentDeduction={150_000}
+        year={2026}
+      />
+    );
+
+    expect(screen.getByText(`-${formatJPY(1_950_000)}`)).toBeInTheDocument();  // 給与所得控除
+    expect(screen.getByText('Income Adjustment Deduction:')).toBeInTheDocument();
+    expect(screen.getByText(`-${formatJPY(150_000)}`)).toBeInTheDocument();    // 所得金額調整控除
+    expect(screen.getByText(formatJPY(7_900_000))).toBeInTheDocument();        // Net
+  });
+});

--- a/src/__tests__/SocialInsuranceTab.test.tsx
+++ b/src/__tests__/SocialInsuranceTab.test.tsx
@@ -75,6 +75,7 @@ describe('SocialInsuranceTab', () => {
         },
         residenceTaxBasicDeduction: 430000,
         salaryIncome: 6000000,
+        grossEmploymentIncome: 6000000,
     };
 
     it('displays Monthly Remuneration label', () => {

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1253,3 +1253,65 @@ describe('所得金額調整控除 (income amount adjustment deduction) integrat
     expect(calculateTotalNetIncome(incomeStreams, 2026)).toBe(20_050_000);
   });
 });
+
+describe('grossEmploymentIncome (canonical gross for the Net Employment Income tooltip)', () => {
+  const baseInputs = {
+    isSubjectToLongTermCarePremium: false,
+    region: 'Tokyo',
+    dependents: [],
+    dcPlanContributions: 0,
+    manualSocialInsuranceEntry: false,
+    manualSocialInsuranceAmount: 0,
+    incomeYear: 2026,
+  };
+
+  it('sums salary, taxable commuting allowance, bonus, and stock compensation', () => {
+    const result = calculateTaxes({
+      ...baseInputs,
+      healthInsuranceProvider: DEFAULT_PROVIDER,
+      incomeStreams: [
+        { id: 's1', type: 'salary' as const, amount: 6_000_000, frequency: 'annual' as const },
+        // 200k/mo commuting = 2.4M/yr; non-taxable cap is 1.8M/yr → 600k taxable
+        { id: 'c1', type: 'commutingAllowance' as const, amount: 200_000, frequency: 'monthly' as const },
+        { id: 'b1', type: 'bonus' as const, amount: 1_000_000, month: 5 },
+        { id: 'rsu1', type: 'stockCompensation' as const, amount: 4_000_000, issuerDomicile: 'foreign' as const },
+      ],
+    });
+
+    // 6,000,000 + (2,400,000 − 1,800,000) + 1,000,000 + 4,000,000 = 11,600,000
+    expect(result.grossEmploymentIncome).toBe(11_600_000);
+
+    // The tooltip derives 給与所得控除 as gross − net − adjustment. With the canonical gross this is
+    // the real (capped) deduction and is never negative.
+    const employmentIncomeDeduction =
+      result.grossEmploymentIncome - (result.netEmploymentIncome ?? 0) - (result.incomeAdjustmentDeduction ?? 0);
+    expect(employmentIncomeDeduction).toBe(1_950_000);
+    expect(employmentIncomeDeduction).toBeGreaterThanOrEqual(0);
+  });
+
+  it('includes stock compensation so the RSU + NHI scenario has no negative deduction', () => {
+    // Pre-fix, the Social Insurance tab omitted stock compensation from its gross, so the derived
+    // deduction (gross − net) went negative for large RSUs (6M gross < 8.05M net).
+    const result = calculateTaxes({
+      ...baseInputs,
+      healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
+      incomeStreams: [
+        { id: 's1', type: 'salary' as const, amount: 6_000_000, frequency: 'annual' as const },
+        { id: 'rsu1', type: 'stockCompensation' as const, amount: 4_000_000, issuerDomicile: 'foreign' as const },
+      ],
+    });
+
+    expect(result.grossEmploymentIncome).toBe(10_000_000); // 6M salary + 4M RSU (NOT 6M)
+    expect(result.netEmploymentIncome).toBe(8_050_000);    // 10M − 1.95M cap
+    expect(result.grossEmploymentIncome - (result.netEmploymentIncome ?? 0)).toBe(1_950_000);
+  });
+
+  it('is 0 when there is no employment income', () => {
+    const result = calculateTaxes({
+      ...baseInputs,
+      healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
+      incomeStreams: [{ id: 'm1', type: 'miscellaneous' as const, amount: 3_000_000 }],
+    });
+    expect(result.grossEmploymentIncome).toBe(0);
+  });
+});

--- a/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/SocialInsuranceTab.tsx
@@ -124,16 +124,14 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
     .filter(s => s.type === 'bonus')
     .reduce((sum, s) => sum + s.amount, 0);
 
-  // Calculate separated gross income
-  const grossEmploymentIncome = inputs.incomeStreams
-    .filter(s => s.type === 'salary' || s.type === 'bonus')
-    .reduce((sum, s) => sum + (s.type === 'salary' && s.frequency === 'monthly' ? s.amount * 12 : s.amount), 0);
-
   const businessAndMiscIncome = inputs.incomeStreams
     .filter(s => s.type === 'business' || s.type === 'miscellaneous')
     .reduce((sum, s) => sum + s.amount, 0);
 
-  const hasEmploymentIncome = grossEmploymentIncome > 0;
+  // Use the canonical gross from the calculation (salary + taxable commuting allowance +
+  // bonus + stock compensation), not a tab-local recomputation that omits stock/commuting,
+  // so the Net Employment Income tooltip reconciles instead of showing a negative deduction.
+  const hasEmploymentIncome = results.grossEmploymentIncome > 0;
   const hasBusinessOrMiscIncome = businessAndMiscIncome > 0;
 
   const monthlyCommutingAllowance = inputs.incomeStreams
@@ -185,7 +183,7 @@ const SocialInsuranceTab: React.FC<SocialInsuranceTabProps> = ({ results, inputs
                 <span>
                   Net Employment Income
                   <NetEmploymentIncomeTooltip
-                    grossEmploymentIncome={grossEmploymentIncome}
+                    grossEmploymentIncome={results.grossEmploymentIncome}
                     netEmploymentIncome={results.netEmploymentIncome}
                     incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
                     year={inputs.incomeYear}

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -114,16 +114,13 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
   const incomeYear = inputs.incomeYear;
   const basicDeductionTiers = getNationalBasicDeductionTiers(incomeYear);
 
-  // Calculate separated gross income
-  const grossEmploymentIncome = inputs.incomeStreams
-    .filter(s => s.type === 'salary' || s.type === 'bonus' || s.type === 'stockCompensation')
-    .reduce((sum, s) => sum + (s.type === 'salary' && s.frequency === 'monthly' ? s.amount * 12 : s.amount), 0);
-
   const businessAndMiscIncome = inputs.incomeStreams
     .filter(s => s.type === 'business' || s.type === 'miscellaneous')
     .reduce((sum, s) => sum + s.amount, 0);
 
-  const hasEmploymentIncome = grossEmploymentIncome > 0;
+  // Use the canonical gross from the calculation (salary + taxable commuting allowance +
+  // bonus + stock compensation), not a tab-local recomputation, so the tooltip reconciles.
+  const hasEmploymentIncome = results.grossEmploymentIncome > 0;
   const hasBusinessOrMiscIncome = businessAndMiscIncome > 0;
 
   // Residence income-based portion (所得割). When a home loan credit spills over to
@@ -161,7 +158,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
               <span>
                 Net Employment Income
                 <NetEmploymentIncomeTooltip
-                  grossEmploymentIncome={grossEmploymentIncome}
+                  grossEmploymentIncome={results.grossEmploymentIncome}
                   netEmploymentIncome={results.netEmploymentIncome}
                   incomeAdjustmentDeduction={results.incomeAdjustmentDeduction ?? 0}
                   year={incomeYear}

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -181,6 +181,14 @@ export interface TakeHomeResults {
   // Added detailed properties
   netEmploymentIncome?: number | undefined;
   /**
+   * Canonical gross employment income (給与等の収入金額): the exact figure the employment income
+   * deduction (給与所得控除) and {@link netEmploymentIncome}/{@link incomeAdjustmentDeduction} are
+   * derived from — salary + taxable commuting allowance + bonus + stock compensation. The UI must
+   * display THIS value rather than recomputing a per-tab subset, which can understate gross and make
+   * the derived deduction (gross − net − adjustment) wrong or even negative. 0 when no employment income.
+   */
+  grossEmploymentIncome: number;
+  /**
    * 所得金額調整控除（子ども・特別障害者等を有する者等）applied to net employment income (給与所得).
    * Subtracted after the 給与所得控除, so it lowers 合計所得金額 and the taxable income for both
    * income tax and residence tax. 0 when the taxpayer is not eligible. {@link netEmploymentIncome}

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -227,6 +227,7 @@ const DEFAULT_TAKE_HOME_RESULTS: TakeHomeResults = {
     healthInsuranceProvider: DEFAULT_PROVIDER,
     region: 'Tokyo',
     isSubjectToLongTermCarePremium: false,
+    grossEmploymentIncome: 0,
     incomeAdjustmentDeduction: 0,
     totalNetIncome: 0,
 };
@@ -529,6 +530,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
         pensionOnBonus,
         employmentInsuranceOnBonus,
         netEmploymentIncome: hasEmploymentIncome ? netEmploymentIncome : undefined,
+        grossEmploymentIncome,
         incomeAdjustmentDeduction,
         totalNetIncome: netIncome,
         nationalIncomeTaxBasicDeduction,


### PR DESCRIPTION
## Summary

The shared `NetEmploymentIncomeTooltip` derives its **Employment Income Deduction** (給与所得控除) line by subtraction — `gross − net − adjustment` — so the rows only reconcile to net when the gross passed in is the *canonical* figure the calculation actually used. Both tabs were instead passing a **tab-local recomputation** of gross:

- `TaxesTab` summed `salary + bonus + stockCompensation` — omitting **taxable commuting allowance**.
- `SocialInsuranceTab` summed `salary + bonus` — omitting **taxable commuting allowance _and_ stock compensation** (this tooltip shows in the SI tab only for National Health Insurance).

The canonical gross (in `calculateTaxes`) is `salary + taxableCommutingAllowance + bonus + stockCompensation`. `results.netEmploymentIncome` is computed from that full gross, so when a tab passed an understated gross:

- the displayed **Gross Employment Income** was understated by the omitted amount,
- the derived **Employment Income Deduction** was understated by the same amount,
- and worst case rendered **double negative**: a National Health Insurance user with large RSUs (e.g. salary ¥6M + foreign stock ¥4M) saw `gross 6M < net 8.05M`, rendering a malformed `--¥-2,050,000`.

The bottom line (Net) was always correct because the rows reconcile by construction — only the top lines were wrong.

## Fix

Surface the canonical gross on `results` and have both tabs read it instead of recomputing:

- Add `grossEmploymentIncome: number` to `TakeHomeResults`; set it in `calculateTaxes` (the value was already computed locally) and in the default results.
- `TaxesTab` / `SocialInsuranceTab`: drop the tab-local gross, gate the row on `results.grossEmploymentIncome > 0`, and pass `results.grossEmploymentIncome` to the shared tooltip. This removes the "two places compute gross differently" drift entirely.

The shared `NetEmploymentIncomeTooltip` is unchanged — it already derives `gross − net − adjustment` correctly; it just needed the canonical gross.

## Testing

- Added calculation tests asserting `results.grossEmploymentIncome` sums salary + taxable commuting + bonus + stock, and that the RSU + NHI case yields a non-negative deduction (10M gross, not 6M).
- Updated the four typed `TakeHomeResults` mocks for the new required field.
- Verified in the running app: both the Taxes and Social Insurance tabs show **Gross ¥9,000,000 / Deduction −¥1,950,000 / Net ¥7,050,000** for the salary ¥5M + foreign RSU ¥4M NHI scenario.

## Notes for reviewers

- `grossEmploymentIncome` is a required `number` (0 when there is no employment income), mirroring the existing `salaryIncome` field.
- The taxable-commuting sub-case is currently unreachable through the UI (the income editor rejects commuting over ¥150,000/month), but its arithmetic is covered by the new calculation test.