### PR TITLE
Add .git-blame-ignore-revs for the formatting reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# Revisions listed here are skipped by `git blame` so large, purely
+# mechanical changes don't obscure real authorship.
+#
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub applies this file automatically in its blame view.
+
+# Adopt Prettier + EditorConfig: one-time repo-wide reformat (#367).
+cd9f9f7c22aa8680f906e171ab0c5d1c8495b643


### PR DESCRIPTION
Adds `.git-blame-ignore-revs` listing the one-time Prettier + EditorConfig reformat (`cd9f9f7`, #367) so `git blame` skips that purely mechanical change and surfaces real authorship instead.

GitHub applies this file automatically in its blame view. Contributors can opt in locally with:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

This is the post-merge follow-up noted in #367 — the SHA had to be the squashed commit on `main`, so it could not go in that PR.