### PR TITLE
Pin html/css/svg to LF in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 *.toml text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.svg text eol=lf


### PR DESCRIPTION
## What

Adds `*.html`, `*.css`, and `*.svg` to the `eol=lf` rules in `.gitattributes`.

## Why

These extensions weren't covered (only `.ts/.tsx/.js/.jsx/.json/.md/.yml/.yaml/.toml` were), so on Windows git checks `index.html` and `src/index.css` out as CRLF. Prettier normalizes html/css to LF, so `npm run format:check` reports them as needing formatting **locally on Windows** — even though they're stored as LF and pass in CI on Linux.

Pinning them to `eol=lf` makes working-tree line endings consistent across platforms. The committed blobs are already LF, so this only changes how the files are checked out (no content change). `*.svg` is included as harmless future-proofing.
