### PR TITLE
Add income deductions: life & earthquake insurance, medical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Japan Take-Home Pay Calculator will be documented in this file.
 
+## 2026-06-27
+
+### New
+
+- Added support for more income deductions (所得控除) in the "Additional Deductions & Credits" section: life insurance ([生命保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm)), earthquake insurance ([地震保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm)), and medical expenses ([医療費控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)), plus an "Other income deductions" field for anything else that reduces taxable income by the same amount for both taxes. Enter your premiums or medical expenses and the calculator works out the deduction — including the different income-tax and residence-tax amounts, and the medical expense income floor — then applies it to your income tax, residence tax, and furusato nozei limit. The Taxes tab shows the combined total with a per-item breakdown.
+
 ## 2026-06-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Japan Take-Home Pay Calculator will be documented in 
 
 ### New
 
-- Added support for more income deductions (所得控除) in the "Additional Deductions & Credits" section: life insurance ([生命保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm)), earthquake insurance ([地震保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm)), and medical expenses ([医療費控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)). Enter your premiums or medical expenses and the calculator works out the deduction — including the different income-tax and residence-tax amounts, and the medical expense income floor — then applies it to your income tax, residence tax, and furusato nozei limit. The Taxes tab shows the combined total with a per-item breakdown.
+- Added support for more income deductions (所得控除) in the "Additional Deductions & Credits" section: life insurance ([生命保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm)), earthquake insurance ([地震保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm)), and medical expenses ([医療費控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)). Enter your premiums or medical expenses and the calculator works out the deduction — including the different income-tax and residence-tax amounts, and the medical expense income floor — then applies it to your income tax, residence tax, and furusato nozei limit. The Taxes tab shows the combined total with a per-item breakdown. For 2026–2027, households with a dependent under 23 get the general life-insurance (new-contract) income-tax cap raised from ¥40,000 to ¥60,000 (生命保険料控除の子育て世帯拡充).
 
 ## 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to the Japan Take-Home Pay Calculator will be documented in this file.
 
-## 2026-06-27
+## 2026-06-29
 
 ### New
 
-- Added support for more income deductions (所得控除) in the "Additional Deductions & Credits" section: life insurance ([生命保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm)), earthquake insurance ([地震保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm)), and medical expenses ([医療費控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)). Enter your premiums or medical expenses and the calculator works out the deduction — including the different income-tax and residence-tax amounts, and the medical expense income floor — then applies it to your income tax, residence tax, and furusato nozei limit. The Taxes tab shows the combined total with a per-item breakdown. For 2026–2027, households with a dependent under 23 get the general life-insurance (new-contract) income-tax cap raised from ¥40,000 to ¥60,000 (生命保険料控除の子育て世帯拡充).
+- Added support for more income deductions in the "Additional Deductions & Credits" section: life insurance ([生命保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm)), earthquake insurance ([地震保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm)), and medical expenses ([医療費控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)). Enter the premiums or medical expenses and the deduction amount is calculated and applied to income tax, residence tax, and furusato nozei limit. The Taxes tab shows the combined total with a per-item breakdown in the "Other Deductions" tooltip. For 2026–2027, households with a dependent under 23 get the general life-insurance (new contract) income tax deduction cap raised from ¥40,000 to ¥60,000.
 
 ## 2026-06-21
 
@@ -18,7 +18,7 @@ All notable changes to the Japan Take-Home Pay Calculator will be documented in 
 
 ### New
 
-- Added support for the home loan tax credit (住宅ローン控除). Enter the annual credit amount you've calculated (控除可能額) and the year you moved in, and the calculator applies it to your tax owed, up to the applicable cap. Find it in the new "Additional Deductions & Credits" section.
+- Added support for the home loan tax credit (住宅ローン控除). Enter the annual credit amount you've calculated (控除可能額) and the year you moved in, and the calculator applies it to tax owed, up to the applicable cap. Find it in the new "Additional Deductions & Credits" section.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Japan Take-Home Pay Calculator will be documented in 
 
 ### New
 
-- Added support for more income deductions (所得控除) in the "Additional Deductions & Credits" section: life insurance ([生命保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm)), earthquake insurance ([地震保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm)), and medical expenses ([医療費控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)), plus an "Other income deductions" field for anything else that reduces taxable income by the same amount for both taxes. Enter your premiums or medical expenses and the calculator works out the deduction — including the different income-tax and residence-tax amounts, and the medical expense income floor — then applies it to your income tax, residence tax, and furusato nozei limit. The Taxes tab shows the combined total with a per-item breakdown.
+- Added support for more income deductions (所得控除) in the "Additional Deductions & Credits" section: life insurance ([生命保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm)), earthquake insurance ([地震保険料控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm)), and medical expenses ([医療費控除](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)). Enter your premiums or medical expenses and the calculator works out the deduction — including the different income-tax and residence-tax amounts, and the medical expense income floor — then applies it to your income tax, residence tax, and furusato nozei limit. The Taxes tab shows the combined total with a per-item breakdown.
 
 ## 2026-06-21
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import SiteHeader from './components/SiteHeader';
 import ChangelogButton from './components/ChangelogButton';
 import { TakeHomeInputForm } from './components/TakeHomeCalculator/InputForm';
 import type { TakeHomeFormState, TakeHomeInputs, TakeHomeResults } from './types/tax';
-import { DEFAULT_INCOME_YEAR } from './types/tax';
+import { DEFAULT_INCOME_YEAR, EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from './types/tax';
 import { calculateTaxes } from './utils/taxCalculations';
 import {
   DEFAULT_PROVIDER_REGION,
@@ -68,6 +68,7 @@ function App({ mode, toggleColorMode }: AppProps) {
     dcPlanContributions: 0,
     manualSocialInsuranceEntry: false,
     manualSocialInsuranceAmount: 0,
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
   };
 
   // State for form inputs

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,10 @@ function App({ mode, toggleColorMode }: AppProps) {
         manualSocialInsuranceAmount: inputs.manualSocialInsuranceAmount,
         customEHIRates: inputs.customEHIRates,
         homeLoanTaxCredit: inputs.homeLoanTaxCredit,
+        lifeInsurance: inputs.lifeInsurance,
+        earthquakeInsurance: inputs.earthquakeInsurance,
+        medicalExpenses: inputs.medicalExpenses,
+        otherIncomeDeductions: inputs.otherIncomeDeductions,
       };
 
       const takeHomePayResults = calculateTaxes(calculationInputs);
@@ -115,6 +119,10 @@ function App({ mode, toggleColorMode }: AppProps) {
     inputs.manualSocialInsuranceAmount,
     inputs.customEHIRates,
     inputs.homeLoanTaxCredit,
+    inputs.lifeInsurance,
+    inputs.earthquakeInsurance,
+    inputs.medicalExpenses,
+    inputs.otherIncomeDeductions,
   ]);
 
   // Handle input changes
@@ -234,6 +242,7 @@ function App({ mode, toggleColorMode }: AppProps) {
             inputs={inputs}
             onInputChange={handleInputChange}
             homeLoanTaxCreditResult={results?.homeLoanTaxCredit}
+            additionalDeductions={results?.additionalDeductions}
           />
           {results && (
             <Suspense

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,7 +94,6 @@ function App({ mode, toggleColorMode }: AppProps) {
         lifeInsurance: inputs.lifeInsurance,
         earthquakeInsurance: inputs.earthquakeInsurance,
         medicalExpenses: inputs.medicalExpenses,
-        otherIncomeDeductions: inputs.otherIncomeDeductions,
       };
 
       const takeHomePayResults = calculateTaxes(calculationInputs);
@@ -122,7 +121,6 @@ function App({ mode, toggleColorMode }: AppProps) {
     inputs.lifeInsurance,
     inputs.earthquakeInsurance,
     inputs.medicalExpenses,
-    inputs.otherIncomeDeductions,
   ]);
 
   // Handle input changes

--- a/src/__tests__/BlueFilerDisplay.test.tsx
+++ b/src/__tests__/BlueFilerDisplay.test.tsx
@@ -12,6 +12,7 @@ import type {
   ResidenceTaxDetails,
   FurusatoNozeiDetails,
 } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 
 // Mock dependencies
 vi.mock('../components/ui/Tooltips', () => ({
@@ -52,9 +53,11 @@ const mockResults: TakeHomeResults = {
   nhiLongTermCarePortion: 0,
   salaryIncome: 0,
   grossEmploymentIncome: 0,
+  additionalDeductions: { national: 0, residence: 0, items: [] },
 };
 
 const mockInputs: TakeHomeInputs = {
+  ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
   incomeStreams: [
     {
       id: 'mock-advanced-business',

--- a/src/__tests__/HealthInsuranceBonusTooltip.test.tsx
+++ b/src/__tests__/HealthInsuranceBonusTooltip.test.tsx
@@ -9,6 +9,7 @@ import {
   type HealthInsuranceProviderId,
 } from '../types/healthInsurance';
 import type { TakeHomeInputs } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 
 // Mock the provider data (time-series structure: regions map to arrays of rate periods)
 vi.mock('../data/employeesHealthInsurance/providerRateData', () => ({
@@ -67,6 +68,7 @@ vi.mock('../data/employeesHealthInsurance/providerRates', () => ({
 
 describe('HealthInsuranceBonusTooltip', () => {
   const mockInputs: TakeHomeInputs = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     incomeStreams: [],
     isSubjectToLongTermCarePremium: false,
     region: DEFAULT_PROVIDER_REGION,

--- a/src/__tests__/IncomeModeTransitions.test.tsx
+++ b/src/__tests__/IncomeModeTransitions.test.tsx
@@ -7,6 +7,7 @@ import { TakeHomeInputForm } from '../components/TakeHomeCalculator/InputForm';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import type { TakeHomeFormState, IncomeStream } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 import { DEFAULT_PROVIDER, DEFAULT_PROVIDER_REGION } from '../types/healthInsurance';
 import { vi } from 'vitest';
 
@@ -22,6 +23,7 @@ vi.mock('../components/TakeHomeCalculator/Income/IncomeDetailsModal', () => ({
 // Test wrapper that mimics App.tsx state management
 const TestWrapper = ({ initialState }: { initialState?: Partial<TakeHomeFormState> }) => {
   const [inputs, setInputs] = useState<TakeHomeFormState>({
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     annualIncome: 5000000,
     incomeYear: 2026,
     incomeMode: 'salary',

--- a/src/__tests__/InputForm.test.tsx
+++ b/src/__tests__/InputForm.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TakeHomeInputForm } from '../components/TakeHomeCalculator/InputForm';
 import type { TakeHomeFormState } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 import { PROVIDER_DEFINITIONS } from '../data/employeesHealthInsurance/providerRateData';
 import {
   getProviderDisplayName,
@@ -20,6 +21,7 @@ describe('TakeHomeInputForm Tests', () => {
   const mockOnInputChange = vi.fn();
 
   const baseInputs: TakeHomeFormState = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     annualIncome: 5000000,
     incomeYear: 2026,
     incomeMode: 'salary',
@@ -286,6 +288,7 @@ describe('TakeHomeInputForm Tests', () => {
 describe('Dependent Coverage UI Behavior', () => {
   const mockOnInputChange = vi.fn();
   const baseInputs: TakeHomeFormState = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     annualIncome: 5000000,
     incomeYear: 2026,
     incomeMode: 'salary',
@@ -485,6 +488,7 @@ describe('Dependent Coverage UI Behavior', () => {
 describe('Age Range Selection', () => {
   const mockOnInputChange = vi.fn();
   const baseInputs: TakeHomeFormState = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     annualIncome: 5000000,
     incomeYear: 2026,
     incomeMode: 'salary',
@@ -535,6 +539,7 @@ describe('TakeHomeInputForm Dependents Modal', () => {
   }));
 
   const defaultInputs: TakeHomeFormState = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     annualIncome: 0,
     incomeYear: 2026,
     incomeMode: 'advanced',
@@ -577,6 +582,7 @@ describe('Commuting Allowance Integration', () => {
   const mockOnInputChange = vi.fn();
 
   const baseInputs: TakeHomeFormState = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     annualIncome: 5000000,
     incomeYear: 2026,
     incomeMode: 'advanced',
@@ -647,6 +653,7 @@ describe('Regression: Health Insurance Provider Auto-Correction', () => {
   // Wrapper component to manage state like the real application
   const TestWrapper = () => {
     const [inputs, setInputs] = useState<TakeHomeFormState>({
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       annualIncome: 10000000,
       incomeYear: 2026,
       incomeMode: 'advanced',

--- a/src/__tests__/NHICapIndicator.test.tsx
+++ b/src/__tests__/NHICapIndicator.test.tsx
@@ -12,6 +12,7 @@ import type {
   ResidenceTaxDetails,
   FurusatoNozeiDetails,
 } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 
 // Mock scrollTo (used by SMRTableTooltip)
 Element.prototype.scrollTo = vi.fn();
@@ -54,9 +55,11 @@ function buildNHIScenario(annualIncome: number, region: string, includeLTC: bool
     nhiChildSupportPortion: breakdown.childSupportPortion,
     salaryIncome: 0,
     grossEmploymentIncome: 0,
+    additionalDeductions: { national: 0, residence: 0, items: [] },
   };
 
   const inputs: TakeHomeInputs = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     incomeStreams: [{ id: '1', type: 'business', amount: annualIncome }],
     isSubjectToLongTermCarePremium: includeLTC,
     region,

--- a/src/__tests__/NHIPortionTooltip.test.tsx
+++ b/src/__tests__/NHIPortionTooltip.test.tsx
@@ -16,6 +16,7 @@ import type {
   ResidenceTaxDetails,
   FurusatoNozeiDetails,
 } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 
 /**
  * Build minimal TakeHomeResults and TakeHomeInputs for a given NHI scenario,
@@ -55,9 +56,11 @@ function buildNHIScenario(annualIncome: number, region: string, includeLTC: bool
     nhiChildSupportPortion: breakdown.childSupportPortion,
     salaryIncome: 0,
     grossEmploymentIncome: 0,
+    additionalDeductions: { national: 0, residence: 0, items: [] },
   };
 
   const inputs: TakeHomeInputs = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     incomeStreams: [{ id: '1', type: 'business', amount: annualIncome }],
     isSubjectToLongTermCarePremium: includeLTC,
     region,

--- a/src/__tests__/SocialInsuranceTab.test.tsx
+++ b/src/__tests__/SocialInsuranceTab.test.tsx
@@ -4,6 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import SocialInsuranceTab from '../components/TakeHomeCalculator/tabs/SocialInsuranceTab';
 import type { TakeHomeResults, TakeHomeInputs, ResidenceTaxDetails } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 import { vi, describe, it, expect, beforeAll } from 'vitest';
 
 // Mock DetailedTooltip to render children directly for easier testing
@@ -32,6 +33,7 @@ beforeAll(() => {
 
 describe('SocialInsuranceTab', () => {
   const mockInputs: TakeHomeInputs = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     incomeStreams: [
       { id: '1', type: 'salary', amount: 500000, frequency: 'monthly' }, // 6M annual
       { id: '2', type: 'commutingAllowance', amount: 20000, frequency: 'monthly' }, // 240k annual
@@ -90,6 +92,7 @@ describe('SocialInsuranceTab', () => {
     residenceTaxBasicDeduction: 430000,
     salaryIncome: 6000000,
     grossEmploymentIncome: 6000000,
+    additionalDeductions: { national: 0, residence: 0, items: [] },
   };
 
   it('displays Monthly Remuneration label', () => {

--- a/src/__tests__/dependentDeductions.test.ts
+++ b/src/__tests__/dependentDeductions.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   calculateDependentDeductions,
   calculateDependentTotalNetIncome,
+  hasDependentRelativeUnder23,
   hasIncomeAdjustmentDeductionDependent,
 } from '../utils/dependentDeductions';
 import { calculateIncomeAdjustmentDeductionAmount } from '../data/netEmploymentIncome';
@@ -1708,5 +1709,48 @@ describe('所得金額調整控除 (Income Amount Adjustment Deduction)', () => 
       });
       expect(hasIncomeAdjustmentDeductionDependent([richSpouse], 2026)).toBe(false);
     });
+  });
+});
+
+describe('hasDependentRelativeUnder23', () => {
+  const child = (
+    ageCategory: 'under16' | '16to18' | '19to22' | '23to69' | '70plus',
+    otherNetIncome = 0,
+  ): Dependent =>
+    ({
+      id: 'd',
+      relationship: 'child',
+      ageCategory,
+      income: { grossEmploymentIncome: 0, otherNetIncome },
+      disability: 'none',
+      isCohabiting: true,
+    }) as Dependent;
+
+  const spouseUnder70: Dependent = {
+    id: 's',
+    relationship: 'spouse',
+    ageCategory: 'under70',
+    income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
+    disability: 'none',
+    isCohabiting: true,
+  } as Dependent;
+
+  it('is true for a non-spouse dependent under 23 within the threshold (incl. under 16)', () => {
+    expect(hasDependentRelativeUnder23([child('under16')], 2026)).toBe(true);
+    expect(hasDependentRelativeUnder23([child('19to22')], 2026)).toBe(true);
+  });
+
+  it('is false for dependents aged 23 or older', () => {
+    expect(hasDependentRelativeUnder23([child('23to69')], 2026)).toBe(false);
+    expect(hasDependentRelativeUnder23([child('70plus')], 2026)).toBe(false);
+  });
+
+  it('excludes a spouse and any dependent over the 扶養親族 income threshold', () => {
+    expect(hasDependentRelativeUnder23([spouseUnder70], 2026)).toBe(false);
+    expect(hasDependentRelativeUnder23([child('19to22', 700_000)], 2026)).toBe(false);
+  });
+
+  it('is false with no dependents', () => {
+    expect(hasDependentRelativeUnder23([], 2026)).toBe(false);
   });
 });

--- a/src/__tests__/earthquakeInsuranceDeduction.test.ts
+++ b/src/__tests__/earthquakeInsuranceDeduction.test.ts
@@ -1,0 +1,68 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect } from 'vitest';
+import { calculateEarthquakeInsuranceDeduction } from '../data/insuranceDeductions';
+
+describe('calculateEarthquakeInsuranceDeduction — earthquake portion', () => {
+  it('deducts the full premium nationally and half for residence, each capped', () => {
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 30_000 })).toEqual({
+      national: 30_000,
+      residence: 15_000,
+    });
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 50_000 })).toEqual({
+      national: 50_000,
+      residence: 25_000,
+    });
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 80_000 })).toEqual({
+      national: 50_000,
+      residence: 25_000,
+    });
+  });
+});
+
+describe('calculateEarthquakeInsuranceDeduction — 旧長期損害保険料 portion', () => {
+  it('applies the old long-term bands', () => {
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 0, longTermOld: 10_000 })).toEqual({
+      national: 10_000,
+      residence: 7_500,
+    });
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 0, longTermOld: 20_000 })).toEqual({
+      national: 15_000,
+      residence: 10_000,
+    });
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 0, longTermOld: 30_000 })).toEqual({
+      national: 15_000,
+      residence: 10_000,
+    });
+  });
+});
+
+describe('calculateEarthquakeInsuranceDeduction — combined and edge cases', () => {
+  it('sums the two portions under the cap', () => {
+    expect(
+      calculateEarthquakeInsuranceDeduction({ earthquake: 20_000, longTermOld: 10_000 }),
+    ).toEqual({ national: 30_000, residence: 17_500 });
+  });
+
+  it('caps the combined deduction at the overall maximum', () => {
+    expect(
+      calculateEarthquakeInsuranceDeduction({ earthquake: 50_000, longTermOld: 30_000 }),
+    ).toEqual({ national: 50_000, residence: 25_000 });
+  });
+
+  it('rounds the residence half up to the next yen', () => {
+    // 25,001 / 2 = 12,500.5 → 12,501 (1円未満切上げ convention).
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 25_001 })).toEqual({
+      national: 25_001,
+      residence: 12_501,
+    });
+  });
+
+  it('returns zero for empty input', () => {
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 0 })).toEqual({
+      national: 0,
+      residence: 0,
+    });
+  });
+});

--- a/src/__tests__/earthquakeInsuranceDeduction.test.ts
+++ b/src/__tests__/earthquakeInsuranceDeduction.test.ts
@@ -6,15 +6,15 @@ import { calculateEarthquakeInsuranceDeduction } from '../data/insuranceDeductio
 
 describe('calculateEarthquakeInsuranceDeduction — earthquake portion', () => {
   it('deducts the full premium nationally and half for residence, each capped', () => {
-    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 30_000 })).toEqual({
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 30_000, longTermOld: 0 })).toEqual({
       national: 30_000,
       residence: 15_000,
     });
-    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 50_000 })).toEqual({
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 50_000, longTermOld: 0 })).toEqual({
       national: 50_000,
       residence: 25_000,
     });
-    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 80_000 })).toEqual({
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 80_000, longTermOld: 0 })).toEqual({
       national: 50_000,
       residence: 25_000,
     });
@@ -53,14 +53,14 @@ describe('calculateEarthquakeInsuranceDeduction — combined and edge cases', ()
 
   it('rounds the residence half up to the next yen', () => {
     // 25,001 / 2 = 12,500.5 → 12,501 (1円未満切上げ convention).
-    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 25_001 })).toEqual({
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 25_001, longTermOld: 0 })).toEqual({
       national: 25_001,
       residence: 12_501,
     });
   });
 
   it('returns zero for empty input', () => {
-    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 0 })).toEqual({
+    expect(calculateEarthquakeInsuranceDeduction({ earthquake: 0, longTermOld: 0 })).toEqual({
       national: 0,
       residence: 0,
     });

--- a/src/__tests__/furusato.test.ts
+++ b/src/__tests__/furusato.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 import { calculateTaxes } from '../utils/taxCalculations';
 import { DEFAULT_PROVIDER } from '../types/healthInsurance';
 import type { FurusatoNozeiDetails } from '../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 
 describe('calculateFurusatoNozeiLimit', () => {
   it('calculates furusato nozei for the default salary', () => {
@@ -54,6 +55,7 @@ describe('calculateFurusatoNozeiLimit', () => {
 
   it('furusato nozei limit is reduced by DC plan contributions', () => {
     const fn = calculateTaxes({
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [{ id: 'test', type: 'salary', amount: 5_000_000, frequency: 'annual' }],
       isSubjectToLongTermCarePremium: false,
       region: 'Tokyo',
@@ -74,6 +76,7 @@ describe('calculateFurusatoNozeiLimit', () => {
 
   describe('home loan tax credit (住宅ローン控除) interactions', () => {
     const baseInputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { id: 'test', type: 'salary' as const, amount: 7_000_000, frequency: 'annual' as const },
       ],
@@ -169,6 +172,7 @@ describe('calculateFurusatoNozeiLimit', () => {
       // At ¥3.5M the residence-tax taxable income is well above the income-tax taxable
       // income (the income-tax basic deduction is larger), so the two cap bases diverge.
       const inputs = {
+        ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
         incomeStreams: [
           { id: 'test', type: 'salary' as const, amount: 3_500_000, frequency: 'annual' as const },
         ],
@@ -216,6 +220,7 @@ describe('calculateFurusatoNozeiLimit', () => {
     // ----------------------------------------------------------------------
     it('computes the home loan credit independently of any furusato donation (interaction deferred)', () => {
       const inputs = {
+        ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
         incomeStreams: [
           { id: 'test', type: 'salary' as const, amount: 3_500_000, frequency: 'annual' as const },
         ],
@@ -261,6 +266,7 @@ describe('calculateFurusatoNozeiLimit', () => {
 
     it('exposes the pre-home-loan income-based residence portion so the breakdown reconciles', () => {
       const inputs = {
+        ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
         incomeStreams: [
           { id: 'test', type: 'salary' as const, amount: 3_500_000, frequency: 'annual' as const },
         ],
@@ -416,6 +422,7 @@ describe('calculateFurusatoNozeiLimit', () => {
     // Standard calculation for 5M income has limit of 60,000
     // If we increase social insurance deduction manually, taxable income decreases, so limit should decrease
     const fnWithHighSocialInsurance = calculateTaxes({
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [{ id: 'test', type: 'salary', amount: 5_000_000, frequency: 'annual' }],
       isSubjectToLongTermCarePremium: false,
       region: 'Tokyo',
@@ -431,6 +438,7 @@ describe('calculateFurusatoNozeiLimit', () => {
 
     // If we decrease social insurance deduction manually, taxable income increases, so limit should increase
     const fnWithLowSocialInsurance = calculateTaxes({
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [{ id: 'test', type: 'salary', amount: 5_000_000, frequency: 'annual' }],
       isSubjectToLongTermCarePremium: false,
       region: 'Tokyo',
@@ -448,6 +456,7 @@ describe('calculateFurusatoNozeiLimit', () => {
 
 function calculateFNForIncome(income: number): FurusatoNozeiDetails {
   return calculateTaxes({
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     incomeStreams: [{ id: 'test', type: 'salary', amount: income, frequency: 'annual' }],
     isSubjectToLongTermCarePremium: false,
     region: 'Tokyo',

--- a/src/__tests__/lifeInsuranceDeduction.test.ts
+++ b/src/__tests__/lifeInsuranceDeduction.test.ts
@@ -1,0 +1,91 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect } from 'vitest';
+import { calculateLifeInsuranceDeduction } from '../data/insuranceDeductions';
+import type { LifeInsuranceInput } from '../types/tax';
+
+const life = (o: Partial<LifeInsuranceInput>): LifeInsuranceInput => ({
+  generalNew: 0,
+  medicalCareNew: 0,
+  pensionNew: 0,
+  ...o,
+});
+
+describe('calculateLifeInsuranceDeduction — new contract, single category', () => {
+  it('applies the national bands at their boundaries', () => {
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 20_000 })).national).toBe(20_000);
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 40_000 })).national).toBe(30_000);
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 80_000 })).national).toBe(40_000);
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 200_000 })).national).toBe(40_000);
+  });
+
+  it('applies the residence bands at their boundaries', () => {
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 12_000 })).residence).toBe(12_000);
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 32_000 })).residence).toBe(22_000);
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 56_000 })).residence).toBe(28_000);
+    expect(calculateLifeInsuranceDeduction(life({ generalNew: 200_000 })).residence).toBe(28_000);
+  });
+});
+
+describe('calculateLifeInsuranceDeduction — old contract, single category', () => {
+  it('uses the old-contract bands and caps', () => {
+    expect(calculateLifeInsuranceDeduction(life({ generalOld: 25_000 }))).toEqual({
+      national: 25_000,
+      residence: 20_000,
+    });
+    expect(calculateLifeInsuranceDeduction(life({ generalOld: 100_000 }))).toEqual({
+      national: 50_000,
+      residence: 35_000,
+    });
+  });
+});
+
+describe('calculateLifeInsuranceDeduction — combined old + new rule', () => {
+  it('uses old-only when the old premium clears the national ¥60,000 break-even', () => {
+    // old 70,000 > 60,000 → old-only (¥42,500) beats the ¥40,000 combined cap.
+    const d = calculateLifeInsuranceDeduction(life({ generalNew: 40_000, generalOld: 70_000 }));
+    expect(d.national).toBe(42_500);
+    expect(d.residence).toBe(35_000);
+  });
+
+  it('meets the combined cap exactly at the national ¥60,000 break-even', () => {
+    // old 60,000 → old-only deduction is exactly ¥40,000, the combined cap.
+    const d = calculateLifeInsuranceDeduction(life({ generalNew: 80_000, generalOld: 60_000 }));
+    expect(d.national).toBe(40_000);
+  });
+
+  it('honours the residence ¥42,000 break-even, not the national ¥60,000 one', () => {
+    // old 50,000 ≤ 60,000, so a hardcoded national threshold would wrongly cap residence at
+    // ¥28,000. The cap-agnostic max picks old-only (¥30,000), which is correct for residence.
+    const d = calculateLifeInsuranceDeduction(life({ generalNew: 56_000, generalOld: 50_000 }));
+    expect(d.residence).toBe(30_000);
+    expect(d.national).toBe(40_000);
+  });
+});
+
+describe('calculateLifeInsuranceDeduction — 介護医療 and caps', () => {
+  it('treats 介護医療 as new-contract only', () => {
+    expect(calculateLifeInsuranceDeduction(life({ medicalCareNew: 40_000 }))).toEqual({
+      national: 30_000,
+      residence: 24_000,
+    });
+  });
+
+  it('caps the sum of all three categories at the overall maximum', () => {
+    const d = calculateLifeInsuranceDeduction(
+      life({
+        generalNew: 80_000,
+        generalOld: 100_000, // general category resolves to the ¥50,000 old-only amount
+        medicalCareNew: 80_000,
+        pensionNew: 80_000,
+      }),
+    );
+    expect(d.national).toBe(120_000);
+    expect(d.residence).toBe(70_000);
+  });
+
+  it('returns zero for empty input', () => {
+    expect(calculateLifeInsuranceDeduction(life({}))).toEqual({ national: 0, residence: 0 });
+  });
+});

--- a/src/__tests__/lifeInsuranceDeduction.test.ts
+++ b/src/__tests__/lifeInsuranceDeduction.test.ts
@@ -133,11 +133,11 @@ describe('calculateLifeInsuranceDeduction — child-rearing expansion (令和8�
   });
 
   it('still applies the ¥120,000 / ¥70,000 overall caps when eligible', () => {
-    const d = deduct(
+    const deduction = deduct(
       life({ generalNew: 120_000, medicalCareNew: 80_000, pensionNew: 80_000 }),
       2026,
       true,
     );
-    expect(d).toEqual({ national: 120_000, residence: 70_000 });
+    expect(deduction).toEqual({ national: 120_000, residence: 70_000 });
   });
 });

--- a/src/__tests__/lifeInsuranceDeduction.test.ts
+++ b/src/__tests__/lifeInsuranceDeduction.test.ts
@@ -12,29 +12,37 @@ const life = (o: Partial<LifeInsuranceInput>): LifeInsuranceInput => ({
   ...o,
 });
 
+/**
+ * Calls the deduction with test-friendly defaults: no child-rearing raise (year 2026, no
+ * qualifying dependent). Pass `year` and `hasDependentUnder23` explicitly to exercise the
+ * 令和8・9年分 expansion. Production always supplies both, so they are required there.
+ */
+const deduct = (input: LifeInsuranceInput, year = 2026, hasDependentUnder23 = false) =>
+  calculateLifeInsuranceDeduction(input, year, hasDependentUnder23);
+
 describe('calculateLifeInsuranceDeduction — new contract, single category', () => {
   it('applies the national bands at their boundaries', () => {
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 20_000 })).national).toBe(20_000);
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 40_000 })).national).toBe(30_000);
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 80_000 })).national).toBe(40_000);
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 200_000 })).national).toBe(40_000);
+    expect(deduct(life({ generalNew: 20_000 })).national).toBe(20_000);
+    expect(deduct(life({ generalNew: 40_000 })).national).toBe(30_000);
+    expect(deduct(life({ generalNew: 80_000 })).national).toBe(40_000);
+    expect(deduct(life({ generalNew: 200_000 })).national).toBe(40_000);
   });
 
   it('applies the residence bands at their boundaries', () => {
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 12_000 })).residence).toBe(12_000);
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 32_000 })).residence).toBe(22_000);
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 56_000 })).residence).toBe(28_000);
-    expect(calculateLifeInsuranceDeduction(life({ generalNew: 200_000 })).residence).toBe(28_000);
+    expect(deduct(life({ generalNew: 12_000 })).residence).toBe(12_000);
+    expect(deduct(life({ generalNew: 32_000 })).residence).toBe(22_000);
+    expect(deduct(life({ generalNew: 56_000 })).residence).toBe(28_000);
+    expect(deduct(life({ generalNew: 200_000 })).residence).toBe(28_000);
   });
 });
 
 describe('calculateLifeInsuranceDeduction — old contract, single category', () => {
   it('uses the old-contract bands and caps', () => {
-    expect(calculateLifeInsuranceDeduction(life({ generalOld: 25_000 }))).toEqual({
+    expect(deduct(life({ generalOld: 25_000 }))).toEqual({
       national: 25_000,
       residence: 20_000,
     });
-    expect(calculateLifeInsuranceDeduction(life({ generalOld: 100_000 }))).toEqual({
+    expect(deduct(life({ generalOld: 100_000 }))).toEqual({
       national: 50_000,
       residence: 35_000,
     });
@@ -44,36 +52,36 @@ describe('calculateLifeInsuranceDeduction — old contract, single category', ()
 describe('calculateLifeInsuranceDeduction — combined old + new rule', () => {
   it('uses old-only when the old premium clears the national ¥60,000 break-even', () => {
     // old 70,000 > 60,000 → old-only (¥42,500) beats the ¥40,000 combined cap.
-    const d = calculateLifeInsuranceDeduction(life({ generalNew: 40_000, generalOld: 70_000 }));
-    expect(d.national).toBe(42_500);
-    expect(d.residence).toBe(35_000);
+    const deduction = deduct(life({ generalNew: 40_000, generalOld: 70_000 }));
+    expect(deduction.national).toBe(42_500);
+    expect(deduction.residence).toBe(35_000);
   });
 
   it('meets the combined cap exactly at the national ¥60,000 break-even', () => {
     // old 60,000 → old-only deduction is exactly ¥40,000, the combined cap.
-    const d = calculateLifeInsuranceDeduction(life({ generalNew: 80_000, generalOld: 60_000 }));
-    expect(d.national).toBe(40_000);
+    const deduction = deduct(life({ generalNew: 80_000, generalOld: 60_000 }));
+    expect(deduction.national).toBe(40_000);
   });
 
   it('honours the residence ¥42,000 break-even, not the national ¥60,000 one', () => {
     // old 50,000 ≤ 60,000, so a hardcoded national threshold would wrongly cap residence at
     // ¥28,000. The cap-agnostic max picks old-only (¥30,000), which is correct for residence.
-    const d = calculateLifeInsuranceDeduction(life({ generalNew: 56_000, generalOld: 50_000 }));
-    expect(d.residence).toBe(30_000);
-    expect(d.national).toBe(40_000);
+    const deduction = deduct(life({ generalNew: 56_000, generalOld: 50_000 }));
+    expect(deduction.residence).toBe(30_000);
+    expect(deduction.national).toBe(40_000);
   });
 });
 
 describe('calculateLifeInsuranceDeduction — 介護医療 and caps', () => {
   it('treats 介護医療 as new-contract only', () => {
-    expect(calculateLifeInsuranceDeduction(life({ medicalCareNew: 40_000 }))).toEqual({
+    expect(deduct(life({ medicalCareNew: 40_000 }))).toEqual({
       national: 30_000,
       residence: 24_000,
     });
   });
 
   it('caps the sum of all three categories at the overall maximum', () => {
-    const d = calculateLifeInsuranceDeduction(
+    const deduction = deduct(
       life({
         generalNew: 80_000,
         generalOld: 100_000, // general category resolves to the ¥50,000 old-only amount
@@ -81,11 +89,55 @@ describe('calculateLifeInsuranceDeduction — 介護医療 and caps', () => {
         pensionNew: 80_000,
       }),
     );
-    expect(d.national).toBe(120_000);
-    expect(d.residence).toBe(70_000);
+    expect(deduction.national).toBe(120_000);
+    expect(deduction.residence).toBe(70_000);
   });
 
   it('returns zero for empty input', () => {
-    expect(calculateLifeInsuranceDeduction(life({}))).toEqual({ national: 0, residence: 0 });
+    expect(deduct(life({}))).toEqual({ national: 0, residence: 0 });
+  });
+});
+
+describe('calculateLifeInsuranceDeduction — child-rearing expansion (令和8・9年分)', () => {
+  it('raises the 一般 new-contract income-tax cap to ¥60,000, leaving residence unchanged', () => {
+    const raised = deduct(life({ generalNew: 120_000 }), 2026, true);
+    expect(raised).toEqual({ national: 60_000, residence: 28_000 });
+    // Without eligibility the same premium is capped at the standard ¥40,000.
+    expect(deduct(life({ generalNew: 120_000 }), 2026, false).national).toBe(40_000);
+  });
+
+  it('applies the raised sliding scale at a mid boundary', () => {
+    // 60,000 → ×½ + 15,000 = 45,000 (standard scale would give 35,000).
+    expect(deduct(life({ generalNew: 60_000 }), 2026, true).national).toBe(45_000);
+  });
+
+  it('only raises 一般 — 介護医療 and 個人年金 stay at ¥40,000', () => {
+    expect(deduct(life({ medicalCareNew: 120_000 }), 2026, true).national).toBe(40_000);
+    expect(deduct(life({ pensionNew: 120_000 }), 2026, true).national).toBe(40_000);
+  });
+
+  it('does not raise outside the eligible years or without a qualifying dependent', () => {
+    const big = life({ generalNew: 120_000 });
+    expect(deduct(big, 2026, false).national).toBe(40_000);
+    expect(deduct(big, 2025, true).national).toBe(40_000);
+    expect(deduct(big, 2028, true).national).toBe(40_000);
+  });
+
+  it('keeps old-only 一般 at ¥50,000 but lets new+old combined reach ¥60,000', () => {
+    // Old-only is unchanged by the measure.
+    expect(deduct(life({ generalOld: 120_000 }), 2026, true).national).toBe(50_000);
+    // New (¥60,000) + old (¥37,500), combined capped at the raised ¥60,000.
+    expect(deduct(life({ generalNew: 120_000, generalOld: 50_000 }), 2026, true).national).toBe(
+      60_000,
+    );
+  });
+
+  it('still applies the ¥120,000 / ¥70,000 overall caps when eligible', () => {
+    const d = deduct(
+      life({ generalNew: 120_000, medicalCareNew: 80_000, pensionNew: 80_000 }),
+      2026,
+      true,
+    );
+    expect(d).toEqual({ national: 120_000, residence: 70_000 });
   });
 });

--- a/src/__tests__/medicalExpenseDeduction.test.ts
+++ b/src/__tests__/medicalExpenseDeduction.test.ts
@@ -33,6 +33,8 @@ describe('calculateAdditionalDeductions', () => {
   it('aggregates per-tax totals and itemizes the breakdown', () => {
     const result = calculateAdditionalDeductions(
       {
+        incomeYear: 2026,
+        dependents: [],
         lifeInsurance: { generalNew: 100_000, medicalCareNew: 0, pensionNew: 100_000 },
         earthquakeInsurance: { earthquake: 50_000 },
         medicalExpenses: { paid: 350_000, reimbursed: 100_000 },
@@ -47,7 +49,7 @@ describe('calculateAdditionalDeductions', () => {
 
   it('keeps medical equal across both taxes', () => {
     const result = calculateAdditionalDeductions(
-      { medicalExpenses: { paid: 200_000, reimbursed: 0 } },
+      { incomeYear: 2026, dependents: [], medicalExpenses: { paid: 200_000, reimbursed: 0 } },
       10_000_000,
     );
     expect(result.items).toHaveLength(1);
@@ -56,14 +58,18 @@ describe('calculateAdditionalDeductions', () => {
 
   it('omits items that compute to zero', () => {
     const result = calculateAdditionalDeductions(
-      { lifeInsurance: { generalNew: 0, medicalCareNew: 0, pensionNew: 0 } },
+      {
+        incomeYear: 2026,
+        dependents: [],
+        lifeInsurance: { generalNew: 0, medicalCareNew: 0, pensionNew: 0 },
+      },
       5_000_000,
     );
     expect(result).toEqual({ national: 0, residence: 0, items: [] });
   });
 
   it('returns an empty result when no additional deductions are entered', () => {
-    expect(calculateAdditionalDeductions({}, 5_000_000)).toEqual({
+    expect(calculateAdditionalDeductions({ incomeYear: 2026, dependents: [] }, 5_000_000)).toEqual({
       national: 0,
       residence: 0,
       items: [],

--- a/src/__tests__/medicalExpenseDeduction.test.ts
+++ b/src/__tests__/medicalExpenseDeduction.test.ts
@@ -6,6 +6,7 @@ import {
   calculateAdditionalDeductions,
   calculateMedicalExpenseDeduction,
 } from '../utils/additionalDeductions';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 
 describe('calculateMedicalExpenseDeduction', () => {
   it('subtracts the ¥100,000 floor when income is high', () => {
@@ -36,7 +37,7 @@ describe('calculateAdditionalDeductions', () => {
         incomeYear: 2026,
         dependents: [],
         lifeInsurance: { generalNew: 100_000, medicalCareNew: 0, pensionNew: 100_000 },
-        earthquakeInsurance: { earthquake: 50_000 },
+        earthquakeInsurance: { earthquake: 50_000, longTermOld: 0 },
         medicalExpenses: { paid: 350_000, reimbursed: 100_000 },
       },
       10_000_000,
@@ -49,7 +50,12 @@ describe('calculateAdditionalDeductions', () => {
 
   it('keeps medical equal across both taxes', () => {
     const result = calculateAdditionalDeductions(
-      { incomeYear: 2026, dependents: [], medicalExpenses: { paid: 200_000, reimbursed: 0 } },
+      {
+        ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
+        incomeYear: 2026,
+        dependents: [],
+        medicalExpenses: { paid: 200_000, reimbursed: 0 },
+      },
       10_000_000,
     );
     expect(result.items).toHaveLength(1);
@@ -59,6 +65,7 @@ describe('calculateAdditionalDeductions', () => {
   it('omits items that compute to zero', () => {
     const result = calculateAdditionalDeductions(
       {
+        ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
         incomeYear: 2026,
         dependents: [],
         lifeInsurance: { generalNew: 0, medicalCareNew: 0, pensionNew: 0 },
@@ -69,7 +76,12 @@ describe('calculateAdditionalDeductions', () => {
   });
 
   it('returns an empty result when no additional deductions are entered', () => {
-    expect(calculateAdditionalDeductions({ incomeYear: 2026, dependents: [] }, 5_000_000)).toEqual({
+    expect(
+      calculateAdditionalDeductions(
+        { ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS, incomeYear: 2026, dependents: [] },
+        5_000_000,
+      ),
+    ).toEqual({
       national: 0,
       residence: 0,
       items: [],

--- a/src/__tests__/medicalExpenseDeduction.test.ts
+++ b/src/__tests__/medicalExpenseDeduction.test.ts
@@ -17,6 +17,10 @@ describe('calculateMedicalExpenseDeduction', () => {
     expect(calculateMedicalExpenseDeduction(300_000, 0, 1_000_000)).toBe(250_000);
   });
 
+  it('uses 5% of income as the floor when that is lower than ¥100,000 even when expenses are under ¥100,000', () => {
+    expect(calculateMedicalExpenseDeduction(70_000, 0, 1_000_000)).toBe(20_000);
+  });
+
   it('returns zero when net expenses are below the floor', () => {
     expect(calculateMedicalExpenseDeduction(80_000, 0, 10_000_000)).toBe(0);
   });
@@ -68,7 +72,7 @@ describe('calculateAdditionalDeductions', () => {
         ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
         incomeYear: 2026,
         dependents: [],
-        lifeInsurance: { generalNew: 0, medicalCareNew: 0, pensionNew: 0 },
+        medicalExpenses: { paid: 80_000, reimbursed: 0 },
       },
       5_000_000,
     );

--- a/src/__tests__/medicalExpenseDeduction.test.ts
+++ b/src/__tests__/medicalExpenseDeduction.test.ts
@@ -1,0 +1,86 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect } from 'vitest';
+import {
+  calculateAdditionalDeductions,
+  calculateMedicalExpenseDeduction,
+  calculateOtherIncomeDeduction,
+} from '../utils/additionalDeductions';
+
+describe('calculateMedicalExpenseDeduction', () => {
+  it('subtracts the ¥100,000 floor when income is high', () => {
+    expect(calculateMedicalExpenseDeduction(350_000, 100_000, 10_000_000)).toBe(150_000);
+  });
+
+  it('uses 5% of income as the floor when that is lower than ¥100,000', () => {
+    expect(calculateMedicalExpenseDeduction(300_000, 0, 1_000_000)).toBe(250_000);
+  });
+
+  it('returns zero when net expenses are below the floor', () => {
+    expect(calculateMedicalExpenseDeduction(80_000, 0, 10_000_000)).toBe(0);
+  });
+
+  it('clamps reimbursements that exceed what was paid', () => {
+    expect(calculateMedicalExpenseDeduction(50_000, 80_000, 10_000_000)).toBe(0);
+  });
+
+  it('caps the deduction at ¥2,000,000', () => {
+    expect(calculateMedicalExpenseDeduction(2_500_000, 0, 10_000_000)).toBe(2_000_000);
+  });
+});
+
+describe('calculateOtherIncomeDeduction', () => {
+  it('passes through a positive amount, flooring fractions', () => {
+    expect(calculateOtherIncomeDeduction(50_000)).toBe(50_000);
+    expect(calculateOtherIncomeDeduction(1_234.7)).toBe(1_234);
+  });
+
+  it('treats undefined and negative amounts as zero', () => {
+    expect(calculateOtherIncomeDeduction(undefined)).toBe(0);
+    expect(calculateOtherIncomeDeduction(-5_000)).toBe(0);
+  });
+});
+
+describe('calculateAdditionalDeductions', () => {
+  it('aggregates per-tax totals and itemizes the breakdown', () => {
+    const result = calculateAdditionalDeductions(
+      {
+        lifeInsurance: { generalNew: 100_000, medicalCareNew: 0, pensionNew: 100_000 },
+        earthquakeInsurance: { earthquake: 50_000 },
+        medicalExpenses: { paid: 350_000, reimbursed: 100_000 },
+        otherIncomeDeductions: 30_000,
+      },
+      10_000_000,
+    );
+    expect(result.items).toHaveLength(4);
+    // life 80k/56k + earthquake 50k/25k + medical 150k + other 30k
+    expect(result.national).toBe(310_000);
+    expect(result.residence).toBe(261_000);
+  });
+
+  it('keeps medical and other equal across both taxes', () => {
+    const result = calculateAdditionalDeductions(
+      { medicalExpenses: { paid: 200_000, reimbursed: 0 } },
+      10_000_000,
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.national).toBe(result.residence);
+  });
+
+  it('omits items that compute to zero', () => {
+    const result = calculateAdditionalDeductions(
+      { lifeInsurance: { generalNew: 0, medicalCareNew: 0, pensionNew: 0 } },
+      5_000_000,
+    );
+    expect(result).toEqual({ national: 0, residence: 0, items: [] });
+  });
+
+  it('returns an empty result when no additional deductions are entered', () => {
+    expect(calculateAdditionalDeductions({}, 5_000_000)).toEqual({
+      national: 0,
+      residence: 0,
+      items: [],
+    });
+  });
+});

--- a/src/__tests__/medicalExpenseDeduction.test.ts
+++ b/src/__tests__/medicalExpenseDeduction.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect } from 'vitest';
 import {
   calculateAdditionalDeductions,
   calculateMedicalExpenseDeduction,
-  calculateOtherIncomeDeduction,
 } from '../utils/additionalDeductions';
 
 describe('calculateMedicalExpenseDeduction', () => {
@@ -30,18 +29,6 @@ describe('calculateMedicalExpenseDeduction', () => {
   });
 });
 
-describe('calculateOtherIncomeDeduction', () => {
-  it('passes through a positive amount, flooring fractions', () => {
-    expect(calculateOtherIncomeDeduction(50_000)).toBe(50_000);
-    expect(calculateOtherIncomeDeduction(1_234.7)).toBe(1_234);
-  });
-
-  it('treats undefined and negative amounts as zero', () => {
-    expect(calculateOtherIncomeDeduction(undefined)).toBe(0);
-    expect(calculateOtherIncomeDeduction(-5_000)).toBe(0);
-  });
-});
-
 describe('calculateAdditionalDeductions', () => {
   it('aggregates per-tax totals and itemizes the breakdown', () => {
     const result = calculateAdditionalDeductions(
@@ -49,17 +36,16 @@ describe('calculateAdditionalDeductions', () => {
         lifeInsurance: { generalNew: 100_000, medicalCareNew: 0, pensionNew: 100_000 },
         earthquakeInsurance: { earthquake: 50_000 },
         medicalExpenses: { paid: 350_000, reimbursed: 100_000 },
-        otherIncomeDeductions: 30_000,
       },
       10_000_000,
     );
-    expect(result.items).toHaveLength(4);
-    // life 80k/56k + earthquake 50k/25k + medical 150k + other 30k
-    expect(result.national).toBe(310_000);
-    expect(result.residence).toBe(261_000);
+    expect(result.items).toHaveLength(3);
+    // life 80k/56k + earthquake 50k/25k + medical 150k
+    expect(result.national).toBe(280_000);
+    expect(result.residence).toBe(231_000);
   });
 
-  it('keeps medical and other equal across both taxes', () => {
+  it('keeps medical equal across both taxes', () => {
     const result = calculateAdditionalDeductions(
       { medicalExpenses: { paid: 200_000, reimbursed: 0 } },
       10_000_000,

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1118,6 +1118,117 @@ describe('Commuting Allowance', () => {
   });
 });
 
+describe('Additional income deductions (life, earthquake, medical, other)', () => {
+  const baseSalaryInputs = {
+    incomeStreams: [
+      { type: 'salary' as const, amount: 8_000_000, frequency: 'annual' as const, id: 's1' },
+    ],
+    isSubjectToLongTermCarePremium: false,
+    healthInsuranceProvider: DEFAULT_PROVIDER,
+    region: 'Tokyo',
+    dependents: [],
+    dcPlanContributions: 0,
+    manualSocialInsuranceEntry: false,
+    manualSocialInsuranceAmount: 0,
+    incomeYear: 2026,
+  };
+
+  it('subtracts insurance and other deductions from both taxable incomes without touching 調整控除', () => {
+    const base = calculateTaxes(baseSalaryInputs);
+    const withDeductions = calculateTaxes({
+      ...baseSalaryInputs,
+      lifeInsurance: { generalNew: 100_000, medicalCareNew: 0, pensionNew: 100_000 },
+      earthquakeInsurance: { earthquake: 50_000 },
+      otherIncomeDeductions: 20_000,
+    });
+
+    // life 80k/56k + earthquake 50k/25k + other 20k = 150k national, 101k residence
+    expect(withDeductions.additionalDeductions).toBeDefined();
+    expect(withDeductions.additionalDeductions!.national).toBe(150_000);
+    expect(withDeductions.additionalDeductions!.residence).toBe(101_000);
+    expect(withDeductions.additionalDeductions!.items.map(i => i.key)).toEqual([
+      'lifeInsurance',
+      'earthquakeInsurance',
+      'other',
+    ]);
+
+    // Both taxable incomes drop by exactly the per-tax total (the amounts are multiples of 1,000).
+    expect(
+      base.taxableIncomeForNationalIncomeTax! - withDeductions.taxableIncomeForNationalIncomeTax!,
+    ).toBe(150_000);
+    expect(base.taxableIncomeForResidenceTax! - withDeductions.taxableIncomeForResidenceTax!).toBe(
+      101_000,
+    );
+
+    // These are 物的控除, so the residence 調整控除 (personal deduction difference) is unchanged.
+    expect(withDeductions.residenceTax.personalDeductionDifference).toBe(
+      base.residenceTax.personalDeductionDifference,
+    );
+
+    expect(withDeductions.nationalIncomeTax).toBeLessThan(base.nationalIncomeTax);
+    expect(withDeductions.residenceTax.totalResidenceTax).toBeLessThan(
+      base.residenceTax.totalResidenceTax,
+    );
+  });
+
+  it('applies the medical expense income floor and reduces both taxes equally', () => {
+    const base = calculateTaxes(baseSalaryInputs);
+    const withMedical = calculateTaxes({
+      ...baseSalaryInputs,
+      medicalExpenses: { paid: 350_000, reimbursed: 100_000 },
+    });
+
+    // netIncome 6,100,000 → floor min(¥100k, 5% × 6.1M = ¥305k) = ¥100k → 250k − 100k = ¥150k.
+    expect(withMedical.additionalDeductions!.national).toBe(150_000);
+    expect(withMedical.additionalDeductions!.residence).toBe(150_000);
+    expect(withMedical.additionalDeductions!.items).toHaveLength(1);
+    expect(withMedical.additionalDeductions!.items[0]!.key).toBe('medical');
+
+    expect(
+      base.taxableIncomeForNationalIncomeTax! - withMedical.taxableIncomeForNationalIncomeTax!,
+    ).toBe(150_000);
+    expect(base.taxableIncomeForResidenceTax! - withMedical.taxableIncomeForResidenceTax!).toBe(
+      150_000,
+    );
+  });
+
+  it('lowers the furusato nozei limit when residence tax falls', () => {
+    const base = calculateTaxes(baseSalaryInputs);
+    const withDeductions = calculateTaxes({
+      ...baseSalaryInputs,
+      lifeInsurance: { generalNew: 100_000, medicalCareNew: 80_000, pensionNew: 100_000 },
+      earthquakeInsurance: { earthquake: 50_000 },
+    });
+    expect(withDeductions.furusatoNozei.limit).toBeLessThan(base.furusatoNozei.limit);
+  });
+
+  it('subtracts deductions before the home loan credit, shifting it toward the residence spillover', () => {
+    // A credit larger than the income tax pins appliedToIncomeTax to the income-tax base. Adding
+    // 物的控除 lowers that base, so appliedToIncomeTax must strictly fall and the residence spillover
+    // must not decrease — which can only happen if the deductions are applied before the credit.
+    const creditOnly = calculateTaxes({
+      ...baseSalaryInputs,
+      homeLoanTaxCredit: { creditAmount: 800_000, moveInYear: 2024 },
+    });
+    const withDeductions = calculateTaxes({
+      ...baseSalaryInputs,
+      homeLoanTaxCredit: { creditAmount: 800_000, moveInYear: 2024 },
+      lifeInsurance: { generalNew: 100_000, medicalCareNew: 80_000, pensionNew: 100_000 },
+      earthquakeInsurance: { earthquake: 50_000 },
+      medicalExpenses: { paid: 600_000, reimbursed: 0 },
+      otherIncomeDeductions: 100_000,
+    });
+
+    expect(creditOnly.homeLoanTaxCredit).toBeDefined();
+    expect(withDeductions.homeLoanTaxCredit!.appliedToIncomeTax).toBeLessThan(
+      creditOnly.homeLoanTaxCredit!.appliedToIncomeTax,
+    );
+    expect(withDeductions.homeLoanTaxCredit!.appliedToResidenceTax).toBeGreaterThanOrEqual(
+      creditOnly.homeLoanTaxCredit!.appliedToResidenceTax,
+    );
+  });
+});
+
 describe('RSU (Restricted Stock Unit) income', () => {
   it('calculates foreign RSU income only correctly', () => {
     // RSU foreign income of 2M should be subject to employment income deduction

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1164,10 +1164,9 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
     });
 
     // life 80k/56k + earthquake 50k/25k = 130k national, 81k residence
-    expect(withDeductions.additionalDeductions).toBeDefined();
-    expect(withDeductions.additionalDeductions!.national).toBe(130_000);
-    expect(withDeductions.additionalDeductions!.residence).toBe(81_000);
-    expect(withDeductions.additionalDeductions!.items.map(i => i.key)).toEqual([
+    expect(withDeductions.additionalDeductions.national).toBe(130_000);
+    expect(withDeductions.additionalDeductions.residence).toBe(81_000);
+    expect(withDeductions.additionalDeductions.items.map(i => i.key)).toEqual([
       'lifeInsurance',
       'earthquakeInsurance',
     ]);
@@ -1199,10 +1198,10 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
     });
 
     // netIncome 6,100,000 → floor min(¥100k, 5% × 6.1M = ¥305k) = ¥100k → 250k − 100k = ¥150k.
-    expect(withMedical.additionalDeductions!.national).toBe(150_000);
-    expect(withMedical.additionalDeductions!.residence).toBe(150_000);
-    expect(withMedical.additionalDeductions!.items).toHaveLength(1);
-    expect(withMedical.additionalDeductions!.items[0]!.key).toBe('medical');
+    expect(withMedical.additionalDeductions.national).toBe(150_000);
+    expect(withMedical.additionalDeductions.residence).toBe(150_000);
+    expect(withMedical.additionalDeductions.items).toHaveLength(1);
+    expect(withMedical.additionalDeductions.items[0]!.key).toBe('medical');
 
     expect(
       base.taxableIncomeForNationalIncomeTax! - withMedical.taxableIncomeForNationalIncomeTax!,
@@ -1263,15 +1262,14 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
       lifeInsurance: { generalNew: 120_000, medicalCareNew: 0, pensionNew: 0 },
     };
     const lifeNational = (inp: typeof withChild) =>
-      calculateTaxes(inp).additionalDeductions!.items.find(i => i.key === 'lifeInsurance')!
-        .national;
+      calculateTaxes(inp).additionalDeductions.items.find(i => i.key === 'lifeInsurance')!.national;
 
     // With a <23 dependent in 2026 the 一般 (new) income-tax cap is ¥60,000; without it, ¥40,000.
     expect(lifeNational(withChild)).toBe(60_000);
     expect(lifeNational({ ...withChild, dependents: [] })).toBe(40_000);
     // Residence tax is never affected by the measure.
     expect(
-      calculateTaxes(withChild).additionalDeductions!.items.find(i => i.key === 'lifeInsurance')!
+      calculateTaxes(withChild).additionalDeductions.items.find(i => i.key === 'lifeInsurance')!
         .residence,
     ).toBe(28_000);
   });

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1224,6 +1224,35 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
       creditOnly.homeLoanTaxCredit!.appliedToResidenceTax,
     );
   });
+
+  it('raises the 一般 life-insurance income-tax cap to ¥60,000 for a 2026 household with a <23 dependent', () => {
+    const withChild = {
+      ...baseSalaryInputs,
+      dependents: [
+        {
+          id: 'c1',
+          relationship: 'child' as const,
+          ageCategory: '19to22' as const,
+          income: { grossEmploymentIncome: 0, otherNetIncome: 0 },
+          disability: 'none' as const,
+          isCohabiting: true,
+        },
+      ],
+      lifeInsurance: { generalNew: 120_000, medicalCareNew: 0, pensionNew: 0 },
+    };
+    const lifeNational = (inp: typeof withChild) =>
+      calculateTaxes(inp).additionalDeductions!.items.find(i => i.key === 'lifeInsurance')!
+        .national;
+
+    // With a <23 dependent in 2026 the 一般 (new) income-tax cap is ¥60,000; without it, ¥40,000.
+    expect(lifeNational(withChild)).toBe(60_000);
+    expect(lifeNational({ ...withChild, dependents: [] })).toBe(40_000);
+    // Residence tax is never affected by the measure.
+    expect(
+      calculateTaxes(withChild).additionalDeductions!.items.find(i => i.key === 'lifeInsurance')!
+        .residence,
+    ).toBe(28_000);
+  });
 });
 
 describe('RSU (Restricted Stock Unit) income', () => {

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -16,6 +16,7 @@ import {
   CUSTOM_PROVIDER_ID,
 } from '../types/healthInsurance';
 import type { Dependent } from '../types/dependents';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../types/tax';
 
 describe('calculateNetEmploymentIncome', () => {
   describe('2026 tiers (R8)', () => {
@@ -146,6 +147,7 @@ describe('calculateTaxes', () => {
   // Test cases for different income brackets
   it('calculates taxes correctly for income below 1,950,000 yen', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 1_500_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -171,6 +173,7 @@ describe('calculateTaxes', () => {
 
   it('calculates taxes correctly for income between 1,950,000 and 3,300,000 yen', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 2_500_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -196,6 +199,7 @@ describe('calculateTaxes', () => {
 
   it('calculates taxes correctly for income between 3,300,000 and 6,950,000 yen', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 5_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -222,6 +226,7 @@ describe('calculateTaxes', () => {
   // Test cases for high income brackets
   it('calculates taxes correctly for income above 40,000,000 yen', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 50_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -248,6 +253,7 @@ describe('calculateTaxes', () => {
   // Test edge cases
   it('handles zero income correctly', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 0, frequency: 'annual' as const, id: 'test' },
       ],
@@ -271,6 +277,7 @@ describe('calculateTaxes', () => {
 
   it('handles negative income correctly', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: -1_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -294,6 +301,7 @@ describe('calculateTaxes', () => {
 
   it('calculates taxes correctly for non-employment income', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [{ type: 'miscellaneous' as const, amount: 5_000_000, id: 'test' }],
       isSubjectToLongTermCarePremium: false,
       healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
@@ -317,6 +325,7 @@ describe('calculateTaxes', () => {
     // Test case for employees who work for small employers or are part-time/low income
     // and are therefore enrolled in National Health Insurance instead of employee insurance
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 5_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -354,6 +363,7 @@ describe('calculateTaxes', () => {
   it('calculates taxes correctly with DC plan contributions', () => {
     // Test without DC plan contributions
     const inputsWithoutDcPlan = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 5_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -400,6 +410,7 @@ describe('calculateTaxes', () => {
 
   it('calculates taxes correctly with Blue-Filer deduction for business income', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         {
           id: '1',
@@ -720,6 +731,7 @@ describe('calculateNationalIncomeTax', () => {
 describe('calculateTaxes with Dependent Coverage', () => {
   it('calculates taxes correctly with dependent coverage below threshold', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 1_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -751,6 +763,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
 
   it('calculates taxes correctly with dependent coverage at threshold', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 1_299_999, frequency: 'annual' as const, id: 'test' },
       ],
@@ -776,6 +789,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
 
   it('calculates taxes correctly with dependent coverage and long-term care premium eligibility', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 1_200_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -797,6 +811,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
 
   it('calculates taxes correctly with Custom Provider', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 5_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -823,6 +838,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
 
   it('uses manual social insurance amount when enabled', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 5_000_000, frequency: 'annual' as const, id: 'test' },
       ],
@@ -850,6 +866,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
 
   it('caps Blue-Filer deduction at the amount of business income', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       isSubjectToLongTermCarePremium: false,
       healthInsuranceProvider: NATIONAL_HEALTH_INSURANCE_ID,
       region: 'Tokyo',
@@ -881,6 +898,7 @@ describe('calculateTaxes with Dependent Coverage', () => {
 
   it('calculates NHI base correctly with Employment AND Miscellaneous income', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { id: '1', type: 'salary' as const, amount: 3_000_000, frequency: 'annual' as const },
         { id: '2', type: 'miscellaneous' as const, amount: 1_000_000 },
@@ -960,6 +978,7 @@ describe('calculateTotalNetIncome', () => {
 describe('Commuting Allowance', () => {
   it('is non-taxable up to 150,000 JPY/month but subject to social insurance', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 300_000, frequency: 'monthly' as const, id: 's1' },
         {
@@ -1027,6 +1046,7 @@ describe('Commuting Allowance', () => {
 
   it('excess over 150,000 JPY/month is taxable', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 300_000, frequency: 'monthly' as const, id: 's1' },
         {
@@ -1089,6 +1109,7 @@ describe('Commuting Allowance', () => {
     // 6-month pass costs 120,000 (20,000/month equivalent).
     // Should be fully non-taxable.
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { type: 'salary' as const, amount: 300_000, frequency: 'monthly' as const, id: 's1' },
         {
@@ -1120,6 +1141,7 @@ describe('Commuting Allowance', () => {
 
 describe('Additional income deductions (life, earthquake, medical, other)', () => {
   const baseSalaryInputs = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     incomeStreams: [
       { type: 'salary' as const, amount: 8_000_000, frequency: 'annual' as const, id: 's1' },
     ],
@@ -1138,7 +1160,7 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
     const withDeductions = calculateTaxes({
       ...baseSalaryInputs,
       lifeInsurance: { generalNew: 100_000, medicalCareNew: 0, pensionNew: 100_000 },
-      earthquakeInsurance: { earthquake: 50_000 },
+      earthquakeInsurance: { earthquake: 50_000, longTermOld: 0 },
     });
 
     // life 80k/56k + earthquake 50k/25k = 130k national, 81k residence
@@ -1195,7 +1217,7 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
     const withDeductions = calculateTaxes({
       ...baseSalaryInputs,
       lifeInsurance: { generalNew: 100_000, medicalCareNew: 80_000, pensionNew: 100_000 },
-      earthquakeInsurance: { earthquake: 50_000 },
+      earthquakeInsurance: { earthquake: 50_000, longTermOld: 0 },
     });
     expect(withDeductions.furusatoNozei.limit).toBeLessThan(base.furusatoNozei.limit);
   });
@@ -1212,7 +1234,7 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
       ...baseSalaryInputs,
       homeLoanTaxCredit: { creditAmount: 800_000, moveInYear: 2024 },
       lifeInsurance: { generalNew: 100_000, medicalCareNew: 80_000, pensionNew: 100_000 },
-      earthquakeInsurance: { earthquake: 50_000 },
+      earthquakeInsurance: { earthquake: 50_000, longTermOld: 0 },
       medicalExpenses: { paid: 600_000, reimbursed: 0 },
     });
 
@@ -1259,6 +1281,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
   it('calculates foreign RSU income only correctly', () => {
     // RSU foreign income of 2M should be subject to employment income deduction
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         {
           id: 'rsu1',
@@ -1305,6 +1328,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
     // Salary 3M + RSU 2M should both go through employment income deduction
     // But RSU should NOT be in social insurance base
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { id: 's1', type: 'salary' as const, amount: 3_000_000, frequency: 'annual' as const },
         {
@@ -1359,6 +1383,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
     // All three should go through employment income deduction
     // But only salary/bonus in social insurance base
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { id: 's1', type: 'salary' as const, amount: 2_000_000, frequency: 'annual' as const },
         { id: 'b1', type: 'bonus' as const, amount: 1_000_000, month: 5 },
@@ -1401,6 +1426,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
   it('RSU foreign income with NHI includes RSU in net income base', () => {
     // With NHI, RSU should be included in the net income that forms the NHI base
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         {
           id: 'rsu1',
@@ -1465,6 +1491,7 @@ describe('RSU (Restricted Stock Unit) income', () => {
 
   it('supports multiple stock compensation streams and sums them in tax calculations', () => {
     const inputs = {
+      ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
       incomeStreams: [
         { id: 's1', type: 'salary' as const, amount: 3_000_000, frequency: 'annual' as const },
         {
@@ -1545,6 +1572,7 @@ describe('所得金額調整控除 (income amount adjustment deduction) integrat
   };
 
   const baseInputs = (dependents: Dependent[]) => ({
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     incomeStreams: [
       { id: 's1', type: 'salary' as const, amount: 22_000_000, frequency: 'annual' as const },
     ],
@@ -1611,6 +1639,7 @@ describe('所得金額調整控除 (income amount adjustment deduction) integrat
 
 describe('grossEmploymentIncome (canonical gross for the Net Employment Income tooltip)', () => {
   const baseInputs = {
+    ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
     isSubjectToLongTermCarePremium: false,
     region: 'Tokyo',
     dependents: [],

--- a/src/__tests__/taxCalculations.test.ts
+++ b/src/__tests__/taxCalculations.test.ts
@@ -1133,31 +1133,29 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
     incomeYear: 2026,
   };
 
-  it('subtracts insurance and other deductions from both taxable incomes without touching 調整控除', () => {
+  it('subtracts insurance deductions from both taxable incomes without touching 調整控除', () => {
     const base = calculateTaxes(baseSalaryInputs);
     const withDeductions = calculateTaxes({
       ...baseSalaryInputs,
       lifeInsurance: { generalNew: 100_000, medicalCareNew: 0, pensionNew: 100_000 },
       earthquakeInsurance: { earthquake: 50_000 },
-      otherIncomeDeductions: 20_000,
     });
 
-    // life 80k/56k + earthquake 50k/25k + other 20k = 150k national, 101k residence
+    // life 80k/56k + earthquake 50k/25k = 130k national, 81k residence
     expect(withDeductions.additionalDeductions).toBeDefined();
-    expect(withDeductions.additionalDeductions!.national).toBe(150_000);
-    expect(withDeductions.additionalDeductions!.residence).toBe(101_000);
+    expect(withDeductions.additionalDeductions!.national).toBe(130_000);
+    expect(withDeductions.additionalDeductions!.residence).toBe(81_000);
     expect(withDeductions.additionalDeductions!.items.map(i => i.key)).toEqual([
       'lifeInsurance',
       'earthquakeInsurance',
-      'other',
     ]);
 
     // Both taxable incomes drop by exactly the per-tax total (the amounts are multiples of 1,000).
     expect(
       base.taxableIncomeForNationalIncomeTax! - withDeductions.taxableIncomeForNationalIncomeTax!,
-    ).toBe(150_000);
+    ).toBe(130_000);
     expect(base.taxableIncomeForResidenceTax! - withDeductions.taxableIncomeForResidenceTax!).toBe(
-      101_000,
+      81_000,
     );
 
     // These are 物的控除, so the residence 調整控除 (personal deduction difference) is unchanged.
@@ -1216,7 +1214,6 @@ describe('Additional income deductions (life, earthquake, medical, other)', () =
       lifeInsurance: { generalNew: 100_000, medicalCareNew: 80_000, pensionNew: 100_000 },
       earthquakeInsurance: { earthquake: 50_000 },
       medicalExpenses: { paid: 600_000, reimbursed: 0 },
-      otherIncomeDeductions: 100_000,
     });
 
     expect(creditOnly.homeLoanTaxCredit).toBeDefined();

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -479,7 +479,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                   <SpinnerNumberField
                     id="earthquakeLongTermOld"
                     name="earthquakeLongTermOld"
-                    value={earthquakeInput.longTermOld ?? 0}
+                    value={earthquakeInput.longTermOld}
                     onInputChange={e =>
                       updateEarthquake({
                         longTermOld: Number((e.target as HTMLInputElement).value) || 0,

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -54,12 +54,12 @@ interface AdditionalDeductionsModalProps {
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
   onHomeLoanTaxCreditChange: (input: HomeLoanTaxCreditInput | undefined) => void;
   homeLoanTaxCreditResult?: HomeLoanTaxCreditResult | undefined;
-  lifeInsurance?: LifeInsuranceInput | undefined;
-  onLifeInsuranceChange: (input: LifeInsuranceInput | undefined) => void;
-  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
-  onEarthquakeInsuranceChange: (input: EarthquakeInsuranceInput | undefined) => void;
-  medicalExpenses?: MedicalExpensesInput | undefined;
-  onMedicalExpensesChange: (input: MedicalExpensesInput | undefined) => void;
+  lifeInsurance: LifeInsuranceInput;
+  onLifeInsuranceChange: (input: LifeInsuranceInput) => void;
+  earthquakeInsurance: EarthquakeInsuranceInput;
+  onEarthquakeInsuranceChange: (input: EarthquakeInsuranceInput) => void;
+  medicalExpenses: MedicalExpensesInput;
+  onMedicalExpensesChange: (input: MedicalExpensesInput) => void;
   /** Computed additional deductions, used for the live per-card readouts. */
   additionalDeductions?: AdditionalDeductionsResult | undefined;
   /** Income year being modeled; upper bound for the home-loan move-in-year dropdown. */
@@ -177,28 +177,24 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
     onHomeLoanTaxCreditChange({ ...effectiveHomeLoan, ...patch });
   };
 
-  const lifeInput: LifeInsuranceInput = lifeInsurance ?? {
-    generalNew: 0,
-    medicalCareNew: 0,
-    pensionNew: 0,
-  };
+  const lifeInput = lifeInsurance;
   const updateLife = (patch: Partial<LifeInsuranceInput>) => {
     onLifeInsuranceChange({ ...lifeInput, ...patch });
   };
   const [showOldLife, setShowOldLife] = React.useState(
-    !!(lifeInsurance?.generalOld || lifeInsurance?.pensionOld),
+    !!(lifeInsurance.generalOld || lifeInsurance.pensionOld),
   );
   const toggleOldLife = (checked: boolean) => {
     setShowOldLife(checked);
     if (!checked) updateLife({ generalOld: 0, pensionOld: 0 });
   };
 
-  const earthquakeInput: EarthquakeInsuranceInput = earthquakeInsurance ?? { earthquake: 0 };
+  const earthquakeInput = earthquakeInsurance;
   const updateEarthquake = (patch: Partial<EarthquakeInsuranceInput>) => {
     onEarthquakeInsuranceChange({ ...earthquakeInput, ...patch });
   };
 
-  const medicalInput: MedicalExpensesInput = medicalExpenses ?? { paid: 0, reimbursed: 0 };
+  const medicalInput = medicalExpenses;
   const updateMedical = (patch: Partial<MedicalExpensesInput>) => {
     onMedicalExpensesChange({ ...medicalInput, ...patch });
   };

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -25,7 +25,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import TuneIcon from '@mui/icons-material/Tune';
 import WarningIcon from '@mui/icons-material/Warning';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { useTheme } from '@mui/material/styles';
+import { useTheme, type SxProps, type Theme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import type {
@@ -65,6 +65,19 @@ interface AdditionalDeductionsModalProps {
   /** Income year being modeled; upper bound for the home-loan move-in-year dropdown. */
   incomeYear: number;
 }
+
+/**
+ * Shared style for the live "Deduction: …" readouts under each card: a muted line whose bold
+ * figures are lifted to the primary colour so they stand out. Keeping the emphasis on the line
+ * (via `& strong`) lets the content stay plain `<strong>` markup, and scopes the recolour here rather than
+ * globally — where it would clobber intentionally-coloured text elsewhere.
+ */
+const readoutSx: SxProps<Theme> = {
+  mt: 1.5,
+  fontSize: '0.85rem',
+  color: 'text.secondary',
+  '& strong': { color: 'text.primary', fontWeight: 600 },
+};
 
 const SectionHeader: React.FC<{ children: React.ReactNode; tooltip?: string }> = ({
   children,
@@ -134,6 +147,20 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
+  // Insurance category fields: on mobile, shorten the label to English (using `shortEn` when the
+  // full English is too wide) and move the Japanese term to helper text so the inputs fit on one
+  // row; on desktop (already one row, with room) keep the full inline "English (日本語)".
+  const catField = (
+    en: string,
+    jp: string,
+    shortEn: string = en,
+  ): { label: string; helperText?: string } =>
+    isMobile ? { label: shortEn, helperText: jp } : { label: `${en} (${jp})` };
+
+  // The three-up life fields are narrow on mobile; trim the input's side padding so a 6-digit ¥
+  // value fits without clipping. (No-op on desktop, where the fields are wide.)
+  const denseValueSx = isMobile ? { '& .MuiInputBase-input': { px: 1 } } : undefined;
+
   const effectiveHomeLoan: HomeLoanTaxCreditInput = homeLoanTaxCredit ?? {
     moveInYear: incomeYear,
     creditAmount: 0,
@@ -169,11 +196,6 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
   const earthquakeInput: EarthquakeInsuranceInput = earthquakeInsurance ?? { earthquake: 0 };
   const updateEarthquake = (patch: Partial<EarthquakeInsuranceInput>) => {
     onEarthquakeInsuranceChange({ ...earthquakeInput, ...patch });
-  };
-  const [showOldQuake, setShowOldQuake] = React.useState(!!earthquakeInsurance?.longTermOld);
-  const toggleOldQuake = (checked: boolean) => {
-    setShowOldQuake(checked);
-    if (!checked) updateEarthquake({ longTermOld: 0 });
   };
 
   const medicalInput: MedicalExpensesInput = medicalExpenses ?? { paid: 0, reimbursed: 0 };
@@ -298,18 +320,18 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 Life Insurance (生命保険料控除)
                 <SimpleTooltip>
                   A deduction for life, medical-care, and pension insurance premiums. Enter the
-                  annual premiums; the calculator works out the income-tax and residence-tax
-                  deductions, which differ.
+                  annual premiums; the calculator works out the deductions for income tax and
+                  residence tax, which differ.
                 </SimpleTooltip>
               </Typography>
               <Typography
                 variant="body2"
                 sx={{ fontSize: '0.8rem', color: 'text.secondary', mb: 1.5 }}
               >
-                New contracts (新契約) — policies from 2012 onward.
+                New contracts (新契約) — policies from 2012.
               </Typography>
               <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-                <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                <FormControl sx={{ flex: '1 1 86px', minWidth: 86 }}>
                   <SpinnerNumberField
                     id="lifeGeneralNew"
                     name="lifeGeneralNew"
@@ -317,13 +339,14 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     onInputChange={e =>
                       updateLife({ generalNew: Number((e.target as HTMLInputElement).value) || 0 })
                     }
-                    label="General (一般)"
+                    {...catField('General', '一般')}
+                    {...(denseValueSx && { sx: denseValueSx })}
                     step={1_000}
                     shiftStep={10_000}
                     min={0}
                   />
                 </FormControl>
-                <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                <FormControl sx={{ flex: '1 1 86px', minWidth: 86 }}>
                   <SpinnerNumberField
                     id="lifeMedicalCareNew"
                     name="lifeMedicalCareNew"
@@ -333,13 +356,14 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                         medicalCareNew: Number((e.target as HTMLInputElement).value) || 0,
                       })
                     }
-                    label="Medical care (介護医療)"
+                    {...catField('Medical care', '介護医療', 'Medical')}
+                    {...(denseValueSx && { sx: denseValueSx })}
                     step={1_000}
                     shiftStep={10_000}
                     min={0}
                   />
                 </FormControl>
-                <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                <FormControl sx={{ flex: '1 1 86px', minWidth: 86 }}>
                   <SpinnerNumberField
                     id="lifePensionNew"
                     name="lifePensionNew"
@@ -347,7 +371,8 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     onInputChange={e =>
                       updateLife({ pensionNew: Number((e.target as HTMLInputElement).value) || 0 })
                     }
-                    label="Pension (個人年金)"
+                    {...catField('Pension', '個人年金')}
+                    {...(denseValueSx && { sx: denseValueSx })}
                     step={1_000}
                     shiftStep={10_000}
                     min={0}
@@ -373,7 +398,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
               />
               {showOldLife && (
                 <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 1 }}>
-                  <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                  <FormControl sx={{ flex: '1 1 130px', minWidth: 120 }}>
                     <SpinnerNumberField
                       id="lifeGeneralOld"
                       name="lifeGeneralOld"
@@ -383,13 +408,13 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                           generalOld: Number((e.target as HTMLInputElement).value) || 0,
                         })
                       }
-                      label="General, old (旧一般)"
+                      {...catField('General, old', '旧一般')}
                       step={1_000}
                       shiftStep={10_000}
                       min={0}
                     />
                   </FormControl>
-                  <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                  <FormControl sx={{ flex: '1 1 130px', minWidth: 120 }}>
                     <SpinnerNumberField
                       id="lifePensionOld"
                       name="lifePensionOld"
@@ -399,7 +424,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                           pensionOld: Number((e.target as HTMLInputElement).value) || 0,
                         })
                       }
-                      label="Pension, old (旧個人年金)"
+                      {...catField('Pension, old', '旧個人年金')}
                       step={1_000}
                       shiftStep={10_000}
                       min={0}
@@ -409,19 +434,9 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
               )}
 
               {lifeItem && (
-                <Typography
-                  variant="body2"
-                  sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
-                >
-                  Deduction:{' '}
-                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
-                    {formatJPY(lifeItem.national)}
-                  </Box>{' '}
-                  income tax,{' '}
-                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
-                    {formatJPY(lifeItem.residence)}
-                  </Box>{' '}
-                  residence tax
+                <Typography variant="body2" sx={readoutSx}>
+                  Deduction: <strong>{formatJPY(lifeItem.national)}</strong> income tax,{' '}
+                  <strong>{formatJPY(lifeItem.residence)}</strong> residence tax
                   <DeductionCalcTooltip infoKey="lifeInsurance" />
                 </Typography>
               )}
@@ -444,11 +459,11 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 Earthquake Insurance (地震保険料控除)
                 <SimpleTooltip>
                   A deduction for earthquake insurance premiums (and qualifying pre-2007 long-term
-                  casualty premiums). The income-tax and residence-tax amounts differ.
+                  casualty premiums). The deduction differs for income tax and residence tax.
                 </SimpleTooltip>
               </Typography>
               <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-                <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
+                <FormControl sx={{ flex: '1 1 130px', minWidth: 120 }}>
                   <SpinnerNumberField
                     id="earthquakePremium"
                     name="earthquakePremium"
@@ -458,7 +473,23 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                         earthquake: Number((e.target as HTMLInputElement).value) || 0,
                       })
                     }
-                    label="Earthquake premium (地震保険料)"
+                    {...catField('Earthquake premium', '地震保険料', 'Earthquake')}
+                    step={1_000}
+                    shiftStep={10_000}
+                    min={0}
+                  />
+                </FormControl>
+                <FormControl sx={{ flex: '1 1 130px', minWidth: 120 }}>
+                  <SpinnerNumberField
+                    id="earthquakeLongTermOld"
+                    name="earthquakeLongTermOld"
+                    value={earthquakeInput.longTermOld ?? 0}
+                    onInputChange={e =>
+                      updateEarthquake({
+                        longTermOld: Number((e.target as HTMLInputElement).value) || 0,
+                      })
+                    }
+                    {...catField('Long-term, old', '旧長期損害保険料', 'Long-term')}
                     step={1_000}
                     shiftStep={10_000}
                     min={0}
@@ -466,57 +497,10 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 </FormControl>
               </Box>
 
-              <FormControlLabel
-                sx={{ mt: 1, ml: 0 }}
-                control={
-                  <Checkbox
-                    size="small"
-                    checked={showOldQuake}
-                    onChange={e => toggleOldQuake(e.target.checked)}
-                    sx={{ py: 0, mr: 0.5 }}
-                  />
-                }
-                label={
-                  <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
-                    I have 旧長期損害保険 (pre-2007 long-term)
-                  </Typography>
-                }
-              />
-              {showOldQuake && (
-                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 1 }}>
-                  <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
-                    <SpinnerNumberField
-                      id="earthquakeLongTermOld"
-                      name="earthquakeLongTermOld"
-                      value={earthquakeInput.longTermOld ?? 0}
-                      onInputChange={e =>
-                        updateEarthquake({
-                          longTermOld: Number((e.target as HTMLInputElement).value) || 0,
-                        })
-                      }
-                      label="旧長期損害保険料"
-                      step={1_000}
-                      shiftStep={10_000}
-                      min={0}
-                    />
-                  </FormControl>
-                </Box>
-              )}
-
               {earthquakeItem && (
-                <Typography
-                  variant="body2"
-                  sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
-                >
-                  Deduction:{' '}
-                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
-                    {formatJPY(earthquakeItem.national)}
-                  </Box>{' '}
-                  income tax,{' '}
-                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
-                    {formatJPY(earthquakeItem.residence)}
-                  </Box>{' '}
-                  residence tax
+                <Typography variant="body2" sx={readoutSx}>
+                  Deduction: <strong>{formatJPY(earthquakeItem.national)}</strong> income tax,{' '}
+                  <strong>{formatJPY(earthquakeItem.residence)}</strong> residence tax
                   <DeductionCalcTooltip infoKey="earthquakeInsurance" />
                 </Typography>
               )}
@@ -579,25 +563,15 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
               </Box>
 
               {medicalItem ? (
-                <Typography
-                  variant="body2"
-                  sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
-                >
-                  Deduction:{' '}
-                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
-                    {formatJPY(medicalItem.national)}
-                  </Box>{' '}
-                  (same for income tax and residence tax)
+                <Typography variant="body2" sx={readoutSx}>
+                  Deduction: <strong>{formatJPY(medicalItem.national)}</strong>
                   <DeductionCalcTooltip infoKey="medical" />
                 </Typography>
               ) : (
                 medicalInput.paid > 0 && (
-                  <Typography
-                    variant="body2"
-                    sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
-                  >
-                    Below the deduction floor (the lower of ¥100,000 and 5% of income), so no
-                    deduction this year.
+                  <Typography variant="body2" sx={readoutSx}>
+                    The calculated amount is less than the deduction floor (the lower of ¥100,000
+                    and 5% of income).
                   </Typography>
                 )
               )}
@@ -690,7 +664,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                             build, or a pre-owned home bought from a consumption tax-collecting
                             business. Uncheck it if no consumption tax was charged, such as a
                             pre-owned home bought from a private individual. For 2014–2021 move-ins
-                            this changes the residence-tax spillover cap (特定取得 → 7% / ¥136,500;
+                            this changes the residence tax spillover cap (特定取得 → 7% / ¥136,500;
                             non-特定取得 → 5% / ¥97,500).
                           </Typography>
                           <Box sx={{ mt: 1 }}>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -44,6 +44,7 @@ import {
   homeLoanCreditDistinguishesTokuteiShutoku,
 } from '../../utils/homeLoanTaxCredit';
 import { formatJPY } from '../../utils/formatters';
+import { ADDITIONAL_DEDUCTION_INFO } from './additionalDeductionInfo';
 
 interface AdditionalDeductionsModalProps {
   open: boolean;
@@ -83,6 +84,35 @@ const SectionHeader: React.FC<{ children: React.ReactNode; tooltip?: string }> =
     {tooltip && <SimpleTooltip>{tooltip}</SimpleTooltip>}
   </Typography>
 );
+
+/**
+ * Info icon + popover shown next to a computed deduction readout, explaining how the amount was
+ * derived and linking the official source. These deductions are computed for the user, so the
+ * explanation lives next to the result (not in a "how to calculate" accordion like the home loan
+ * credit, whose accordion explains how to derive the figure the user must enter).
+ */
+const DeductionCalcTooltip: React.FC<{ infoKey: keyof typeof ADDITIONAL_DEDUCTION_INFO }> = ({
+  infoKey,
+}) => {
+  const info = ADDITIONAL_DEDUCTION_INFO[infoKey];
+  return (
+    <DetailedTooltip title={info.label} icon={SIMPLE_TOOLTIP_ICON}>
+      <Box>
+        <Typography variant="body2">{info.explanation}</Typography>
+        <Box sx={{ mt: 1 }}>
+          <a
+            href={info.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
+          >
+            {info.sourceLabel}
+          </a>
+        </Box>
+      </Box>
+    </DetailedTooltip>
+  );
+};
 
 export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps> = ({
   open,
@@ -392,41 +422,9 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     {formatJPY(lifeItem.residence)}
                   </Box>{' '}
                   residence tax
+                  <DeductionCalcTooltip infoKey="lifeInsurance" />
                 </Typography>
               )}
-
-              <Accordion
-                disableGutters
-                elevation={0}
-                sx={{ mt: 2, border: '1px solid', borderColor: 'divider' }}
-              >
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    How is this calculated?
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Typography
-                    variant="body2"
-                    sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}
-                  >
-                    Each category's deduction comes from its premium on a sliding scale, capped per
-                    category (new: ¥40,000 income tax / ¥28,000 residence; old: ¥50,000 / ¥35,000)
-                    and overall at ¥120,000 income tax / ¥70,000 residence. When a category has both
-                    new and old policies, the most favourable method is used.
-                  </Typography>
-                  <Box>
-                    <a
-                      href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
-                    >
-                      NTA: 生命保険料控除
-                    </a>
-                  </Box>
-                </AccordionDetails>
-              </Accordion>
             </CardContent>
           </Card>
 
@@ -519,40 +517,9 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     {formatJPY(earthquakeItem.residence)}
                   </Box>{' '}
                   residence tax
+                  <DeductionCalcTooltip infoKey="earthquakeInsurance" />
                 </Typography>
               )}
-
-              <Accordion
-                disableGutters
-                elevation={0}
-                sx={{ mt: 2, border: '1px solid', borderColor: 'divider' }}
-              >
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    How is this calculated?
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Typography
-                    variant="body2"
-                    sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}
-                  >
-                    The earthquake premium is deductible in full up to ¥50,000 for income tax, and
-                    at half up to ¥25,000 for residence tax. A 旧長期損害保険料 portion can be
-                    added, with the combined deduction capped at ¥50,000 / ¥25,000.
-                  </Typography>
-                  <Box>
-                    <a
-                      href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
-                    >
-                      NTA: 地震保険料控除
-                    </a>
-                  </Box>
-                </AccordionDetails>
-              </Accordion>
             </CardContent>
           </Card>
 
@@ -571,13 +538,13 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
               >
                 Medical Expenses (医療費控除)
                 <SimpleTooltip>
-                  Enter what you paid in medical expenses and any reimbursements. The calculator
-                  subtracts the income-based floor for you, so enter the raw amounts — not a
-                  deduction figure.
+                  Enter what you paid in medical expenses and any reimbursements (insurance payouts,
+                  高額療養費, government subsidies, etc.). The calculator subtracts the income-based
+                  floor for you, so enter the raw amounts — not a deduction figure.
                 </SimpleTooltip>
               </Typography>
               <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-                <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
+                <FormControl sx={{ flex: '1 1 130px', minWidth: 120 }}>
                   <SpinnerNumberField
                     id="medicalPaid"
                     name="medicalPaid"
@@ -591,7 +558,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     min={0}
                   />
                 </FormControl>
-                <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
+                <FormControl sx={{ flex: '1 1 130px', minWidth: 120 }}>
                   <SpinnerNumberField
                     id="medicalReimbursed"
                     name="medicalReimbursed"
@@ -601,7 +568,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                         reimbursed: Number((e.target as HTMLInputElement).value) || 0,
                       })
                     }
-                    label="Insurance reimbursements"
+                    label="Reimbursements"
                     step={1_000}
                     shiftStep={10_000}
                     min={0}
@@ -619,6 +586,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                     {formatJPY(medicalItem.national)}
                   </Box>{' '}
                   (same for income tax and residence tax)
+                  <DeductionCalcTooltip infoKey="medical" />
                 </Typography>
               ) : (
                 medicalInput.paid > 0 && (
@@ -631,37 +599,6 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                   </Typography>
                 )
               )}
-
-              <Accordion
-                disableGutters
-                elevation={0}
-                sx={{ mt: 2, border: '1px solid', borderColor: 'divider' }}
-              >
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    How is this calculated?
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Typography
-                    variant="body2"
-                    sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}
-                  >
-                    The deduction is your medical expenses minus any reimbursements, minus the lower
-                    of ¥100,000 and 5% of your total income, capped at ¥2,000,000.
-                  </Typography>
-                  <Box>
-                    <a
-                      href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
-                    >
-                      NTA: 医療費控除
-                    </a>
-                  </Box>
-                </AccordionDetails>
-              </Accordion>
             </CardContent>
           </Card>
         </Box>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -540,7 +540,9 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 <SimpleTooltip>
                   Enter what you paid in medical expenses and any reimbursements (insurance payouts,
                   高額療養費, government subsidies, etc.). The calculator subtracts the income-based
-                  floor for you, so enter the raw amounts — not a deduction figure.
+                  floor for you, so enter the raw amounts — not a deduction figure. This is the
+                  standard 医療費控除 only; the セルフメディケーション税制 (医療費控除の特例)
+                  alternative isn&apos;t supported yet.
                 </SimpleTooltip>
               </Typography>
               <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -109,7 +109,7 @@ const DeductionCalcTooltip: React.FC<{ infoKey: keyof typeof ADDITIONAL_DEDUCTIO
 }) => {
   const info = ADDITIONAL_DEDUCTION_INFO[infoKey];
   return (
-    <DetailedTooltip title={info.label} icon={SIMPLE_TOOLTIP_ICON}>
+    <DetailedTooltip title={info.name} icon={SIMPLE_TOOLTIP_ICON}>
       <Box>
         <Typography variant="body2">{info.explanation}</Typography>
         <Box sx={{ mt: 1 }}>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -321,7 +321,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 <SimpleTooltip>
                   A deduction for life, medical-care, and pension insurance premiums. Enter the
                   annual premiums; the calculator works out the deductions for income tax and
-                  residence tax, which differ.
+                  residence tax, which may differ.
                 </SimpleTooltip>
               </Typography>
               <Typography

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -28,7 +28,14 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-import type { HomeLoanTaxCreditInput, HomeLoanTaxCreditResult } from '../../types/tax';
+import type {
+  HomeLoanTaxCreditInput,
+  HomeLoanTaxCreditResult,
+  LifeInsuranceInput,
+  EarthquakeInsuranceInput,
+  MedicalExpensesInput,
+  AdditionalDeductionsResult,
+} from '../../types/tax';
 import { SpinnerNumberField } from '../ui/SpinnerNumberField';
 import { SimpleTooltip, DetailedTooltip } from '../ui/Tooltips';
 import { SIMPLE_TOOLTIP_ICON } from '../ui/constants';
@@ -36,6 +43,7 @@ import {
   earliestEligibleMoveInYear,
   homeLoanCreditDistinguishesTokuteiShutoku,
 } from '../../utils/homeLoanTaxCredit';
+import { formatJPY } from '../../utils/formatters';
 
 interface AdditionalDeductionsModalProps {
   open: boolean;
@@ -45,6 +53,16 @@ interface AdditionalDeductionsModalProps {
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
   onHomeLoanTaxCreditChange: (input: HomeLoanTaxCreditInput | undefined) => void;
   homeLoanTaxCreditResult?: HomeLoanTaxCreditResult | undefined;
+  lifeInsurance?: LifeInsuranceInput | undefined;
+  onLifeInsuranceChange: (input: LifeInsuranceInput | undefined) => void;
+  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
+  onEarthquakeInsuranceChange: (input: EarthquakeInsuranceInput | undefined) => void;
+  medicalExpenses?: MedicalExpensesInput | undefined;
+  onMedicalExpensesChange: (input: MedicalExpensesInput | undefined) => void;
+  otherIncomeDeductions?: number | undefined;
+  onOtherIncomeDeductionsChange: (value: number) => void;
+  /** Computed additional deductions, used for the live per-card readouts. */
+  additionalDeductions?: AdditionalDeductionsResult | undefined;
   /** Income year being modeled; upper bound for the home-loan move-in-year dropdown. */
   incomeYear: number;
 }
@@ -76,6 +94,15 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
   homeLoanTaxCredit,
   onHomeLoanTaxCreditChange,
   homeLoanTaxCreditResult,
+  lifeInsurance,
+  onLifeInsuranceChange,
+  earthquakeInsurance,
+  onEarthquakeInsuranceChange,
+  medicalExpenses,
+  onMedicalExpensesChange,
+  otherIncomeDeductions,
+  onOtherIncomeDeductionsChange,
+  additionalDeductions,
   incomeYear,
 }) => {
   const theme = useTheme();
@@ -96,6 +123,41 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
   const updateHomeLoan = (patch: Partial<HomeLoanTaxCreditInput>) => {
     onHomeLoanTaxCreditChange({ ...effectiveHomeLoan, ...patch });
   };
+
+  const lifeInput: LifeInsuranceInput = lifeInsurance ?? {
+    generalNew: 0,
+    medicalCareNew: 0,
+    pensionNew: 0,
+  };
+  const updateLife = (patch: Partial<LifeInsuranceInput>) => {
+    onLifeInsuranceChange({ ...lifeInput, ...patch });
+  };
+  const [showOldLife, setShowOldLife] = React.useState(
+    !!(lifeInsurance?.generalOld || lifeInsurance?.pensionOld),
+  );
+  const toggleOldLife = (checked: boolean) => {
+    setShowOldLife(checked);
+    if (!checked) updateLife({ generalOld: 0, pensionOld: 0 });
+  };
+
+  const earthquakeInput: EarthquakeInsuranceInput = earthquakeInsurance ?? { earthquake: 0 };
+  const updateEarthquake = (patch: Partial<EarthquakeInsuranceInput>) => {
+    onEarthquakeInsuranceChange({ ...earthquakeInput, ...patch });
+  };
+  const [showOldQuake, setShowOldQuake] = React.useState(!!earthquakeInsurance?.longTermOld);
+  const toggleOldQuake = (checked: boolean) => {
+    setShowOldQuake(checked);
+    if (!checked) updateEarthquake({ longTermOld: 0 });
+  };
+
+  const medicalInput: MedicalExpensesInput = medicalExpenses ?? { paid: 0, reimbursed: 0 };
+  const updateMedical = (patch: Partial<MedicalExpensesInput>) => {
+    onMedicalExpensesChange({ ...medicalInput, ...patch });
+  };
+
+  const lifeItem = additionalDeductions?.items.find(i => i.key === 'lifeInsurance');
+  const earthquakeItem = additionalDeductions?.items.find(i => i.key === 'earthquakeInsurance');
+  const medicalItem = additionalDeductions?.items.find(i => i.key === 'medical');
 
   return (
     <Dialog
@@ -189,6 +251,457 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                   step={1_000}
                   shiftStep={10_000}
                   helperText="Not including employer contributions."
+                />
+              </FormControl>
+            </CardContent>
+          </Card>
+
+          {/* Life Insurance (生命保険料控除) */}
+          <Card variant="outlined" sx={{ mt: 2 }}>
+            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+              <Typography
+                sx={{
+                  fontSize: '0.95rem',
+                  fontWeight: 600,
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: 'text.primary',
+                }}
+              >
+                Life Insurance (生命保険料控除)
+                <SimpleTooltip>
+                  A deduction for life, medical-care, and pension insurance premiums. Enter the
+                  annual premiums; the calculator works out the income-tax and residence-tax
+                  deductions, which differ.
+                </SimpleTooltip>
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{ fontSize: '0.8rem', color: 'text.secondary', mb: 1.5 }}
+              >
+                New contracts (新契約) — policies from 2012 onward.
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                  <SpinnerNumberField
+                    id="lifeGeneralNew"
+                    name="lifeGeneralNew"
+                    value={lifeInput.generalNew}
+                    onInputChange={e =>
+                      updateLife({ generalNew: Number((e.target as HTMLInputElement).value) || 0 })
+                    }
+                    label="General (一般)"
+                    step={1_000}
+                    shiftStep={10_000}
+                    min={0}
+                  />
+                </FormControl>
+                <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                  <SpinnerNumberField
+                    id="lifeMedicalCareNew"
+                    name="lifeMedicalCareNew"
+                    value={lifeInput.medicalCareNew}
+                    onInputChange={e =>
+                      updateLife({
+                        medicalCareNew: Number((e.target as HTMLInputElement).value) || 0,
+                      })
+                    }
+                    label="Medical care (介護医療)"
+                    step={1_000}
+                    shiftStep={10_000}
+                    min={0}
+                  />
+                </FormControl>
+                <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                  <SpinnerNumberField
+                    id="lifePensionNew"
+                    name="lifePensionNew"
+                    value={lifeInput.pensionNew}
+                    onInputChange={e =>
+                      updateLife({ pensionNew: Number((e.target as HTMLInputElement).value) || 0 })
+                    }
+                    label="Pension (個人年金)"
+                    step={1_000}
+                    shiftStep={10_000}
+                    min={0}
+                  />
+                </FormControl>
+              </Box>
+
+              <FormControlLabel
+                sx={{ mt: 1, ml: 0 }}
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={showOldLife}
+                    onChange={e => toggleOldLife(e.target.checked)}
+                    sx={{ py: 0, mr: 0.5 }}
+                  />
+                }
+                label={
+                  <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
+                    I also have pre-2012 policies (旧契約)
+                  </Typography>
+                }
+              />
+              {showOldLife && (
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 1 }}>
+                  <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                    <SpinnerNumberField
+                      id="lifeGeneralOld"
+                      name="lifeGeneralOld"
+                      value={lifeInput.generalOld ?? 0}
+                      onInputChange={e =>
+                        updateLife({
+                          generalOld: Number((e.target as HTMLInputElement).value) || 0,
+                        })
+                      }
+                      label="General, old (旧一般)"
+                      step={1_000}
+                      shiftStep={10_000}
+                      min={0}
+                    />
+                  </FormControl>
+                  <FormControl sx={{ flex: '1 1 150px', minWidth: 130 }}>
+                    <SpinnerNumberField
+                      id="lifePensionOld"
+                      name="lifePensionOld"
+                      value={lifeInput.pensionOld ?? 0}
+                      onInputChange={e =>
+                        updateLife({
+                          pensionOld: Number((e.target as HTMLInputElement).value) || 0,
+                        })
+                      }
+                      label="Pension, old (旧個人年金)"
+                      step={1_000}
+                      shiftStep={10_000}
+                      min={0}
+                    />
+                  </FormControl>
+                </Box>
+              )}
+
+              {lifeItem && (
+                <Typography
+                  variant="body2"
+                  sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
+                >
+                  Deduction:{' '}
+                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                    {formatJPY(lifeItem.national)}
+                  </Box>{' '}
+                  income tax,{' '}
+                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                    {formatJPY(lifeItem.residence)}
+                  </Box>{' '}
+                  residence tax
+                </Typography>
+              )}
+
+              <Accordion
+                disableGutters
+                elevation={0}
+                sx={{ mt: 2, border: '1px solid', borderColor: 'divider' }}
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    How is this calculated?
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Typography
+                    variant="body2"
+                    sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}
+                  >
+                    Each category's deduction comes from its premium on a sliding scale, capped per
+                    category (new: ¥40,000 income tax / ¥28,000 residence; old: ¥50,000 / ¥35,000)
+                    and overall at ¥120,000 income tax / ¥70,000 residence. When a category has both
+                    new and old policies, the most favourable method is used.
+                  </Typography>
+                  <Box>
+                    <a
+                      href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
+                    >
+                      NTA: 生命保険料控除
+                    </a>
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+            </CardContent>
+          </Card>
+
+          {/* Earthquake Insurance (地震保険料控除) */}
+          <Card variant="outlined" sx={{ mt: 2 }}>
+            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+              <Typography
+                sx={{
+                  fontSize: '0.95rem',
+                  fontWeight: 600,
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: 'text.primary',
+                }}
+              >
+                Earthquake Insurance (地震保険料控除)
+                <SimpleTooltip>
+                  A deduction for earthquake insurance premiums (and qualifying pre-2007 long-term
+                  casualty premiums). The income-tax and residence-tax amounts differ.
+                </SimpleTooltip>
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+                <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
+                  <SpinnerNumberField
+                    id="earthquakePremium"
+                    name="earthquakePremium"
+                    value={earthquakeInput.earthquake}
+                    onInputChange={e =>
+                      updateEarthquake({
+                        earthquake: Number((e.target as HTMLInputElement).value) || 0,
+                      })
+                    }
+                    label="Earthquake premium (地震保険料)"
+                    step={1_000}
+                    shiftStep={10_000}
+                    min={0}
+                  />
+                </FormControl>
+              </Box>
+
+              <FormControlLabel
+                sx={{ mt: 1, ml: 0 }}
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={showOldQuake}
+                    onChange={e => toggleOldQuake(e.target.checked)}
+                    sx={{ py: 0, mr: 0.5 }}
+                  />
+                }
+                label={
+                  <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
+                    I have 旧長期損害保険 (pre-2007 long-term)
+                  </Typography>
+                }
+              />
+              {showOldQuake && (
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 1 }}>
+                  <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
+                    <SpinnerNumberField
+                      id="earthquakeLongTermOld"
+                      name="earthquakeLongTermOld"
+                      value={earthquakeInput.longTermOld ?? 0}
+                      onInputChange={e =>
+                        updateEarthquake({
+                          longTermOld: Number((e.target as HTMLInputElement).value) || 0,
+                        })
+                      }
+                      label="旧長期損害保険料"
+                      step={1_000}
+                      shiftStep={10_000}
+                      min={0}
+                    />
+                  </FormControl>
+                </Box>
+              )}
+
+              {earthquakeItem && (
+                <Typography
+                  variant="body2"
+                  sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
+                >
+                  Deduction:{' '}
+                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                    {formatJPY(earthquakeItem.national)}
+                  </Box>{' '}
+                  income tax,{' '}
+                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                    {formatJPY(earthquakeItem.residence)}
+                  </Box>{' '}
+                  residence tax
+                </Typography>
+              )}
+
+              <Accordion
+                disableGutters
+                elevation={0}
+                sx={{ mt: 2, border: '1px solid', borderColor: 'divider' }}
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    How is this calculated?
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Typography
+                    variant="body2"
+                    sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}
+                  >
+                    The earthquake premium is deductible in full up to ¥50,000 for income tax, and
+                    at half up to ¥25,000 for residence tax. A 旧長期損害保険料 portion can be
+                    added, with the combined deduction capped at ¥50,000 / ¥25,000.
+                  </Typography>
+                  <Box>
+                    <a
+                      href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
+                    >
+                      NTA: 地震保険料控除
+                    </a>
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+            </CardContent>
+          </Card>
+
+          {/* Medical Expenses (医療費控除) */}
+          <Card variant="outlined" sx={{ mt: 2 }}>
+            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+              <Typography
+                sx={{
+                  fontSize: '0.95rem',
+                  fontWeight: 600,
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: 'text.primary',
+                }}
+              >
+                Medical Expenses (医療費控除)
+                <SimpleTooltip>
+                  Enter what you paid in medical expenses and any reimbursements. The calculator
+                  subtracts the income-based floor for you, so enter the raw amounts — not a
+                  deduction figure.
+                </SimpleTooltip>
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
+                  <SpinnerNumberField
+                    id="medicalPaid"
+                    name="medicalPaid"
+                    value={medicalInput.paid}
+                    onInputChange={e =>
+                      updateMedical({ paid: Number((e.target as HTMLInputElement).value) || 0 })
+                    }
+                    label="Total paid"
+                    step={1_000}
+                    shiftStep={10_000}
+                    min={0}
+                  />
+                </FormControl>
+                <FormControl sx={{ flex: '1 1 160px', minWidth: 140 }}>
+                  <SpinnerNumberField
+                    id="medicalReimbursed"
+                    name="medicalReimbursed"
+                    value={medicalInput.reimbursed}
+                    onInputChange={e =>
+                      updateMedical({
+                        reimbursed: Number((e.target as HTMLInputElement).value) || 0,
+                      })
+                    }
+                    label="Insurance reimbursements"
+                    step={1_000}
+                    shiftStep={10_000}
+                    min={0}
+                  />
+                </FormControl>
+              </Box>
+
+              {medicalItem ? (
+                <Typography
+                  variant="body2"
+                  sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
+                >
+                  Deduction:{' '}
+                  <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                    {formatJPY(medicalItem.national)}
+                  </Box>{' '}
+                  (same for income tax and residence tax)
+                </Typography>
+              ) : (
+                medicalInput.paid > 0 && (
+                  <Typography
+                    variant="body2"
+                    sx={{ mt: 1.5, fontSize: '0.85rem', color: 'text.secondary' }}
+                  >
+                    Below the deduction floor (the lower of ¥100,000 and 5% of income), so no
+                    deduction this year.
+                  </Typography>
+                )
+              )}
+
+              <Accordion
+                disableGutters
+                elevation={0}
+                sx={{ mt: 2, border: '1px solid', borderColor: 'divider' }}
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    How is this calculated?
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Typography
+                    variant="body2"
+                    sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 1 }}
+                  >
+                    The deduction is your medical expenses minus any reimbursements, minus the lower
+                    of ¥100,000 and 5% of your total income, capped at ¥2,000,000.
+                  </Typography>
+                  <Box>
+                    <a
+                      href="https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
+                    >
+                      NTA: 医療費控除
+                    </a>
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+            </CardContent>
+          </Card>
+
+          {/* Other Income Deductions (その他の所得控除) */}
+          <Card variant="outlined" sx={{ mt: 2 }}>
+            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+              <Typography
+                sx={{
+                  fontSize: '0.95rem',
+                  fontWeight: 600,
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: 'text.primary',
+                }}
+              >
+                Other Income Deductions (その他の所得控除)
+                <SimpleTooltip>
+                  For income deductions not listed above that reduce income tax and residence tax by
+                  the same amount, such as 雑損控除. Enter the deduction amount, not the amount you
+                  paid.
+                </SimpleTooltip>
+              </Typography>
+              <FormControl fullWidth>
+                <SpinnerNumberField
+                  id="otherIncomeDeductions"
+                  name="otherIncomeDeductions"
+                  value={otherIncomeDeductions ?? 0}
+                  onInputChange={e =>
+                    onOtherIncomeDeductionsChange(Number((e.target as HTMLInputElement).value) || 0)
+                  }
+                  label="Deduction amount"
+                  step={1_000}
+                  shiftStep={10_000}
+                  min={0}
+                  helperText="Don't include anything already entered above or under Dependents. Personal deductions (障害者・寡婦・ひとり親・勤労学生) aren't supported yet."
                 />
               </FormControl>
             </CardContent>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -59,8 +59,6 @@ interface AdditionalDeductionsModalProps {
   onEarthquakeInsuranceChange: (input: EarthquakeInsuranceInput | undefined) => void;
   medicalExpenses?: MedicalExpensesInput | undefined;
   onMedicalExpensesChange: (input: MedicalExpensesInput | undefined) => void;
-  otherIncomeDeductions?: number | undefined;
-  onOtherIncomeDeductionsChange: (value: number) => void;
   /** Computed additional deductions, used for the live per-card readouts. */
   additionalDeductions?: AdditionalDeductionsResult | undefined;
   /** Income year being modeled; upper bound for the home-loan move-in-year dropdown. */
@@ -100,8 +98,6 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
   onEarthquakeInsuranceChange,
   medicalExpenses,
   onMedicalExpensesChange,
-  otherIncomeDeductions,
-  onOtherIncomeDeductionsChange,
   additionalDeductions,
   incomeYear,
 }) => {
@@ -666,44 +662,6 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                   </Box>
                 </AccordionDetails>
               </Accordion>
-            </CardContent>
-          </Card>
-
-          {/* Other Income Deductions (その他の所得控除) */}
-          <Card variant="outlined" sx={{ mt: 2 }}>
-            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-              <Typography
-                sx={{
-                  fontSize: '0.95rem',
-                  fontWeight: 600,
-                  mb: 1,
-                  display: 'flex',
-                  alignItems: 'center',
-                  color: 'text.primary',
-                }}
-              >
-                Other Income Deductions (その他の所得控除)
-                <SimpleTooltip>
-                  For income deductions not listed above that reduce income tax and residence tax by
-                  the same amount, such as 雑損控除. Enter the deduction amount, not the amount you
-                  paid.
-                </SimpleTooltip>
-              </Typography>
-              <FormControl fullWidth>
-                <SpinnerNumberField
-                  id="otherIncomeDeductions"
-                  name="otherIncomeDeductions"
-                  value={otherIncomeDeductions ?? 0}
-                  onInputChange={e =>
-                    onOtherIncomeDeductionsChange(Number((e.target as HTMLInputElement).value) || 0)
-                  }
-                  label="Deduction amount"
-                  step={1_000}
-                  shiftStep={10_000}
-                  min={0}
-                  helperText="Don't include anything already entered above or under Dependents. Personal deductions (障害者・寡婦・ひとり親・勤労学生) aren't supported yet."
-                />
-              </FormControl>
             </CardContent>
           </Card>
         </Box>

--- a/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
+++ b/src/components/TakeHomeCalculator/AdditionalDeductionsModal.tsx
@@ -388,7 +388,7 @@ export const AdditionalDeductionsModal: React.FC<AdditionalDeductionsModalProps>
                 }
                 label={
                   <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
-                    I also have pre-2012 policies (旧契約)
+                    Input pre-2012 policies (旧契約)
                   </Typography>
                 }
               />

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -140,19 +140,19 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
     } as unknown as React.ChangeEvent<HTMLInputElement>);
   };
 
-  const handleLifeInsuranceChange = (newInput: LifeInsuranceInput | undefined) => {
+  const handleLifeInsuranceChange = (newInput: LifeInsuranceInput) => {
     onInputChange({
       target: { name: 'lifeInsurance', value: newInput },
     } as unknown as React.ChangeEvent<HTMLInputElement>);
   };
 
-  const handleEarthquakeInsuranceChange = (newInput: EarthquakeInsuranceInput | undefined) => {
+  const handleEarthquakeInsuranceChange = (newInput: EarthquakeInsuranceInput) => {
     onInputChange({
       target: { name: 'earthquakeInsurance', value: newInput },
     } as unknown as React.ChangeEvent<HTMLInputElement>);
   };
 
-  const handleMedicalExpensesChange = (newInput: MedicalExpensesInput | undefined) => {
+  const handleMedicalExpensesChange = (newInput: MedicalExpensesInput) => {
     onInputChange({
       target: { name: 'medicalExpenses', value: newInput },
     } as unknown as React.ChangeEvent<HTMLInputElement>);

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -31,6 +31,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { DependentsModal } from './Dependents/DependentsModal';
 import { IncomeDetailsModal } from './Income/IncomeDetailsModal';
 import { AdditionalDeductionsModal } from './AdditionalDeductionsModal';
+import { ADDITIONAL_DEDUCTION_INFO } from './additionalDeductionInfo';
 import { calculateTotalNetIncome } from '../../utils/taxCalculations';
 import { formatJPY } from '../../utils/formatters';
 
@@ -1109,13 +1110,9 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
                 parts.push(
                   `Home loan tax credit ${formatJPY(inputs.homeLoanTaxCredit.creditAmount)}`,
                 );
-              const additionalLabels: Record<string, string> = {
-                lifeInsurance: 'Life insurance',
-                earthquakeInsurance: 'Earthquake insurance',
-                medical: 'Medical',
-              };
               additionalDeductions?.items.forEach(item => {
-                parts.push(`${additionalLabels[item.key] ?? item.key} ${formatJPY(item.national)}`);
+                const name = ADDITIONAL_DEDUCTION_INFO[item.key]?.name ?? item.key;
+                parts.push(`${name} ${formatJPY(item.national)}`);
               });
               // Via the UI the move-in dropdown only offers eligible years, so a credit entered
               // but zeroed (availableCredit 0) means income exceeded the cohort's eligibility limit.

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -158,12 +158,6 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
     } as unknown as React.ChangeEvent<HTMLInputElement>);
   };
 
-  const handleOtherIncomeDeductionsChange = (value: number) => {
-    onInputChange({
-      target: { name: 'otherIncomeDeductions', value },
-    } as unknown as React.ChangeEvent<HTMLInputElement>);
-  };
-
   const handleIncomeStreamsChange = (newStreams: IncomeStream[]) => {
     // Calculate total annual income from streams
     const totalIncome = newStreams.reduce((sum, s) => {
@@ -1119,7 +1113,6 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
                 lifeInsurance: 'Life insurance',
                 earthquakeInsurance: 'Earthquake insurance',
                 medical: 'Medical',
-                other: 'Other deductions',
               };
               additionalDeductions?.items.forEach(item => {
                 parts.push(`${additionalLabels[item.key] ?? item.key} ${formatJPY(item.national)}`);
@@ -1195,8 +1188,6 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
         onEarthquakeInsuranceChange={handleEarthquakeInsuranceChange}
         medicalExpenses={inputs.medicalExpenses}
         onMedicalExpensesChange={handleMedicalExpensesChange}
-        otherIncomeDeductions={inputs.otherIncomeDeductions}
-        onOtherIncomeDeductionsChange={handleOtherIncomeDeductionsChange}
         additionalDeductions={additionalDeductions}
         incomeYear={inputs.incomeYear}
       />

--- a/src/components/TakeHomeCalculator/InputForm.tsx
+++ b/src/components/TakeHomeCalculator/InputForm.tsx
@@ -40,6 +40,10 @@ import type {
   IncomeStream,
   HomeLoanTaxCreditInput,
   HomeLoanTaxCreditResult,
+  LifeInsuranceInput,
+  EarthquakeInsuranceInput,
+  MedicalExpensesInput,
+  AdditionalDeductionsResult,
 } from '../../types/tax';
 import {
   getProviderDisplayName,
@@ -62,6 +66,8 @@ interface TaxInputFormProps {
   ) => void;
   /** Computed home loan tax credit result, used to flag when the credit was zeroed (income over the limit). */
   homeLoanTaxCreditResult?: HomeLoanTaxCreditResult | undefined;
+  /** Computed additional deductions, passed through to the modal for live readouts and the summary. */
+  additionalDeductions?: AdditionalDeductionsResult | undefined;
 }
 
 // National Health Insurance provider (used in both employment and non-employment scenarios)
@@ -86,6 +92,7 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
   inputs,
   onInputChange,
   homeLoanTaxCreditResult,
+  additionalDeductions,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -130,6 +137,30 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
         name: 'dcPlanContributions',
         value,
       },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+  };
+
+  const handleLifeInsuranceChange = (newInput: LifeInsuranceInput | undefined) => {
+    onInputChange({
+      target: { name: 'lifeInsurance', value: newInput },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+  };
+
+  const handleEarthquakeInsuranceChange = (newInput: EarthquakeInsuranceInput | undefined) => {
+    onInputChange({
+      target: { name: 'earthquakeInsurance', value: newInput },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+  };
+
+  const handleMedicalExpensesChange = (newInput: MedicalExpensesInput | undefined) => {
+    onInputChange({
+      target: { name: 'medicalExpenses', value: newInput },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+  };
+
+  const handleOtherIncomeDeductionsChange = (value: number) => {
+    onInputChange({
+      target: { name: 'otherIncomeDeductions', value },
     } as unknown as React.ChangeEvent<HTMLInputElement>);
   };
 
@@ -1084,6 +1115,15 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
                 parts.push(
                   `Home loan tax credit ${formatJPY(inputs.homeLoanTaxCredit.creditAmount)}`,
                 );
+              const additionalLabels: Record<string, string> = {
+                lifeInsurance: 'Life insurance',
+                earthquakeInsurance: 'Earthquake insurance',
+                medical: 'Medical',
+                other: 'Other deductions',
+              };
+              additionalDeductions?.items.forEach(item => {
+                parts.push(`${additionalLabels[item.key] ?? item.key} ${formatJPY(item.national)}`);
+              });
               // Via the UI the move-in dropdown only offers eligible years, so a credit entered
               // but zeroed (availableCredit 0) means income exceeded the cohort's eligibility limit.
               const homeLoanNotApplied = !!(
@@ -1149,6 +1189,15 @@ export const TakeHomeInputForm: React.FC<TaxInputFormProps> = ({
         homeLoanTaxCredit={inputs.homeLoanTaxCredit}
         onHomeLoanTaxCreditChange={handleHomeLoanTaxCreditChange}
         homeLoanTaxCreditResult={homeLoanTaxCreditResult}
+        lifeInsurance={inputs.lifeInsurance}
+        onLifeInsuranceChange={handleLifeInsuranceChange}
+        earthquakeInsurance={inputs.earthquakeInsurance}
+        onEarthquakeInsuranceChange={handleEarthquakeInsuranceChange}
+        medicalExpenses={inputs.medicalExpenses}
+        onMedicalExpensesChange={handleMedicalExpensesChange}
+        otherIncomeDeductions={inputs.otherIncomeDeductions}
+        onOtherIncomeDeductionsChange={handleOtherIncomeDeductionsChange}
+        additionalDeductions={additionalDeductions}
         incomeYear={inputs.incomeYear}
       />
     </Box>

--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -27,6 +27,7 @@ import type {
   CustomEmployeesHealthInsuranceRates,
   IncomeStream,
 } from '../../types/tax';
+import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../../types/tax';
 import { formatJPY } from '../../utils/formatters';
 import {
   generateChartData,
@@ -284,6 +285,9 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
   const chartData = useMemo<ChartData<'bar' | 'line'>>(
     () =>
       generateChartData(chartRange, {
+        // The by-income projection does not yet apply the modal's additional deductions
+        // (生命保険料/地震保険料/医療費) or the home loan credit; hold them at zero for now (follow-up).
+        ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
         isEmploymentIncome,
         incomeYear,
         isSubjectToLongTermCarePremium,
@@ -334,6 +338,8 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
 
                 // Calculate full tax results for this income level to get cap status
                 const taxInputs = {
+                  // See note in chartData: additional deductions / home loan credit not reflected here yet.
+                  ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
                   annualIncome: income,
                   incomeYear,
                   isEmploymentIncome,

--- a/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
+++ b/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
@@ -13,12 +13,15 @@ import type { AdditionalDeductionItem } from '../../types/tax';
  * work out the figure the user must enter.
  */
 export interface AdditionalDeductionInfo {
-  /** Japanese deduction name; used as the tooltip title. */
+  /** English deduction name; the primary label shown in tooltips (we don't assume readers know Japanese). */
+  name: string;
+  /** Japanese deduction name; kept for the source reference and official-doc cross-referencing. */
   label: string;
   /** How the displayed amount is computed — explains why it may differ from the raw figures. */
   explanation: string;
-  /** Official source link text and URL. */
+  /** Official source link text. */
   sourceLabel: string;
+  /** Official source link URL. */
   sourceUrl: string;
 }
 
@@ -27,6 +30,7 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
   AdditionalDeductionInfo
 > = {
   lifeInsurance: {
+    name: 'Life insurance',
     label: '生命保険料控除',
     explanation:
       'Each category is computed from its premiums on a sliding scale, then capped (new contracts ¥40,000 income tax / ¥28,000 residence; old contracts ¥50,000 / ¥35,000), with an overall cap of ¥120,000 / ¥70,000. With both new and old policies in a category, the most favourable method is used. For 2026–2027, a household with a dependent under 23 gets the general (new) cap for income tax raised to ¥60,000.',
@@ -34,6 +38,7 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
     sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm',
   },
   earthquakeInsurance: {
+    name: 'Earthquake insurance',
     label: '地震保険料控除',
     explanation:
       'The earthquake premium is deductible in full up to ¥50,000 for income tax, and at half up to ¥25,000 for residence tax. A 旧長期損害保険料 portion can be added, with the combined deduction capped at ¥50,000 / ¥25,000.',
@@ -41,6 +46,7 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
     sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm',
   },
   medical: {
+    name: 'Medical expenses',
     label: '医療費控除',
     explanation:
       'The deduction is your medical expenses minus any reimbursements, minus the lower of ¥100,000 and 5% of your total net income, capped at ¥2,000,000.',

--- a/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
+++ b/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
@@ -13,10 +13,9 @@ import type { AdditionalDeductionItem } from '../../types/tax';
  * work out the figure the user must enter.
  */
 export interface AdditionalDeductionInfo {
-  /** English deduction name; the primary label shown in tooltips (we don't assume readers know Japanese). */
+  /** English deduction name; shown as the primary label in tooltips (we don't assume readers know
+   * Japanese). The Japanese term is still available via {@link sourceLabel}. */
   name: string;
-  /** Japanese deduction name; kept for the source reference and official-doc cross-referencing. */
-  label: string;
   /** How the displayed amount is computed — explains why it may differ from the raw figures. */
   explanation: string;
   /** Official source link text. */
@@ -31,7 +30,6 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
 > = {
   lifeInsurance: {
     name: 'Life insurance',
-    label: '生命保険料控除',
     explanation:
       'Each category is computed from its premiums on a sliding scale, then capped (new contracts ¥40,000 income tax / ¥28,000 residence; old contracts ¥50,000 / ¥35,000), with an overall cap of ¥120,000 / ¥70,000. With both new and old policies in a category, the most favourable method is used. For 2026–2027, a household with a dependent under 23 gets the general (new) cap for income tax raised to ¥60,000.',
     sourceLabel: '生命保険料控除 (NTA No.1140)',
@@ -39,7 +37,6 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
   },
   earthquakeInsurance: {
     name: 'Earthquake insurance',
-    label: '地震保険料控除',
     explanation:
       'The earthquake premium is deductible in full up to ¥50,000 for income tax, and at half up to ¥25,000 for residence tax. A 旧長期損害保険料 portion can be added, with the combined deduction capped at ¥50,000 / ¥25,000.',
     sourceLabel: '地震保険料控除 (NTA No.1145)',
@@ -47,7 +44,6 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
   },
   medical: {
     name: 'Medical expenses',
-    label: '医療費控除',
     explanation:
       'The deduction is your medical expenses minus any reimbursements, minus the lower of ¥100,000 and 5% of your total net income, capped at ¥2,000,000.',
     sourceLabel: '医療費控除 (NTA No.1120)',

--- a/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
+++ b/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
@@ -29,7 +29,7 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
   lifeInsurance: {
     label: '生命保険料控除',
     explanation:
-      'Each category is computed from its premiums on a sliding scale, then capped (new contracts ¥40,000 income tax / ¥28,000 residence; old contracts ¥50,000 / ¥35,000), with an overall cap of ¥120,000 / ¥70,000. With both new and old policies in a category, the most favourable method is used. For 2026–2027, a household with a dependent under 23 gets the general (new) income-tax cap raised to ¥60,000.',
+      'Each category is computed from its premiums on a sliding scale, then capped (new contracts ¥40,000 income tax / ¥28,000 residence; old contracts ¥50,000 / ¥35,000), with an overall cap of ¥120,000 / ¥70,000. With both new and old policies in a category, the most favourable method is used. For 2026–2027, a household with a dependent under 23 gets the general (new) cap for income tax raised to ¥60,000.',
     sourceLabel: '生命保険料控除 (NTA No.1140)',
     sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm',
   },

--- a/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
+++ b/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
@@ -29,7 +29,7 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
   lifeInsurance: {
     label: '生命保険料控除',
     explanation:
-      'Each category is computed from its premiums on a sliding scale, then capped (new contracts ¥40,000 income tax / ¥28,000 residence; old contracts ¥50,000 / ¥35,000), with an overall cap of ¥120,000 / ¥70,000. With both new and old policies in a category, the most favourable method is used.',
+      'Each category is computed from its premiums on a sliding scale, then capped (new contracts ¥40,000 income tax / ¥28,000 residence; old contracts ¥50,000 / ¥35,000), with an overall cap of ¥120,000 / ¥70,000. With both new and old policies in a category, the most favourable method is used. For 2026–2027, a household with a dependent under 23 gets the general (new) income-tax cap raised to ¥60,000.',
     sourceLabel: '生命保険料控除 (NTA No.1140)',
     sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm',
   },

--- a/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
+++ b/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
@@ -43,7 +43,7 @@ export const ADDITIONAL_DEDUCTION_INFO: Record<
   medical: {
     label: '医療費控除',
     explanation:
-      'The deduction is your medical expenses minus any reimbursements, minus the lower of ¥100,000 and 5% of your total income, capped at ¥2,000,000.',
+      'The deduction is your medical expenses minus any reimbursements, minus the lower of ¥100,000 and 5% of your total net income, capped at ¥2,000,000.',
     sourceLabel: '医療費控除 (NTA No.1120)',
     sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm',
   },

--- a/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
+++ b/src/components/TakeHomeCalculator/additionalDeductionInfo.ts
@@ -1,0 +1,50 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { AdditionalDeductionItem } from '../../types/tax';
+
+/**
+ * Display + explanatory metadata for an additional income deduction, shared between the
+ * Additional Deductions modal (the tooltip next to each computed readout) and the Taxes-tab
+ * breakdown tooltip, so the "how was this computed" explanation can't drift between the two.
+ *
+ * These deductions are computed for the user from amounts they already know, so the explanation
+ * belongs next to the *result* — unlike the home loan credit, whose accordion explains how to
+ * work out the figure the user must enter.
+ */
+export interface AdditionalDeductionInfo {
+  /** Japanese deduction name; used as the tooltip title. */
+  label: string;
+  /** How the displayed amount is computed — explains why it may differ from the raw figures. */
+  explanation: string;
+  /** Official source link text and URL. */
+  sourceLabel: string;
+  sourceUrl: string;
+}
+
+export const ADDITIONAL_DEDUCTION_INFO: Record<
+  AdditionalDeductionItem['key'],
+  AdditionalDeductionInfo
+> = {
+  lifeInsurance: {
+    label: '生命保険料控除',
+    explanation:
+      'Each category is computed from its premiums on a sliding scale, then capped (new contracts ¥40,000 income tax / ¥28,000 residence; old contracts ¥50,000 / ¥35,000), with an overall cap of ¥120,000 / ¥70,000. With both new and old policies in a category, the most favourable method is used.',
+    sourceLabel: '生命保険料控除 (NTA No.1140)',
+    sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm',
+  },
+  earthquakeInsurance: {
+    label: '地震保険料控除',
+    explanation:
+      'The earthquake premium is deductible in full up to ¥50,000 for income tax, and at half up to ¥25,000 for residence tax. A 旧長期損害保険料 portion can be added, with the combined deduction capped at ¥50,000 / ¥25,000.',
+    sourceLabel: '地震保険料控除 (NTA No.1145)',
+    sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm',
+  },
+  medical: {
+    label: '医療費控除',
+    explanation:
+      'The deduction is your medical expenses minus any reimbursements, minus the lower of ¥100,000 and 5% of your total income, capped at ¥2,000,000.',
+    sourceLabel: '医療費控除 (NTA No.1120)',
+    sourceUrl: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm',
+  },
+};

--- a/src/components/TakeHomeCalculator/tabs/AdditionalDeductionsTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/AdditionalDeductionsTooltip.tsx
@@ -1,0 +1,109 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import type { AdditionalDeductionsResult } from '../../../types/tax';
+import { formatJPY } from '../../../utils/formatters';
+import { ADDITIONAL_DEDUCTION_INFO } from '../additionalDeductionInfo';
+import { DetailedTooltip } from '../../ui/Tooltips';
+
+interface AdditionalDeductionsTooltipProps {
+  deductions: AdditionalDeductionsResult;
+  taxType: 'national' | 'residence';
+}
+
+/**
+ * Tooltip for the "Other Deductions" row: a breakdown of the additional income deductions
+ * (生命保険料控除 / 地震保険料控除 / 医療費控除) for the given tax, with per-item explanations and
+ * sources. Renders its own DetailedTooltip trigger (titled per tax type), so callers place it
+ * directly after the row label.
+ */
+const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = ({
+  deductions,
+  taxType,
+}) => {
+  const isNational = taxType === 'national';
+  const getAmount = (item: AdditionalDeductionsResult['items'][number]) =>
+    isNational ? item.national : item.residence;
+  const rows = deductions.items.filter(item => getAmount(item) > 0);
+  const total = isNational ? deductions.national : deductions.residence;
+
+  return (
+    <DetailedTooltip
+      title={`Other Income Deductions (${isNational ? 'National' : 'Residence'} Tax)`}
+    >
+      <Box sx={{ minWidth: { xs: 0, sm: 320 }, maxWidth: { xs: '100vw', sm: 460 } }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+          Additional Deductions Breakdown
+        </Typography>
+        <TableContainer component={Box} sx={{ mb: 2 }}>
+          <Table
+            size="small"
+            sx={{ '& .MuiTableCell-root': { padding: '2px 6px', fontSize: '0.95em' } }}
+          >
+            <TableHead>
+              <TableRow>
+                <TableCell>Deduction</TableCell>
+                <TableCell align="right">Amount</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map(item => (
+                <TableRow key={item.key}>
+                  <TableCell>
+                    <div style={{ fontWeight: 500 }}>
+                      {ADDITIONAL_DEDUCTION_INFO[item.key]?.name ?? item.label}
+                    </div>
+                  </TableCell>
+                  <TableCell align="right">{formatJPY(getAmount(item))}</TableCell>
+                </TableRow>
+              ))}
+              <TableRow sx={{ backgroundColor: 'action.hover' }}>
+                <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  {formatJPY(total)}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <Typography variant="body2" sx={{ fontSize: '0.85em', color: 'text.secondary', mb: 1 }}>
+          {isNational
+            ? 'These reduce your taxable income for national income tax.'
+            : 'These reduce your taxable income for residence tax. The life and earthquake insurance deductions are smaller for residence tax than for income tax.'}
+        </Typography>
+        {rows.map(item => {
+          const info = ADDITIONAL_DEDUCTION_INFO[item.key];
+          if (!info) return null;
+          return (
+            <Typography
+              key={item.key}
+              variant="body2"
+              sx={{ fontSize: '0.85em', color: 'text.secondary', mt: 1 }}
+            >
+              <strong>{info.name}:</strong> {info.explanation}{' '}
+              <a
+                href={info.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
+              >
+                {info.sourceLabel}
+              </a>
+            </Typography>
+          );
+        })}
+      </Box>
+    </DetailedTooltip>
+  );
+};
+
+export default AdditionalDeductionsTooltip;

--- a/src/components/TakeHomeCalculator/tabs/AdditionalDeductionsTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/AdditionalDeductionsTooltip.tsx
@@ -58,11 +58,7 @@ const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = 
             <TableBody>
               {rows.map(item => (
                 <TableRow key={item.key}>
-                  <TableCell>
-                    <div style={{ fontWeight: 500 }}>
-                      {ADDITIONAL_DEDUCTION_INFO[item.key]?.name ?? item.label}
-                    </div>
-                  </TableCell>
+                  <TableCell>{ADDITIONAL_DEDUCTION_INFO[item.key]?.name ?? item.label}</TableCell>
                   <TableCell align="right">{formatJPY(getAmount(item))}</TableCell>
                 </TableRow>
               ))}

--- a/src/components/TakeHomeCalculator/tabs/AdditionalDeductionsTooltip.tsx
+++ b/src/components/TakeHomeCalculator/tabs/AdditionalDeductionsTooltip.tsx
@@ -58,7 +58,7 @@ const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = 
             <TableBody>
               {rows.map(item => (
                 <TableRow key={item.key}>
-                  <TableCell>{ADDITIONAL_DEDUCTION_INFO[item.key]?.name ?? item.label}</TableCell>
+                  <TableCell>{ADDITIONAL_DEDUCTION_INFO[item.key].name}</TableCell>
                   <TableCell align="right">{formatJPY(getAmount(item))}</TableCell>
                 </TableRow>
               ))}

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -15,7 +15,11 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import type { TakeHomeResults, TakeHomeInputs } from '../../../types/tax';
+import type {
+  TakeHomeResults,
+  TakeHomeInputs,
+  AdditionalDeductionsResult,
+} from '../../../types/tax';
 import type { DependentDeductionResults } from '../../../types/dependents';
 import { formatJPY } from '../../../utils/formatters';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
@@ -200,6 +204,103 @@ const DependentDeductionTooltip: React.FC<DependentDeductionTooltipProps> = ({
           </>
         )}
       </Box>
+    </Box>
+  );
+};
+
+const ADDITIONAL_DEDUCTION_SOURCES: Record<string, { label: string; url: string }> = {
+  lifeInsurance: {
+    label: '生命保険料控除 (NTA)',
+    url: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm',
+  },
+  earthquakeInsurance: {
+    label: '地震保険料控除 (NTA)',
+    url: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm',
+  },
+  medical: {
+    label: '医療費控除 (NTA)',
+    url: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm',
+  },
+};
+
+interface AdditionalDeductionsTooltipProps {
+  deductions: AdditionalDeductionsResult;
+  taxType: 'national' | 'residence';
+}
+
+const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = ({
+  deductions,
+  taxType,
+}) => {
+  const isNational = taxType === 'national';
+  const getAmount = (item: AdditionalDeductionsResult['items'][number]) =>
+    isNational ? item.national : item.residence;
+  const rows = deductions.items.filter(item => getAmount(item) > 0);
+  const total = isNational ? deductions.national : deductions.residence;
+  const sourcedRows = rows.filter(item => ADDITIONAL_DEDUCTION_SOURCES[item.key]);
+
+  return (
+    <Box sx={{ minWidth: { xs: 0, sm: 320 }, maxWidth: { xs: '100vw', sm: 460 } }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+        Additional Deductions Breakdown
+      </Typography>
+      <TableContainer component={Box} sx={{ mb: 2 }}>
+        <Table
+          size="small"
+          sx={{ '& .MuiTableCell-root': { padding: '2px 6px', fontSize: '0.95em' } }}
+        >
+          <TableHead>
+            <TableRow>
+              <TableCell>Deduction</TableCell>
+              <TableCell align="right">Amount</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map(item => (
+              <TableRow key={item.key}>
+                <TableCell>
+                  <div style={{ fontWeight: 500 }}>{item.label}</div>
+                </TableCell>
+                <TableCell align="right">{formatJPY(getAmount(item))}</TableCell>
+              </TableRow>
+            ))}
+            <TableRow sx={{ backgroundColor: 'action.hover' }}>
+              <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
+              <TableCell align="right" sx={{ fontWeight: 600 }}>
+                {formatJPY(total)}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Typography variant="body2" sx={{ fontSize: '0.85em', color: 'text.secondary', mb: 1 }}>
+        {isNational
+          ? 'These reduce your taxable income for national income tax.'
+          : 'These reduce your taxable income for residence tax. The life and earthquake insurance amounts are smaller than the income-tax amounts.'}
+      </Typography>
+      {sourcedRows.length > 0 && (
+        <Box sx={{ mt: 1 }}>
+          Official Sources (NTA):
+          <ul>
+            {sourcedRows.map(item => (
+              <li key={item.key}>
+                <a
+                  href={ADDITIONAL_DEDUCTION_SOURCES[item.key]!.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: 'var(--primary-main)',
+                    textDecoration: 'underline',
+                    fontSize: '0.95em',
+                  }}
+                >
+                  {ADDITIONAL_DEDUCTION_SOURCES[item.key]!.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Box>
+      )}
     </Box>
   );
 };
@@ -554,6 +655,24 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
               </span>
             }
             value={formatJPY(-results.dependentDeductions.nationalTax.total)}
+            type="detail"
+          />
+        )}
+
+        {results.additionalDeductions && results.additionalDeductions.national > 0 && (
+          <ResultRow
+            label={
+              <span>
+                Other Deductions
+                <DetailedTooltip title="Other Income Deductions (National Tax)">
+                  <AdditionalDeductionsTooltip
+                    deductions={results.additionalDeductions}
+                    taxType="national"
+                  />
+                </DetailedTooltip>
+              </span>
+            }
+            value={formatJPY(-results.additionalDeductions.national)}
             type="detail"
           />
         )}
@@ -996,6 +1115,24 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
               </span>
             }
             value={formatJPY(-results.dependentDeductions.residenceTax.total)}
+            type="detail"
+          />
+        )}
+
+        {results.additionalDeductions && results.additionalDeductions.residence > 0 && (
+          <ResultRow
+            label={
+              <span>
+                Other Deductions
+                <DetailedTooltip title="Other Income Deductions (Residence Tax)">
+                  <AdditionalDeductionsTooltip
+                    deductions={results.additionalDeductions}
+                    taxType="residence"
+                  />
+                </DetailedTooltip>
+              </span>
+            }
+            value={formatJPY(-results.additionalDeductions.residence)}
             type="detail"
           />
         )}

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -15,19 +15,15 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import type {
-  TakeHomeResults,
-  TakeHomeInputs,
-  AdditionalDeductionsResult,
-} from '../../../types/tax';
+import type { TakeHomeResults, TakeHomeInputs } from '../../../types/tax';
 import type { DependentDeductionResults } from '../../../types/dependents';
 import { formatJPY } from '../../../utils/formatters';
-import { ADDITIONAL_DEDUCTION_INFO } from '../additionalDeductionInfo';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import WarningIcon from '@mui/icons-material/Warning';
 import { DetailedTooltip } from '../../ui/Tooltips';
 import { ResultRow } from '../ResultRow';
 import NetEmploymentIncomeTooltip from './NetEmploymentIncomeTooltip';
+import AdditionalDeductionsTooltip from './AdditionalDeductionsTooltip';
 import { getNationalBasicDeductionTiers } from '../../../data/nationalBasicDeduction';
 
 interface TaxesTabProps {
@@ -205,87 +201,6 @@ const DependentDeductionTooltip: React.FC<DependentDeductionTooltipProps> = ({
           </>
         )}
       </Box>
-    </Box>
-  );
-};
-
-interface AdditionalDeductionsTooltipProps {
-  deductions: AdditionalDeductionsResult;
-  taxType: 'national' | 'residence';
-}
-
-const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = ({
-  deductions,
-  taxType,
-}) => {
-  const isNational = taxType === 'national';
-  const getAmount = (item: AdditionalDeductionsResult['items'][number]) =>
-    isNational ? item.national : item.residence;
-  const rows = deductions.items.filter(item => getAmount(item) > 0);
-  const total = isNational ? deductions.national : deductions.residence;
-
-  return (
-    <Box sx={{ minWidth: { xs: 0, sm: 320 }, maxWidth: { xs: '100vw', sm: 460 } }}>
-      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
-        Additional Deductions Breakdown
-      </Typography>
-      <TableContainer component={Box} sx={{ mb: 2 }}>
-        <Table
-          size="small"
-          sx={{ '& .MuiTableCell-root': { padding: '2px 6px', fontSize: '0.95em' } }}
-        >
-          <TableHead>
-            <TableRow>
-              <TableCell>Deduction</TableCell>
-              <TableCell align="right">Amount</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map(item => (
-              <TableRow key={item.key}>
-                <TableCell>
-                  <div style={{ fontWeight: 500 }}>
-                    {ADDITIONAL_DEDUCTION_INFO[item.key]?.name ?? item.label}
-                  </div>
-                </TableCell>
-                <TableCell align="right">{formatJPY(getAmount(item))}</TableCell>
-              </TableRow>
-            ))}
-            <TableRow sx={{ backgroundColor: 'action.hover' }}>
-              <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
-              <TableCell align="right" sx={{ fontWeight: 600 }}>
-                {formatJPY(total)}
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <Typography variant="body2" sx={{ fontSize: '0.85em', color: 'text.secondary', mb: 1 }}>
-        {isNational
-          ? 'These reduce your taxable income for national income tax.'
-          : 'These reduce your taxable income for residence tax. The life and earthquake insurance deductions are smaller for residence tax than for income tax.'}
-      </Typography>
-      {rows.map(item => {
-        const info = ADDITIONAL_DEDUCTION_INFO[item.key];
-        if (!info) return null;
-        return (
-          <Typography
-            key={item.key}
-            variant="body2"
-            sx={{ fontSize: '0.85em', color: 'text.secondary', mt: 1 }}
-          >
-            <strong>{info.name}:</strong> {info.explanation}{' '}
-            <a
-              href={info.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
-            >
-              {info.sourceLabel}
-            </a>
-          </Typography>
-        );
-      })}
     </Box>
   );
 };
@@ -649,12 +564,10 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
             label={
               <span>
                 Other Deductions
-                <DetailedTooltip title="Other Income Deductions (National Tax)">
-                  <AdditionalDeductionsTooltip
-                    deductions={results.additionalDeductions}
-                    taxType="national"
-                  />
-                </DetailedTooltip>
+                <AdditionalDeductionsTooltip
+                  deductions={results.additionalDeductions}
+                  taxType="national"
+                />
               </span>
             }
             value={formatJPY(-results.additionalDeductions.national)}
@@ -1109,12 +1022,10 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
             label={
               <span>
                 Other Deductions
-                <DetailedTooltip title="Other Income Deductions (Residence Tax)">
-                  <AdditionalDeductionsTooltip
-                    deductions={results.additionalDeductions}
-                    taxType="residence"
-                  />
-                </DetailedTooltip>
+                <AdditionalDeductionsTooltip
+                  deductions={results.additionalDeductions}
+                  taxType="residence"
+                />
               </span>
             }
             value={formatJPY(-results.additionalDeductions.residence)}

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -244,7 +244,9 @@ const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = 
             {rows.map(item => (
               <TableRow key={item.key}>
                 <TableCell>
-                  <div style={{ fontWeight: 500 }}>{item.label}</div>
+                  <div style={{ fontWeight: 500 }}>
+                    {ADDITIONAL_DEDUCTION_INFO[item.key]?.name ?? item.label}
+                  </div>
                 </TableCell>
                 <TableCell align="right">{formatJPY(getAmount(item))}</TableCell>
               </TableRow>
@@ -272,7 +274,7 @@ const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = 
             variant="body2"
             sx={{ fontSize: '0.85em', color: 'text.secondary', mt: 1 }}
           >
-            <strong>{info.label}:</strong> {info.explanation}{' '}
+            <strong>{info.name}:</strong> {info.explanation}{' '}
             <a
               href={info.sourceUrl}
               target="_blank"

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -22,6 +22,7 @@ import type {
 } from '../../../types/tax';
 import type { DependentDeductionResults } from '../../../types/dependents';
 import { formatJPY } from '../../../utils/formatters';
+import { ADDITIONAL_DEDUCTION_INFO } from '../additionalDeductionInfo';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import WarningIcon from '@mui/icons-material/Warning';
 import { DetailedTooltip } from '../../ui/Tooltips';
@@ -208,21 +209,6 @@ const DependentDeductionTooltip: React.FC<DependentDeductionTooltipProps> = ({
   );
 };
 
-const ADDITIONAL_DEDUCTION_SOURCES: Record<string, { label: string; url: string }> = {
-  lifeInsurance: {
-    label: '生命保険料控除 (NTA)',
-    url: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm',
-  },
-  earthquakeInsurance: {
-    label: '地震保険料控除 (NTA)',
-    url: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm',
-  },
-  medical: {
-    label: '医療費控除 (NTA)',
-    url: 'https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm',
-  },
-};
-
 interface AdditionalDeductionsTooltipProps {
   deductions: AdditionalDeductionsResult;
   taxType: 'national' | 'residence';
@@ -237,7 +223,6 @@ const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = 
     isNational ? item.national : item.residence;
   const rows = deductions.items.filter(item => getAmount(item) > 0);
   const total = isNational ? deductions.national : deductions.residence;
-  const sourcedRows = rows.filter(item => ADDITIONAL_DEDUCTION_SOURCES[item.key]);
 
   return (
     <Box sx={{ minWidth: { xs: 0, sm: 320 }, maxWidth: { xs: '100vw', sm: 460 } }}>
@@ -278,29 +263,27 @@ const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = 
           ? 'These reduce your taxable income for national income tax.'
           : 'These reduce your taxable income for residence tax. The life and earthquake insurance amounts are smaller than the income-tax amounts.'}
       </Typography>
-      {sourcedRows.length > 0 && (
-        <Box sx={{ mt: 1 }}>
-          Official Sources (NTA):
-          <ul>
-            {sourcedRows.map(item => (
-              <li key={item.key}>
-                <a
-                  href={ADDITIONAL_DEDUCTION_SOURCES[item.key]!.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{
-                    color: 'var(--primary-main)',
-                    textDecoration: 'underline',
-                    fontSize: '0.95em',
-                  }}
-                >
-                  {ADDITIONAL_DEDUCTION_SOURCES[item.key]!.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </Box>
-      )}
+      {rows.map(item => {
+        const info = ADDITIONAL_DEDUCTION_INFO[item.key];
+        if (!info) return null;
+        return (
+          <Typography
+            key={item.key}
+            variant="body2"
+            sx={{ fontSize: '0.85em', color: 'text.secondary', mt: 1 }}
+          >
+            <strong>{info.label}:</strong> {info.explanation}{' '}
+            <a
+              href={info.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'var(--primary-main)', textDecoration: 'underline' }}
+            >
+              {info.sourceLabel}
+            </a>
+          </Typography>
+        );
+      })}
     </Box>
   );
 };

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -642,7 +642,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
           />
         )}
 
-        {results.additionalDeductions && results.additionalDeductions.national > 0 && (
+        {results.additionalDeductions.national > 0 && (
           <ResultRow
             label={
               <span>
@@ -1102,7 +1102,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
           />
         )}
 
-        {results.additionalDeductions && results.additionalDeductions.residence > 0 && (
+        {results.additionalDeductions.residence > 0 && (
           <ResultRow
             label={
               <span>

--- a/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
+++ b/src/components/TakeHomeCalculator/tabs/TaxesTab.tsx
@@ -261,7 +261,7 @@ const AdditionalDeductionsTooltip: React.FC<AdditionalDeductionsTooltipProps> = 
       <Typography variant="body2" sx={{ fontSize: '0.85em', color: 'text.secondary', mb: 1 }}>
         {isNational
           ? 'These reduce your taxable income for national income tax.'
-          : 'These reduce your taxable income for residence tax. The life and earthquake insurance amounts are smaller than the income-tax amounts.'}
+          : 'These reduce your taxable income for residence tax. The life and earthquake insurance deductions are smaller for residence tax than for income tax.'}
       </Typography>
       {rows.map(item => {
         const info = ADDITIONAL_DEDUCTION_INFO[item.key];
@@ -1511,7 +1511,7 @@ const TaxesTab: React.FC<TaxesTabProps> = ({ results, inputs }) => {
                       When your available credit amount exceeds your income tax, the remainder
                       spills over to reduce residence tax. The cap is the lower of ¥97,500 (¥136,500
                       for 2014–2021 move-ins) and 5% (7% for 2014–2021 move-ins) of your{' '}
-                      <strong>income-tax</strong> taxable total income (所得税の課税総所得金額等).
+                      <strong>income tax</strong> taxable total income (所得税の課税総所得金額等).
                     </Typography>
                     {results.homeLoanTaxCredit.residenceTaxSpilloverCap && (
                       <Typography variant="body2" sx={{ mb: 1 }}>

--- a/src/data/insuranceDeductions.ts
+++ b/src/data/insuranceDeductions.ts
@@ -1,0 +1,203 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Life insurance (生命保険料控除) and earthquake insurance (地震保険料控除) premium
+ * deductions. Both produce a {@link DeductionAmount} because the income-tax and
+ * residence-tax amounts differ — which is exactly why they get structured inputs
+ * rather than being folded into a single "other deductions" lump.
+ *
+ * Sources:
+ *   - 生命保険料控除 (national): NTA No.1140 https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm
+ *   - 生命保険料控除 (residence): 練馬区 https://www.city.nerima.tokyo.jp/kurashi/zei/jyuminzei/shotokukojo/seimeihokenryokojo.html
+ *   - 地震保険料控除 (national): NTA No.1145 https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm
+ *   - 地震保険料控除 (residence): 練馬区 https://www.city.nerima.tokyo.jp/kurashi/zei/jyuminzei/shotokukojo/jishinhokenryoukojo.html
+ *
+ * These figures have been stable since the 新契約 regime began in 2012 (life) and the
+ * earthquake deduction replaced 損害保険料控除 in 2007, so they are plain constants rather
+ * than year-indexed tables. If a tax reform changes them, convert to year-banded tables
+ * like `data/homeLoanTaxCredit.ts`.
+ */
+
+import type { DeductionAmount } from '../types/dependents';
+import type { EarthquakeInsuranceInput, LifeInsuranceInput } from '../types/tax';
+
+/**
+ * A premium band: every premium up to and including `upTo` (yen) uses `amount` to compute
+ * the raw (pre-rounding) deduction. Tables are ordered ascending and the final band uses
+ * `upTo: Infinity` for the flat maximum.
+ */
+interface DeductionBand {
+  upTo: number;
+  amount: (premium: number) => number;
+}
+
+/**
+ * Rounds a raw deduction up to the next whole yen (1円未満切上げ). Premiums are usually
+ * round figures, so this only bites on the ½/¼ formulas with odd premiums. The small
+ * epsilon keeps an exactly-integer result (e.g. 30000.0000001 from float error) from
+ * rounding spuriously up to 30001.
+ */
+const roundUpYen = (amount: number): number => {
+  const rounded = Math.ceil(amount - 1e-9);
+  // Math.ceil(-1e-9) yields -0; normalize so deduction outputs never carry a negative zero.
+  return rounded === 0 ? 0 : rounded;
+};
+
+const applyBands = (premium: number, bands: ReadonlyArray<DeductionBand>): number => {
+  const p = Math.max(0, premium);
+  for (const band of bands) {
+    if (p <= band.upTo) return roundUpYen(band.amount(p));
+  }
+  return 0; // Unreachable: the last band is always upTo: Infinity.
+};
+
+// 生命保険料控除 — per-category bands, new (新契約) and old (旧契約) regimes.
+const LIFE_NEW_NATIONAL: ReadonlyArray<DeductionBand> = [
+  { upTo: 20_000, amount: p => p },
+  { upTo: 40_000, amount: p => p / 2 + 10_000 },
+  { upTo: 80_000, amount: p => p / 4 + 20_000 },
+  { upTo: Infinity, amount: () => 40_000 },
+];
+const LIFE_OLD_NATIONAL: ReadonlyArray<DeductionBand> = [
+  { upTo: 25_000, amount: p => p },
+  { upTo: 50_000, amount: p => p / 2 + 12_500 },
+  { upTo: 100_000, amount: p => p / 4 + 25_000 },
+  { upTo: Infinity, amount: () => 50_000 },
+];
+const LIFE_NEW_RESIDENCE: ReadonlyArray<DeductionBand> = [
+  { upTo: 12_000, amount: p => p },
+  { upTo: 32_000, amount: p => p / 2 + 6_000 },
+  { upTo: 56_000, amount: p => p / 4 + 14_000 },
+  { upTo: Infinity, amount: () => 28_000 },
+];
+const LIFE_OLD_RESIDENCE: ReadonlyArray<DeductionBand> = [
+  { upTo: 15_000, amount: p => p },
+  { upTo: 40_000, amount: p => p / 2 + 7_500 },
+  { upTo: 70_000, amount: p => p / 4 + 17_500 },
+  { upTo: Infinity, amount: () => 35_000 },
+];
+
+/** Per-category and overall caps for one tax regime. */
+interface LifeRegime {
+  newBands: ReadonlyArray<DeductionBand>;
+  oldBands: ReadonlyArray<DeductionBand>;
+  /** Cap on the new-only and the new+old combined methods. */
+  newCategoryCap: number;
+  /** Cap on the old-only method. */
+  oldCategoryCap: number;
+  /** Cap on the sum of all categories. */
+  overallCap: number;
+}
+
+const LIFE_NATIONAL: LifeRegime = {
+  newBands: LIFE_NEW_NATIONAL,
+  oldBands: LIFE_OLD_NATIONAL,
+  newCategoryCap: 40_000,
+  oldCategoryCap: 50_000,
+  overallCap: 120_000,
+};
+const LIFE_RESIDENCE: LifeRegime = {
+  newBands: LIFE_NEW_RESIDENCE,
+  oldBands: LIFE_OLD_RESIDENCE,
+  newCategoryCap: 28_000,
+  oldCategoryCap: 35_000,
+  overallCap: 70_000,
+};
+
+/**
+ * Deduction for one life-insurance category (一般 or 個人年金), which may hold both old and
+ * new contracts. Computed cap-agnostically as the most favourable of: new-only (cap
+ * newCategoryCap), old-only (cap oldCategoryCap), and new+old combined (cap newCategoryCap).
+ *
+ * This deliberately does NOT hardcode the NTA's "old premium > ¥60,000" rule from
+ * https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm: that ¥60,000 is the
+ * break-even where the old-only deduction reaches the ¥40,000 combined cap, and it is
+ * specific to national income tax. The residence brackets put the break-even at ¥42,000,
+ * so a hardcoded threshold would understate residence tax. Taking the max reproduces the
+ * national rule exactly and stays correct for residence (練馬区: "有利な適用方法を選択").
+ */
+const lifeCategoryDeduction = (newPremium: number, oldPremium: number, r: LifeRegime): number => {
+  const newDed = Math.min(applyBands(newPremium, r.newBands), r.newCategoryCap);
+  const oldDed = Math.min(applyBands(oldPremium, r.oldBands), r.oldCategoryCap);
+  const combined = Math.min(newDed + oldDed, r.newCategoryCap);
+  return Math.max(newDed, oldDed, combined);
+};
+
+const lifeDeductionForRegime = (input: LifeInsuranceInput, r: LifeRegime): number => {
+  const total =
+    lifeCategoryDeduction(input.generalNew, input.generalOld ?? 0, r) +
+    lifeCategoryDeduction(input.medicalCareNew, 0, r) + // 介護医療: new-contract only.
+    lifeCategoryDeduction(input.pensionNew, input.pensionOld ?? 0, r);
+  return Math.min(total, r.overallCap);
+};
+
+/**
+ * Life insurance premium deduction (生命保険料控除) from annual premiums, split by tax.
+ * Sums the three categories (一般 / 介護医療 / 個人年金) and applies the overall cap
+ * (¥120,000 national / ¥70,000 residence).
+ */
+export const calculateLifeInsuranceDeduction = (input: LifeInsuranceInput): DeductionAmount => ({
+  national: lifeDeductionForRegime(input, LIFE_NATIONAL),
+  residence: lifeDeductionForRegime(input, LIFE_RESIDENCE),
+});
+
+// 地震保険料控除 — the 旧長期損害保険料 sub-portion (the 地震保険料 portion is handled inline).
+const QUAKE_OLD_LONG_TERM_NATIONAL: ReadonlyArray<DeductionBand> = [
+  { upTo: 10_000, amount: p => p },
+  { upTo: 20_000, amount: p => p / 2 + 5_000 },
+  { upTo: Infinity, amount: () => 15_000 },
+];
+const QUAKE_OLD_LONG_TERM_RESIDENCE: ReadonlyArray<DeductionBand> = [
+  { upTo: 5_000, amount: p => p },
+  { upTo: 15_000, amount: p => p / 2 + 2_500 },
+  { upTo: Infinity, amount: () => 10_000 },
+];
+
+const QUAKE_OVERALL_CAP_NATIONAL = 50_000;
+const QUAKE_OVERALL_CAP_RESIDENCE = 25_000;
+
+/**
+ * Earthquake insurance premium deduction (地震保険料控除) from annual premiums, split by tax.
+ * National: 地震保険料 is deductible in full up to ¥50,000. Residence: 地震保険料 is ×½ up to
+ * ¥25,000. Each may add a 旧長期損害保険料 portion; the combined total is capped at the
+ * overall maximum (¥50,000 national / ¥25,000 residence).
+ */
+export const calculateEarthquakeInsuranceDeduction = (
+  input: EarthquakeInsuranceInput,
+): DeductionAmount => {
+  const earthquake = Math.max(0, input.earthquake);
+  const longTermOld = Math.max(0, input.longTermOld ?? 0);
+
+  const quakeNational = Math.min(earthquake, QUAKE_OVERALL_CAP_NATIONAL);
+  const oldNational = applyBands(longTermOld, QUAKE_OLD_LONG_TERM_NATIONAL);
+  const national = Math.min(quakeNational + oldNational, QUAKE_OVERALL_CAP_NATIONAL);
+
+  const quakeResidence = Math.min(roundUpYen(earthquake / 2), QUAKE_OVERALL_CAP_RESIDENCE);
+  const oldResidence = applyBands(longTermOld, QUAKE_OLD_LONG_TERM_RESIDENCE);
+  const residence = Math.min(quakeResidence + oldResidence, QUAKE_OVERALL_CAP_RESIDENCE);
+
+  return { national, residence };
+};
+
+if (import.meta.env.DEV) {
+  // Each band table must be ascending by `upTo` and terminate with an Infinity band.
+  const tables: Record<string, ReadonlyArray<DeductionBand>> = {
+    LIFE_NEW_NATIONAL,
+    LIFE_OLD_NATIONAL,
+    LIFE_NEW_RESIDENCE,
+    LIFE_OLD_RESIDENCE,
+    QUAKE_OLD_LONG_TERM_NATIONAL,
+    QUAKE_OLD_LONG_TERM_RESIDENCE,
+  };
+  for (const [name, bands] of Object.entries(tables)) {
+    if (bands.length === 0 || bands[bands.length - 1]!.upTo !== Infinity) {
+      throw new Error(`insuranceDeductions: ${name} must end with an upTo: Infinity band`);
+    }
+    for (let i = 1; i < bands.length; i++) {
+      if (bands[i]!.upTo <= bands[i - 1]!.upTo) {
+        throw new Error(`insuranceDeductions: ${name} bands must be strictly ascending by upTo`);
+      }
+    }
+  }
+}

--- a/src/data/insuranceDeductions.ts
+++ b/src/data/insuranceDeductions.ts
@@ -5,7 +5,7 @@
  * Life insurance (生命保険料控除) and earthquake insurance (地震保険料控除) premium
  * deductions. Both produce a {@link DeductionAmount} because the income-tax and
  * residence-tax amounts differ — which is exactly why they get structured inputs
- * rather than being folded into a single "other deductions" lump.
+ * rather than being folded into a single combined figure.
  *
  * Sources:
  *   - 生命保険料控除 (national): NTA No.1140 https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm

--- a/src/data/insuranceDeductions.ts
+++ b/src/data/insuranceDeductions.ts
@@ -15,8 +15,10 @@
  *
  * These figures have been stable since the 新契約 regime began in 2012 (life) and the
  * earthquake deduction replaced 損害保険料控除 in 2007, so they are plain constants rather
- * than year-indexed tables. If a tax reform changes them, convert to year-banded tables
- * like `data/homeLoanTaxCredit.ts`.
+ * than year-indexed tables — with one year-bound exception: the 令和8・9年分 (2026–2027)
+ * child-rearing measure that raises the 一般 (new-contract) income-tax cap to ¥60,000 (see
+ * {@link isChildRearingLifeExpansionYear}). If other figures change, convert to year-banded
+ * tables like `data/homeLoanTaxCredit.ts`.
  */
 
 import type { DeductionAmount } from '../types/dependents';
@@ -78,6 +80,29 @@ const LIFE_OLD_RESIDENCE: ReadonlyArray<DeductionBand> = [
   { upTo: Infinity, amount: () => 35_000 },
 ];
 
+/**
+ * 令和8・9年分 (2026–2027) child-rearing measure: when the taxpayer has a 23歳未満の扶養親族, the
+ * 一般 (new-contract) income-tax deduction uses this scale (the standard ¥40,000 table scaled
+ * ×1.5) with a ¥60,000 cap. Income tax only — residence tax, the 介護医療/個人年金 categories, the
+ * old-contract cap, and the ¥120,000 overall cap are unchanged. 令和7年度改正 introduced it for
+ * 令和8年分; 令和8年度改正 extended it to 令和9年分.
+ * Sources: 税理士 https://www.yamada-partners.jp/reform/r7/k02-expansion-of-life-insurance-premium-deduction ;
+ *          NTA 令和8改正 https://www.nta.go.jp/publication/pamph/gensen/2026kaisei.pdf
+ */
+const LIFE_NEW_GENERAL_NATIONAL_CHILD_REARING: ReadonlyArray<DeductionBand> = [
+  { upTo: 30_000, amount: p => p },
+  { upTo: 60_000, amount: p => p / 2 + 15_000 },
+  { upTo: 120_000, amount: p => p / 4 + 30_000 },
+  { upTo: Infinity, amount: () => 60_000 },
+];
+const CHILD_REARING_LIFE_EXPANSION_YEARS: ReadonlySet<number> = new Set([2026, 2027]);
+
+/** Whether the income year is covered by the child-rearing 一般生命保険料控除 expansion (令和8・9年分).
+ * @see LIFE_NEW_GENERAL_NATIONAL_CHILD_REARING
+ */
+export const isChildRearingLifeExpansionYear = (year: number): boolean =>
+  CHILD_REARING_LIFE_EXPANSION_YEARS.has(year);
+
 /** Per-category and overall caps for one tax regime. */
 interface LifeRegime {
   newBands: ReadonlyArray<DeductionBand>;
@@ -106,6 +131,17 @@ const LIFE_RESIDENCE: LifeRegime = {
 };
 
 /**
+ * The national regime with the 令和8・9年分 child-rearing raise applied to the 一般 category: the
+ * new-contract scale and cap become ¥60,000 (income tax only). Used solely for the 一般 category
+ * when eligible — 介護医療, 個人年金, and the overall cap still come from {@link LIFE_NATIONAL}.
+ */
+const LIFE_GENERAL_NATIONAL_CHILD_REARING: LifeRegime = {
+  ...LIFE_NATIONAL,
+  newBands: LIFE_NEW_GENERAL_NATIONAL_CHILD_REARING,
+  newCategoryCap: 60_000,
+};
+
+/**
  * Deduction for one life-insurance category (一般 or 個人年金), which may hold both old and
  * new contracts. Computed cap-agnostically as the most favourable of: new-only (cap
  * newCategoryCap), old-only (cap oldCategoryCap), and new+old combined (cap newCategoryCap).
@@ -117,30 +153,57 @@ const LIFE_RESIDENCE: LifeRegime = {
  * so a hardcoded threshold would understate residence tax. Taking the max reproduces the
  * national rule exactly and stays correct for residence (練馬区: "有利な適用方法を選択").
  */
-const lifeCategoryDeduction = (newPremium: number, oldPremium: number, r: LifeRegime): number => {
-  const newDed = Math.min(applyBands(newPremium, r.newBands), r.newCategoryCap);
-  const oldDed = Math.min(applyBands(oldPremium, r.oldBands), r.oldCategoryCap);
-  const combined = Math.min(newDed + oldDed, r.newCategoryCap);
+const lifeCategoryDeduction = (
+  newPremium: number,
+  oldPremium: number,
+  regime: LifeRegime,
+): number => {
+  const newDed = Math.min(applyBands(newPremium, regime.newBands), regime.newCategoryCap);
+  const oldDed = Math.min(applyBands(oldPremium, regime.oldBands), regime.oldCategoryCap);
+  const combined = Math.min(newDed + oldDed, regime.newCategoryCap);
   return Math.max(newDed, oldDed, combined);
 };
 
-const lifeDeductionForRegime = (input: LifeInsuranceInput, r: LifeRegime): number => {
+const lifeDeductionForRegime = (
+  input: LifeInsuranceInput,
+  regime: LifeRegime,
+  generalRegime: LifeRegime = regime,
+): number => {
+  // The child-rearing raise applies to the 一般 category only, so it uses `generalRegime` (which
+  // differs from `regime` only when the raise is in effect); 介護医療, 個人年金, and the overall cap
+  // always use the base `regime`.
   const total =
-    lifeCategoryDeduction(input.generalNew, input.generalOld ?? 0, r) +
-    lifeCategoryDeduction(input.medicalCareNew, 0, r) + // 介護医療: new-contract only.
-    lifeCategoryDeduction(input.pensionNew, input.pensionOld ?? 0, r);
-  return Math.min(total, r.overallCap);
+    lifeCategoryDeduction(input.generalNew, input.generalOld ?? 0, generalRegime) +
+    lifeCategoryDeduction(input.medicalCareNew, 0, regime) + // 介護医療: new-contract only.
+    lifeCategoryDeduction(input.pensionNew, input.pensionOld ?? 0, regime);
+  return Math.min(total, regime.overallCap);
 };
 
 /**
  * Life insurance premium deduction (生命保険料控除) from annual premiums, split by tax.
  * Sums the three categories (一般 / 介護医療 / 個人年金) and applies the overall cap
  * (¥120,000 national / ¥70,000 residence).
+ *
+ * For an eligible child-rearing year (`year`) with a 23歳未満 dependent (`hasDependentUnder23`),
+ * the 一般 (new-contract) income-tax cap is raised to ¥60,000. Residence tax is never affected.
+ *
+ * @param year                 Income (tax) year being modeled.
+ * @param hasDependentUnder23  Whether the taxpayer has a 23歳未満の扶養親族.
  */
-export const calculateLifeInsuranceDeduction = (input: LifeInsuranceInput): DeductionAmount => ({
-  national: lifeDeductionForRegime(input, LIFE_NATIONAL),
-  residence: lifeDeductionForRegime(input, LIFE_RESIDENCE),
-});
+export const calculateLifeInsuranceDeduction = (
+  input: LifeInsuranceInput,
+  year: number,
+  hasDependentUnder23: boolean,
+): DeductionAmount => {
+  // The raise applies to the 一般 category of national income tax only, so it is passed as that
+  // category's regime; every other category uses the base national regime.
+  const generalRaised = hasDependentUnder23 && isChildRearingLifeExpansionYear(year);
+  const nationalGeneralRegime = generalRaised ? LIFE_GENERAL_NATIONAL_CHILD_REARING : LIFE_NATIONAL;
+  return {
+    national: lifeDeductionForRegime(input, LIFE_NATIONAL, nationalGeneralRegime),
+    residence: lifeDeductionForRegime(input, LIFE_RESIDENCE),
+  };
+};
 
 // 地震保険料控除 — the 旧長期損害保険料 sub-portion (the 地震保険料 portion is handled inline).
 const QUAKE_OLD_LONG_TERM_NATIONAL: ReadonlyArray<DeductionBand> = [
@@ -184,6 +247,7 @@ if (import.meta.env.DEV) {
   // Each band table must be ascending by `upTo` and terminate with an Infinity band.
   const tables: Record<string, ReadonlyArray<DeductionBand>> = {
     LIFE_NEW_NATIONAL,
+    LIFE_NEW_NATIONAL_CHILD_REARING: LIFE_NEW_GENERAL_NATIONAL_CHILD_REARING,
     LIFE_OLD_NATIONAL,
     LIFE_NEW_RESIDENCE,
     LIFE_OLD_RESIDENCE,

--- a/src/data/insuranceDeductions.ts
+++ b/src/data/insuranceDeductions.ts
@@ -35,44 +35,49 @@ interface DeductionBand {
 }
 
 /**
- * Rounds a raw deduction up to the next whole yen (1円未満切上げ). Premiums are usually
- * round figures, so this only bites on the ½/¼ formulas with odd premiums. The small
- * epsilon keeps an exactly-integer result (e.g. 30000.0000001 from float error) from
- * rounding spuriously up to 30001.
+ * Rounds a raw deduction up to the next whole yen (1円未満切上げ). The band formulas divide only by
+ * 2 and 4, so their results are exactly representable (integer or .25/.5/.75) — no float-error
+ * guard is needed and plain Math.ceil suffices.
  */
-const roundUpYen = (amount: number): number => {
-  const rounded = Math.ceil(amount - 1e-9);
-  // Math.ceil(-1e-9) yields -0; normalize so deduction outputs never carry a negative zero.
-  return rounded === 0 ? 0 : rounded;
-};
-
 const applyBands = (premium: number, bands: ReadonlyArray<DeductionBand>): number => {
   const p = Math.max(0, premium);
   for (const band of bands) {
-    if (p <= band.upTo) return roundUpYen(band.amount(p));
+    if (p <= band.upTo) return Math.ceil(band.amount(p));
   }
   return 0; // Unreachable: the last band is always upTo: Infinity.
 };
 
 // 生命保険料控除 — per-category bands, new (新契約) and old (旧契約) regimes.
+/**
+ * @see 生命保険料控除 (national): NTA No.1140 https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm
+ */
 const LIFE_NEW_NATIONAL: ReadonlyArray<DeductionBand> = [
   { upTo: 20_000, amount: p => p },
   { upTo: 40_000, amount: p => p / 2 + 10_000 },
   { upTo: 80_000, amount: p => p / 4 + 20_000 },
   { upTo: Infinity, amount: () => 40_000 },
 ];
+/**
+ * @see 生命保険料控除 (national): NTA No.1140 https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm
+ */
 const LIFE_OLD_NATIONAL: ReadonlyArray<DeductionBand> = [
   { upTo: 25_000, amount: p => p },
   { upTo: 50_000, amount: p => p / 2 + 12_500 },
   { upTo: 100_000, amount: p => p / 4 + 25_000 },
   { upTo: Infinity, amount: () => 50_000 },
 ];
+/**
+ * @see 生命保険料控除 (residence): 練馬区 https://www.city.nerima.tokyo.jp/kurashi/zei/jyuminzei/shotokukojo/seimeihokenryokojo.html
+ */
 const LIFE_NEW_RESIDENCE: ReadonlyArray<DeductionBand> = [
   { upTo: 12_000, amount: p => p },
   { upTo: 32_000, amount: p => p / 2 + 6_000 },
   { upTo: 56_000, amount: p => p / 4 + 14_000 },
   { upTo: Infinity, amount: () => 28_000 },
 ];
+/**
+ * @see 生命保険料控除 (residence): 練馬区 https://www.city.nerima.tokyo.jp/kurashi/zei/jyuminzei/shotokukojo/seimeihokenryokojo.html
+ */
 const LIFE_OLD_RESIDENCE: ReadonlyArray<DeductionBand> = [
   { upTo: 15_000, amount: p => p },
   { upTo: 40_000, amount: p => p / 2 + 7_500 },
@@ -103,30 +108,30 @@ const CHILD_REARING_LIFE_EXPANSION_YEARS: ReadonlySet<number> = new Set([2026, 2
 export const isChildRearingLifeExpansionYear = (year: number): boolean =>
   CHILD_REARING_LIFE_EXPANSION_YEARS.has(year);
 
-/** Per-category and overall caps for one tax regime. */
+/**
+ * Caps for one tax regime. The per-category new-only and old-only amounts are capped by their own
+ * band tables (the flat last row IS the statutory per-category maximum — NTA No.1140), so only the
+ * statute's cross-cutting caps are stored here.
+ */
 interface LifeRegime {
   newBands: ReadonlyArray<DeductionBand>;
   oldBands: ReadonlyArray<DeductionBand>;
-  /** Cap on the new-only and the new+old combined methods. */
-  newCategoryCap: number;
-  /** Cap on the old-only method. */
-  oldCategoryCap: number;
-  /** Cap on the sum of all categories. */
+  /** Statutory cap on a category's new + old combined deduction. */
+  combinedCap: number;
+  /** Cap on the sum of all categories (¥120,000 national, ¥70,000 residence). */
   overallCap: number;
 }
 
 const LIFE_NATIONAL: LifeRegime = {
   newBands: LIFE_NEW_NATIONAL,
   oldBands: LIFE_OLD_NATIONAL,
-  newCategoryCap: 40_000,
-  oldCategoryCap: 50_000,
+  combinedCap: 40_000,
   overallCap: 120_000,
 };
 const LIFE_RESIDENCE: LifeRegime = {
   newBands: LIFE_NEW_RESIDENCE,
   oldBands: LIFE_OLD_RESIDENCE,
-  newCategoryCap: 28_000,
-  oldCategoryCap: 35_000,
+  combinedCap: 28_000,
   overallCap: 70_000,
 };
 
@@ -138,13 +143,14 @@ const LIFE_RESIDENCE: LifeRegime = {
 const LIFE_GENERAL_NATIONAL_CHILD_REARING: LifeRegime = {
   ...LIFE_NATIONAL,
   newBands: LIFE_NEW_GENERAL_NATIONAL_CHILD_REARING,
-  newCategoryCap: 60_000,
+  combinedCap: 60_000,
 };
 
 /**
  * Deduction for one life-insurance category (一般 or 個人年金), which may hold both old and
- * new contracts. Computed cap-agnostically as the most favourable of: new-only (cap
- * newCategoryCap), old-only (cap oldCategoryCap), and new+old combined (cap newCategoryCap).
+ * new contracts. The new-only and old-only amounts are each capped by their own band table (the
+ * flat last row), so the only explicit cap here is the statutory new+old combined limit. Computed
+ * cap-agnostically as the most favourable of: new-only, old-only, and new+old combined.
  *
  * This deliberately does NOT hardcode the NTA's "old premium > ¥60,000" rule from
  * https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm: that ¥60,000 is the
@@ -158,9 +164,9 @@ const lifeCategoryDeduction = (
   oldPremium: number,
   regime: LifeRegime,
 ): number => {
-  const newDed = Math.min(applyBands(newPremium, regime.newBands), regime.newCategoryCap);
-  const oldDed = Math.min(applyBands(oldPremium, regime.oldBands), regime.oldCategoryCap);
-  const combined = Math.min(newDed + oldDed, regime.newCategoryCap);
+  const newDed = applyBands(newPremium, regime.newBands);
+  const oldDed = applyBands(oldPremium, regime.oldBands);
+  const combined = Math.min(newDed + oldDed, regime.combinedCap);
   return Math.max(newDed, oldDed, combined);
 };
 
@@ -211,6 +217,9 @@ const QUAKE_OLD_LONG_TERM_NATIONAL: ReadonlyArray<DeductionBand> = [
   { upTo: 20_000, amount: p => p / 2 + 5_000 },
   { upTo: Infinity, amount: () => 15_000 },
 ];
+/**
+ * @see 地震保険料控除 (residence): 練馬区 https://www.city.nerima.tokyo.jp/kurashi/zei/jyuminzei/shotokukojo/jishinhokenryoukojo.html
+ */
 const QUAKE_OLD_LONG_TERM_RESIDENCE: ReadonlyArray<DeductionBand> = [
   { upTo: 5_000, amount: p => p },
   { upTo: 15_000, amount: p => p / 2 + 2_500 },
@@ -236,7 +245,7 @@ export const calculateEarthquakeInsuranceDeduction = (
   const oldNational = applyBands(longTermOld, QUAKE_OLD_LONG_TERM_NATIONAL);
   const national = Math.min(quakeNational + oldNational, QUAKE_OVERALL_CAP_NATIONAL);
 
-  const quakeResidence = Math.min(roundUpYen(earthquake / 2), QUAKE_OVERALL_CAP_RESIDENCE);
+  const quakeResidence = Math.min(Math.ceil(earthquake / 2), QUAKE_OVERALL_CAP_RESIDENCE);
   const oldResidence = applyBands(longTermOld, QUAKE_OLD_LONG_TERM_RESIDENCE);
   const residence = Math.min(quakeResidence + oldResidence, QUAKE_OVERALL_CAP_RESIDENCE);
 

--- a/src/data/insuranceDeductions.ts
+++ b/src/data/insuranceDeductions.ts
@@ -239,7 +239,7 @@ export const calculateEarthquakeInsuranceDeduction = (
   input: EarthquakeInsuranceInput,
 ): DeductionAmount => {
   const earthquake = Math.max(0, input.earthquake);
-  const longTermOld = Math.max(0, input.longTermOld ?? 0);
+  const longTermOld = Math.max(0, input.longTermOld);
 
   const quakeNational = Math.min(earthquake, QUAKE_OVERALL_CAP_NATIONAL);
   const oldNational = applyBands(longTermOld, QUAKE_OLD_LONG_TERM_NATIONAL);

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -141,8 +141,8 @@ export interface LifeInsuranceInput {
 export interface EarthquakeInsuranceInput {
   /** 地震保険料 paid in the year. */
   earthquake: number;
-  /** 旧長期損害保険料 — qualifying pre-2007 long-term casualty contracts. */
-  longTermOld?: number;
+  /** 旧長期損害保険料 — qualifying pre-2007 long-term casualty contracts (0 if none). */
+  longTermOld: number;
 }
 
 /** User input for the medical expense deduction (医療費控除). Amounts in yen. */
@@ -152,6 +152,28 @@ export interface MedicalExpensesInput {
   /** Amounts reimbursed by insurance, etc. (保険金などで補填される金額). */
   reimbursed: number;
 }
+
+/**
+ * Zero-value defaults for the additional-deduction inputs. The modal always shows these fields
+ * (defaulting to 0), so "nothing entered" is all-zeros rather than absent — which is why these
+ * inputs are required, not optional. Use these to seed form state, and spread
+ * {@link EMPTY_ADDITIONAL_DEDUCTION_INPUTS} in tests to satisfy the required fields in one line.
+ */
+export const EMPTY_LIFE_INSURANCE: LifeInsuranceInput = {
+  generalNew: 0,
+  medicalCareNew: 0,
+  pensionNew: 0,
+};
+export const EMPTY_EARTHQUAKE_INSURANCE: EarthquakeInsuranceInput = {
+  earthquake: 0,
+  longTermOld: 0,
+};
+export const EMPTY_MEDICAL_EXPENSES: MedicalExpensesInput = { paid: 0, reimbursed: 0 };
+export const EMPTY_ADDITIONAL_DEDUCTION_INPUTS = {
+  lifeInsurance: EMPTY_LIFE_INSURANCE,
+  earthquakeInsurance: EMPTY_EARTHQUAKE_INSURANCE,
+  medicalExpenses: EMPTY_MEDICAL_EXPENSES,
+};
 
 /** One line in the additional-deductions breakdown, with its per-tax amounts (yen). */
 export interface AdditionalDeductionItem {
@@ -212,9 +234,9 @@ export interface TakeHomeFormState {
   customEHIRates?: CustomEmployeesHealthInsuranceRates | undefined;
   savedIncomeStreams?: IncomeStream[];
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
-  lifeInsurance?: LifeInsuranceInput | undefined;
-  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
-  medicalExpenses?: MedicalExpensesInput | undefined;
+  lifeInsurance: LifeInsuranceInput;
+  earthquakeInsurance: EarthquakeInsuranceInput;
+  medicalExpenses: MedicalExpensesInput;
 }
 
 /** Interface for Calculation Logic (clean, normalized inputs) */
@@ -235,9 +257,9 @@ export interface TakeHomeInputs {
    */
   incomeYear: number;
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
-  lifeInsurance?: LifeInsuranceInput | undefined;
-  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
-  medicalExpenses?: MedicalExpensesInput | undefined;
+  lifeInsurance: LifeInsuranceInput;
+  earthquakeInsurance: EarthquakeInsuranceInput;
+  medicalExpenses: MedicalExpensesInput;
 }
 
 export interface CustomEmployeesHealthInsuranceRates {
@@ -287,7 +309,7 @@ export interface TakeHomeResults {
   taxableIncomeForResidenceTax?: number | undefined;
   furusatoNozei: FurusatoNozeiDetails;
   homeLoanTaxCredit?: HomeLoanTaxCreditResult;
-  additionalDeductions?: AdditionalDeductionsResult | undefined;
+  additionalDeductions: AdditionalDeductionsResult;
   /**
    * Residence tax income-based portion (所得割) BEFORE the home loan credit spillover, for
    * display. Not simply (post-credit 所得割 + appliedToResidenceTax): the city and prefectural

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -155,7 +155,7 @@ export interface MedicalExpensesInput {
 
 /** One line in the additional-deductions breakdown, with its per-tax amounts (yen). */
 export interface AdditionalDeductionItem {
-  key: 'lifeInsurance' | 'earthquakeInsurance' | 'medical' | 'other';
+  key: 'lifeInsurance' | 'earthquakeInsurance' | 'medical';
   /** Display label (Japanese deduction name), e.g. '生命保険料控除'. */
   label: string;
   /** Amount deductible against national income tax. */
@@ -215,7 +215,6 @@ export interface TakeHomeFormState {
   lifeInsurance?: LifeInsuranceInput | undefined;
   earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
   medicalExpenses?: MedicalExpensesInput | undefined;
-  otherIncomeDeductions?: number | undefined;
 }
 
 /** Interface for Calculation Logic (clean, normalized inputs) */
@@ -239,7 +238,6 @@ export interface TakeHomeInputs {
   lifeInsurance?: LifeInsuranceInput | undefined;
   earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
   medicalExpenses?: MedicalExpensesInput | undefined;
-  otherIncomeDeductions?: number | undefined;
 }
 
 export interface CustomEmployeesHealthInsuranceRates {

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -178,8 +178,6 @@ export const EMPTY_ADDITIONAL_DEDUCTION_INPUTS = {
 /** One line in the additional-deductions breakdown, with its per-tax amounts (yen). */
 export interface AdditionalDeductionItem {
   key: 'lifeInsurance' | 'earthquakeInsurance' | 'medical';
-  /** Display label (Japanese deduction name), e.g. '生命保険料控除'. */
-  label: string;
   /** Amount deductible against national income tax. */
   national: number;
   /** Amount deductible against residence tax. */

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -116,6 +116,70 @@ export interface HomeLoanTaxCreditResult {
 }
 
 /**
+ * User input for the life insurance premium deduction (生命保険料控除). All values are
+ * annual premiums paid, in yen. New-contract (新契約) categories are 2012-01-01-onward
+ * policies; old-contract (旧契約) categories are pre-2012 policies. 介護医療 has no
+ * old-contract equivalent.
+ */
+export interface LifeInsuranceInput {
+  /** 一般生命保険料 — new contract (新契約). */
+  generalNew: number;
+  /** 介護医療保険料 — new contract only. */
+  medicalCareNew: number;
+  /** 個人年金保険料 — new contract (新契約). */
+  pensionNew: number;
+  /** 一般生命保険料 — old contract (旧契約, pre-2012). */
+  generalOld?: number;
+  /** 個人年金保険料 — old contract (旧契約, pre-2012). */
+  pensionOld?: number;
+}
+
+/**
+ * User input for the earthquake insurance premium deduction (地震保険料控除). Values are
+ * annual premiums in yen.
+ */
+export interface EarthquakeInsuranceInput {
+  /** 地震保険料 paid in the year. */
+  earthquake: number;
+  /** 旧長期損害保険料 — qualifying pre-2007 long-term casualty contracts. */
+  longTermOld?: number;
+}
+
+/** User input for the medical expense deduction (医療費控除). Amounts in yen. */
+export interface MedicalExpensesInput {
+  /** Total medical expenses paid (支払った医療費の合計). */
+  paid: number;
+  /** Amounts reimbursed by insurance, etc. (保険金などで補填される金額). */
+  reimbursed: number;
+}
+
+/** One line in the additional-deductions breakdown, with its per-tax amounts (yen). */
+export interface AdditionalDeductionItem {
+  key: 'lifeInsurance' | 'earthquakeInsurance' | 'medical' | 'other';
+  /** Display label (Japanese deduction name), e.g. '生命保険料控除'. */
+  label: string;
+  /** Amount deductible against national income tax. */
+  national: number;
+  /** Amount deductible against residence tax. */
+  residence: number;
+}
+
+/**
+ * Aggregated additional income deductions (所得控除) entered in the modal, beyond the
+ * basic, dependent, social-insurance, and iDeCo deductions handled elsewhere. Shaped like
+ * {@link DependentDeductionResults}: per-tax totals plus an itemized breakdown for display.
+ * Because every member is a 物的控除, none of these affect the residence-tax 調整控除.
+ */
+export interface AdditionalDeductionsResult {
+  /** Total deductible against national income tax (yen). */
+  national: number;
+  /** Total deductible against residence tax (yen). */
+  residence: number;
+  /** Per-item breakdown; only items contributing a positive amount are included. */
+  items: AdditionalDeductionItem[];
+}
+
+/**
  * The most recent income (tax) year the calculator has data and rules for, and the
  * default written into form state.
  *
@@ -148,6 +212,10 @@ export interface TakeHomeFormState {
   customEHIRates?: CustomEmployeesHealthInsuranceRates | undefined;
   savedIncomeStreams?: IncomeStream[];
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
+  lifeInsurance?: LifeInsuranceInput | undefined;
+  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
+  medicalExpenses?: MedicalExpensesInput | undefined;
+  otherIncomeDeductions?: number | undefined;
 }
 
 /** Interface for Calculation Logic (clean, normalized inputs) */
@@ -168,6 +236,10 @@ export interface TakeHomeInputs {
    */
   incomeYear: number;
   homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
+  lifeInsurance?: LifeInsuranceInput | undefined;
+  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
+  medicalExpenses?: MedicalExpensesInput | undefined;
+  otherIncomeDeductions?: number | undefined;
 }
 
 export interface CustomEmployeesHealthInsuranceRates {
@@ -217,6 +289,7 @@ export interface TakeHomeResults {
   taxableIncomeForResidenceTax?: number | undefined;
   furusatoNozei: FurusatoNozeiDetails;
   homeLoanTaxCredit?: HomeLoanTaxCreditResult;
+  additionalDeductions?: AdditionalDeductionsResult | undefined;
   /**
    * Residence tax income-based portion (所得割) BEFORE the home loan credit spillover, for
    * display. Not simply (post-credit 所得割 + appliedToResidenceTax): the city and prefectural

--- a/src/utils/additionalDeductions.ts
+++ b/src/utils/additionalDeductions.ts
@@ -1,0 +1,114 @@
+// Copyright the original author or authors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Aggregates the "additional" income deductions (所得控除) entered in the Additional
+ * Deductions & Credits modal — life insurance, earthquake insurance, medical expenses, and
+ * a free-form "other" amount — into a single {@link AdditionalDeductionsResult} with per-tax
+ * totals and an itemized breakdown for display.
+ *
+ * Split-amount deductions (life, earthquake) come from `data/insuranceDeductions.ts`.
+ * Medical and "other" reduce income tax and residence tax by the same amount and so carry a
+ * single figure. None of these are 人的控除, so none affect the residence-tax 調整控除.
+ */
+
+import type {
+  AdditionalDeductionItem,
+  AdditionalDeductionsResult,
+  EarthquakeInsuranceInput,
+  LifeInsuranceInput,
+  MedicalExpensesInput,
+} from '../types/tax';
+import {
+  calculateEarthquakeInsuranceDeduction,
+  calculateLifeInsuranceDeduction,
+} from '../data/insuranceDeductions';
+
+/** Medical expense deduction floor: the lower of ¥100,000 and 5% of total income. */
+const MEDICAL_DEDUCTION_FLOOR_CAP = 100_000;
+const MEDICAL_DEDUCTION_INCOME_RATE = 0.05;
+/** Statutory maximum medical expense deduction. */
+const MEDICAL_DEDUCTION_MAX = 2_000_000;
+
+/**
+ * Medical expense deduction (医療費控除). Equal for income tax and residence tax.
+ *
+ *   deduction = clamp((paid − reimbursed) − min(¥100,000, netIncome × 5%), 0, ¥2,000,000)
+ *
+ * `netIncome` is the taxpayer's 合計所得金額, used here in place of 総所得金額等 — they
+ * coincide for the income types this calculator models. Source: NTA No.1120
+ * https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm
+ */
+export const calculateMedicalExpenseDeduction = (
+  paid: number,
+  reimbursed: number,
+  netIncome: number,
+): number => {
+  const netPaid = Math.max(0, paid - Math.max(0, reimbursed));
+  const floor = Math.min(
+    MEDICAL_DEDUCTION_FLOOR_CAP,
+    Math.max(0, netIncome) * MEDICAL_DEDUCTION_INCOME_RATE,
+  );
+  const deduction = Math.floor(netPaid - floor);
+  return Math.min(Math.max(0, deduction), MEDICAL_DEDUCTION_MAX);
+};
+
+/** Free-form "other" income deduction: the user supplies the deduction amount directly. */
+export const calculateOtherIncomeDeduction = (amount: number | undefined): number =>
+  Math.max(0, Math.floor(amount ?? 0));
+
+/** The subset of inputs the additional-deduction aggregation reads. */
+export interface AdditionalDeductionInputs {
+  lifeInsurance?: LifeInsuranceInput | undefined;
+  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
+  medicalExpenses?: MedicalExpensesInput | undefined;
+  otherIncomeDeductions?: number | undefined;
+}
+
+/**
+ * Aggregates the additional income deductions into per-tax totals plus an itemized
+ * breakdown. Only items contributing a positive amount appear in `items`. `netIncome`
+ * (合計所得金額) is needed for the medical-expense income floor.
+ */
+export const calculateAdditionalDeductions = (
+  inputs: AdditionalDeductionInputs,
+  netIncome: number,
+): AdditionalDeductionsResult => {
+  const items: AdditionalDeductionItem[] = [];
+
+  if (inputs.lifeInsurance) {
+    const d = calculateLifeInsuranceDeduction(inputs.lifeInsurance);
+    if (d.national > 0 || d.residence > 0) {
+      items.push({ key: 'lifeInsurance', label: '生命保険料控除', ...d });
+    }
+  }
+
+  if (inputs.earthquakeInsurance) {
+    const d = calculateEarthquakeInsuranceDeduction(inputs.earthquakeInsurance);
+    if (d.national > 0 || d.residence > 0) {
+      items.push({ key: 'earthquakeInsurance', label: '地震保険料控除', ...d });
+    }
+  }
+
+  if (inputs.medicalExpenses) {
+    const m = calculateMedicalExpenseDeduction(
+      inputs.medicalExpenses.paid,
+      inputs.medicalExpenses.reimbursed,
+      netIncome,
+    );
+    if (m > 0) {
+      items.push({ key: 'medical', label: '医療費控除', national: m, residence: m });
+    }
+  }
+
+  const other = calculateOtherIncomeDeduction(inputs.otherIncomeDeductions);
+  if (other > 0) {
+    items.push({ key: 'other', label: 'その他の所得控除', national: other, residence: other });
+  }
+
+  return {
+    national: items.reduce((sum, item) => sum + item.national, 0),
+    residence: items.reduce((sum, item) => sum + item.residence, 0),
+    items,
+  };
+};

--- a/src/utils/additionalDeductions.ts
+++ b/src/utils/additionalDeductions.ts
@@ -26,7 +26,7 @@ import {
 } from '../data/insuranceDeductions';
 import { hasDependentRelativeUnder23 } from './dependentDeductions';
 
-/** Medical expense deduction floor: the lower of ¥100,000 and 5% of total income. */
+/** Medical expense deduction floor: the lower of ¥100,000 and 5% of total net income. */
 const MEDICAL_DEDUCTION_FLOOR_CAP = 100_000;
 const MEDICAL_DEDUCTION_INCOME_RATE = 0.05;
 /** Statutory maximum medical expense deduction. */
@@ -37,8 +37,10 @@ const MEDICAL_DEDUCTION_MAX = 2_000_000;
  *
  *   deduction = clamp((paid − reimbursed) − min(¥100,000, netIncome × 5%), 0, ¥2,000,000)
  *
- * `netIncome` is the taxpayer's 合計所得金額, used here in place of 総所得金額等 — they
- * coincide for the income types this calculator models. Source: NTA No.1120
+ * The statutory floor base is 総所得金額等; `netIncome` is the taxpayer's 合計所得金額, used here as
+ * a stand-in. The two differ only by carried-forward losses (純損失・雑損失等の繰越控除): 総所得金額等
+ * is after applying them, 合計所得金額 is before. This calculator models no loss carryforwards, so the
+ * two coincide and the substitution is exact. Source: NTA No.1120
  * https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm
  */
 export const calculateMedicalExpenseDeduction = (

--- a/src/utils/additionalDeductions.ts
+++ b/src/utils/additionalDeductions.ts
@@ -63,9 +63,9 @@ export const calculateMedicalExpenseDeduction = (
 export interface AdditionalDeductionInputs {
   incomeYear: number;
   dependents: Dependent[];
-  lifeInsurance?: LifeInsuranceInput | undefined;
-  earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
-  medicalExpenses?: MedicalExpensesInput | undefined;
+  lifeInsurance: LifeInsuranceInput;
+  earthquakeInsurance: EarthquakeInsuranceInput;
+  medicalExpenses: MedicalExpensesInput;
 }
 
 /**
@@ -79,38 +79,32 @@ export const calculateAdditionalDeductions = (
 ): AdditionalDeductionsResult => {
   const items: AdditionalDeductionItem[] = [];
 
-  if (inputs.lifeInsurance) {
-    const deduction = calculateLifeInsuranceDeduction(
-      inputs.lifeInsurance,
-      inputs.incomeYear,
-      hasDependentRelativeUnder23(inputs.dependents, inputs.incomeYear),
-    );
-    if (deduction.national > 0 || deduction.residence > 0) {
-      items.push({ key: 'lifeInsurance', label: '生命保険料控除', ...deduction });
-    }
+  const lifeDeduction = calculateLifeInsuranceDeduction(
+    inputs.lifeInsurance,
+    inputs.incomeYear,
+    hasDependentRelativeUnder23(inputs.dependents, inputs.incomeYear),
+  );
+  if (lifeDeduction.national > 0 || lifeDeduction.residence > 0) {
+    items.push({ key: 'lifeInsurance', label: '生命保険料控除', ...lifeDeduction });
   }
 
-  if (inputs.earthquakeInsurance) {
-    const deduction = calculateEarthquakeInsuranceDeduction(inputs.earthquakeInsurance);
-    if (deduction.national > 0 || deduction.residence > 0) {
-      items.push({ key: 'earthquakeInsurance', label: '地震保険料控除', ...deduction });
-    }
+  const earthquakeDeduction = calculateEarthquakeInsuranceDeduction(inputs.earthquakeInsurance);
+  if (earthquakeDeduction.national > 0 || earthquakeDeduction.residence > 0) {
+    items.push({ key: 'earthquakeInsurance', label: '地震保険料控除', ...earthquakeDeduction });
   }
 
-  if (inputs.medicalExpenses) {
-    const deduction = calculateMedicalExpenseDeduction(
-      inputs.medicalExpenses.paid,
-      inputs.medicalExpenses.reimbursed,
-      netIncome,
-    );
-    if (deduction > 0) {
-      items.push({
-        key: 'medical',
-        label: '医療費控除',
-        national: deduction,
-        residence: deduction,
-      });
-    }
+  const medicalDeduction = calculateMedicalExpenseDeduction(
+    inputs.medicalExpenses.paid,
+    inputs.medicalExpenses.reimbursed,
+    netIncome,
+  );
+  if (medicalDeduction > 0) {
+    items.push({
+      key: 'medical',
+      label: '医療費控除',
+      national: medicalDeduction,
+      residence: medicalDeduction,
+    });
   }
 
   return {

--- a/src/utils/additionalDeductions.ts
+++ b/src/utils/additionalDeductions.ts
@@ -19,10 +19,12 @@ import type {
   LifeInsuranceInput,
   MedicalExpensesInput,
 } from '../types/tax';
+import type { Dependent } from '../types/dependents';
 import {
   calculateEarthquakeInsuranceDeduction,
   calculateLifeInsuranceDeduction,
 } from '../data/insuranceDeductions';
+import { hasDependentRelativeUnder23 } from './dependentDeductions';
 
 /** Medical expense deduction floor: the lower of ¥100,000 and 5% of total income. */
 const MEDICAL_DEDUCTION_FLOOR_CAP = 100_000;
@@ -53,17 +55,23 @@ export const calculateMedicalExpenseDeduction = (
   return Math.min(Math.max(0, deduction), MEDICAL_DEDUCTION_MAX);
 };
 
-/** The subset of inputs the additional-deduction aggregation reads. */
+/**
+ * The subset of inputs the additional-deduction aggregation reads — a structural subset of
+ * TakeHomeInputs, so the full inputs object satisfies it. `incomeYear` and `dependents` drive the
+ * child-rearing 生命保険料控除 expansion (令和8・9年分); the rest are the figures entered in the modal.
+ */
 export interface AdditionalDeductionInputs {
+  incomeYear: number;
+  dependents: Dependent[];
   lifeInsurance?: LifeInsuranceInput | undefined;
   earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
   medicalExpenses?: MedicalExpensesInput | undefined;
 }
 
 /**
- * Aggregates the additional income deductions into per-tax totals plus an itemized
- * breakdown. Only items contributing a positive amount appear in `items`. `netIncome`
- * (合計所得金額) is needed for the medical-expense income floor.
+ * Aggregates the additional income deductions into per-tax totals plus an itemized breakdown.
+ * Only items contributing a positive amount appear in `items`. `netIncome` (合計所得金額) is needed
+ * for the medical-expense income floor.
  */
 export const calculateAdditionalDeductions = (
   inputs: AdditionalDeductionInputs,
@@ -72,27 +80,36 @@ export const calculateAdditionalDeductions = (
   const items: AdditionalDeductionItem[] = [];
 
   if (inputs.lifeInsurance) {
-    const d = calculateLifeInsuranceDeduction(inputs.lifeInsurance);
-    if (d.national > 0 || d.residence > 0) {
-      items.push({ key: 'lifeInsurance', label: '生命保険料控除', ...d });
+    const deduction = calculateLifeInsuranceDeduction(
+      inputs.lifeInsurance,
+      inputs.incomeYear,
+      hasDependentRelativeUnder23(inputs.dependents, inputs.incomeYear),
+    );
+    if (deduction.national > 0 || deduction.residence > 0) {
+      items.push({ key: 'lifeInsurance', label: '生命保険料控除', ...deduction });
     }
   }
 
   if (inputs.earthquakeInsurance) {
-    const d = calculateEarthquakeInsuranceDeduction(inputs.earthquakeInsurance);
-    if (d.national > 0 || d.residence > 0) {
-      items.push({ key: 'earthquakeInsurance', label: '地震保険料控除', ...d });
+    const deduction = calculateEarthquakeInsuranceDeduction(inputs.earthquakeInsurance);
+    if (deduction.national > 0 || deduction.residence > 0) {
+      items.push({ key: 'earthquakeInsurance', label: '地震保険料控除', ...deduction });
     }
   }
 
   if (inputs.medicalExpenses) {
-    const m = calculateMedicalExpenseDeduction(
+    const deduction = calculateMedicalExpenseDeduction(
       inputs.medicalExpenses.paid,
       inputs.medicalExpenses.reimbursed,
       netIncome,
     );
-    if (m > 0) {
-      items.push({ key: 'medical', label: '医療費控除', national: m, residence: m });
+    if (deduction > 0) {
+      items.push({
+        key: 'medical',
+        label: '医療費控除',
+        national: deduction,
+        residence: deduction,
+      });
     }
   }
 

--- a/src/utils/additionalDeductions.ts
+++ b/src/utils/additionalDeductions.ts
@@ -3,13 +3,13 @@
 
 /**
  * Aggregates the "additional" income deductions (所得控除) entered in the Additional
- * Deductions & Credits modal — life insurance, earthquake insurance, medical expenses, and
- * a free-form "other" amount — into a single {@link AdditionalDeductionsResult} with per-tax
- * totals and an itemized breakdown for display.
+ * Deductions & Credits modal — life insurance, earthquake insurance, and medical expenses —
+ * into a single {@link AdditionalDeductionsResult} with per-tax totals and an itemized
+ * breakdown for display.
  *
  * Split-amount deductions (life, earthquake) come from `data/insuranceDeductions.ts`.
- * Medical and "other" reduce income tax and residence tax by the same amount and so carry a
- * single figure. None of these are 人的控除, so none affect the residence-tax 調整控除.
+ * Medical reduces income tax and residence tax by the same amount and so carries a single
+ * figure. None of these are 人的控除, so none affect the residence-tax 調整控除.
  */
 
 import type {
@@ -53,16 +53,11 @@ export const calculateMedicalExpenseDeduction = (
   return Math.min(Math.max(0, deduction), MEDICAL_DEDUCTION_MAX);
 };
 
-/** Free-form "other" income deduction: the user supplies the deduction amount directly. */
-export const calculateOtherIncomeDeduction = (amount: number | undefined): number =>
-  Math.max(0, Math.floor(amount ?? 0));
-
 /** The subset of inputs the additional-deduction aggregation reads. */
 export interface AdditionalDeductionInputs {
   lifeInsurance?: LifeInsuranceInput | undefined;
   earthquakeInsurance?: EarthquakeInsuranceInput | undefined;
   medicalExpenses?: MedicalExpensesInput | undefined;
-  otherIncomeDeductions?: number | undefined;
 }
 
 /**
@@ -99,11 +94,6 @@ export const calculateAdditionalDeductions = (
     if (m > 0) {
       items.push({ key: 'medical', label: '医療費控除', national: m, residence: m });
     }
-  }
-
-  const other = calculateOtherIncomeDeduction(inputs.otherIncomeDeductions);
-  if (other > 0) {
-    items.push({ key: 'other', label: 'その他の所得控除', national: other, residence: other });
   }
 
   return {

--- a/src/utils/additionalDeductions.ts
+++ b/src/utils/additionalDeductions.ts
@@ -87,12 +87,12 @@ export const calculateAdditionalDeductions = (
     hasDependentRelativeUnder23(inputs.dependents, inputs.incomeYear),
   );
   if (lifeDeduction.national > 0 || lifeDeduction.residence > 0) {
-    items.push({ key: 'lifeInsurance', label: '生命保険料控除', ...lifeDeduction });
+    items.push({ key: 'lifeInsurance', ...lifeDeduction });
   }
 
   const earthquakeDeduction = calculateEarthquakeInsuranceDeduction(inputs.earthquakeInsurance);
   if (earthquakeDeduction.national > 0 || earthquakeDeduction.residence > 0) {
-    items.push({ key: 'earthquakeInsurance', label: '地震保険料控除', ...earthquakeDeduction });
+    items.push({ key: 'earthquakeInsurance', ...earthquakeDeduction });
   }
 
   const medicalDeduction = calculateMedicalExpenseDeduction(
@@ -103,7 +103,6 @@ export const calculateAdditionalDeductions = (
   if (medicalDeduction > 0) {
     items.push({
       key: 'medical',
-      label: '医療費控除',
       national: medicalDeduction,
       residence: medicalDeduction,
     });

--- a/src/utils/dependentDeductions.ts
+++ b/src/utils/dependentDeductions.ts
@@ -99,6 +99,22 @@ export function hasIncomeAdjustmentDeductionDependent(
 }
 
 /**
+ * Whether the taxpayer has a 年齢23歳未満の扶養親族: a non-spouse dependent under 23 whose
+ * 合計所得金額 is within the 扶養親族 threshold (includes children under 16). This is condition ロ
+ * of {@link hasIncomeAdjustmentDeductionDependent} on its own — it is the sole eligibility test
+ * for the child-rearing 生命保険料控除 expansion (令和8・9年分).
+ */
+export function hasDependentRelativeUnder23(dependents: Dependent[], year: number): boolean {
+  const eligibilityMax = getDependentEligibilityMax(year);
+  return dependents.some(dependent => {
+    if (dependent.relationship === 'spouse') return false; // a spouse is never a 扶養親族
+    if (calculateDependentTotalNetIncome(dependent.income, year) > eligibilityMax) return false;
+    const age = (dependent as OtherDependent).ageCategory;
+    return age === 'under16' || age === '16to18' || age === '19to22';
+  });
+}
+
+/**
  * Check if dependent is eligible for Dependent Deduction (扶養控除).
  * @see https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1180.htm
  */

--- a/src/utils/homeLoanTaxCredit.ts
+++ b/src/utils/homeLoanTaxCredit.ts
@@ -122,7 +122,7 @@ export function applyHomeLoanTaxCredit(
   if (unusedCredit > 0) {
     warnings.push(
       `¥${unusedCredit.toLocaleString()} of the credit could not be applied: it exceeds your income tax ` +
-        `plus the ¥${residenceTaxCap.toLocaleString()} residence-tax spillover cap for this year.`,
+        `plus the ¥${residenceTaxCap.toLocaleString()} spillover cap for residence tax this year.`,
     );
   }
 

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -39,6 +39,7 @@ import {
   calculateIncomeAdjustmentDeductionAmount,
 } from '../data/netEmploymentIncome';
 import { applyHomeLoanTaxCredit } from './homeLoanTaxCredit';
+import { calculateAdditionalDeductions } from './additionalDeductions';
 
 /**
  * Rounds the premium to a nearby whole yen according to the given mode.
@@ -529,6 +530,12 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
   // iDeCo and corporate DC contributions are deductible as 小規模企業共済等掛金控除
   const idecoDeduction = Math.max(0, inputs.dcPlanContributions || 0);
 
+  // Additional income deductions (生命保険料控除, 地震保険料控除, 医療費控除, その他) entered in the
+  // modal. The national and residence amounts differ for the insurance deductions; none of these
+  // are 人的控除, so none affect the residence-tax 調整控除. The medical floor needs 合計所得金額,
+  // so pass netIncome.
+  const additionalDeductions = calculateAdditionalDeductions(inputs, netIncome);
+
   const dependentDeductions = calculateDependentDeductions(
     inputs.dependents,
     incomeYear,
@@ -547,6 +554,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     netIncome -
     socialInsuranceDeduction -
     idecoDeduction -
+    additionalDeductions.national -
     nationalIncomeTaxBasicDeduction -
     dependentDeductions.nationalTax.total;
   const taxableIncomeForNationalIncomeTax = Math.max(
@@ -566,6 +574,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
         netIncome -
           socialInsuranceDeduction -
           idecoDeduction -
+          additionalDeductions.residence -
           residenceTaxBasicDeduction -
           dependentDeductions.residenceTax.total,
       ) / 1000,
@@ -578,7 +587,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
   // pre-credit residence tax, needed for the furusato 20% special-deduction cap.
   const preCreditResidenceTax = calculateResidenceTax(
     netIncome,
-    socialInsuranceDeduction + idecoDeduction,
+    socialInsuranceDeduction + idecoDeduction + additionalDeductions.residence,
     dependentDeductions,
     incomeYear,
   );
@@ -607,7 +616,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     homeLoanTaxCreditResult && homeLoanTaxCreditResult.appliedToResidenceTax > 0
       ? calculateResidenceTax(
           netIncome,
-          socialInsuranceDeduction + idecoDeduction,
+          socialInsuranceDeduction + idecoDeduction + additionalDeductions.residence,
           dependentDeductions,
           incomeYear,
           homeLoanTaxCreditResult.appliedToResidenceTax,
@@ -658,6 +667,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     taxableIncomeForResidenceTax,
     furusatoNozei: furusatoNozeiLimit,
     ...(homeLoanTaxCreditResult && { homeLoanTaxCredit: homeLoanTaxCreditResult }),
+    ...(additionalDeductions.items.length > 0 && { additionalDeductions }),
     // Residence income-based portion (所得割) BEFORE the home loan spillover, so the
     // Taxes tab can show the spillover as its own line and have the rows sum.
     ...(homeLoanTaxCreditResult &&

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -530,10 +530,9 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
   // iDeCo and corporate DC contributions are deductible as 小規模企業共済等掛金控除
   const idecoDeduction = Math.max(0, inputs.dcPlanContributions || 0);
 
-  // Additional income deductions (生命保険料控除, 地震保険料控除, 医療費控除, その他) entered in the
-  // modal. The national and residence amounts differ for the insurance deductions; none of these
-  // are 人的控除, so none affect the residence-tax 調整控除. The medical floor needs 合計所得金額,
-  // so pass netIncome.
+  // Additional income deductions (生命保険料控除, 地震保険料控除, 医療費控除) entered in the modal.
+  // The national and residence amounts differ for the insurance deductions; none of these are
+  // 人的控除, so none affect the residence-tax 調整控除. The medical floor needs 合計所得金額.
   const additionalDeductions = calculateAdditionalDeductions(inputs, netIncome);
 
   const dependentDeductions = calculateDependentDeductions(

--- a/src/utils/taxCalculations.ts
+++ b/src/utils/taxCalculations.ts
@@ -251,6 +251,7 @@ const DEFAULT_TAKE_HOME_RESULTS: TakeHomeResults = {
   grossEmploymentIncome: 0,
   incomeAdjustmentDeduction: 0,
   totalNetIncome: 0,
+  additionalDeductions: { national: 0, residence: 0, items: [] },
 };
 
 /**
@@ -666,7 +667,7 @@ export const calculateTaxes = (inputs: TakeHomeInputs): TakeHomeResults => {
     taxableIncomeForResidenceTax,
     furusatoNozei: furusatoNozeiLimit,
     ...(homeLoanTaxCreditResult && { homeLoanTaxCredit: homeLoanTaxCreditResult }),
-    ...(additionalDeductions.items.length > 0 && { additionalDeductions }),
+    additionalDeductions,
     // Residence income-based portion (所得割) BEFORE the home loan spillover, so the
     // Taxes tab can show the spillover as its own line and have the rows sum.
     ...(homeLoanTaxCreditResult &&


### PR DESCRIPTION
Add support for more income deductions in the "Additional Deductions & Credits" modal:

- **生命保険料控除** (life insurance) and **地震保険料控除** (earthquake insurance): premium-based inputs that compute the *separate* income-tax and residence-tax deduction amounts. Life covers the 一般 / 介護医療 / 個人年金 categories and the 旧契約/新契約 combined rule; earthquake covers the 地震保険料 and 旧長期損害保険料 portions.
- **医療費控除** (medical expenses): a mini-calculator — enter what you paid and any reimbursements, and it applies the income-based floor (the lower of ¥100,000 and 5% of total income) for you.
- **生命保険料控除 child-rearing expansion (令和8・9年分)**: for 2026–2027, a taxpayer with a 23歳未満の扶養親族 gets the 一般 (new-contract) income-tax cap raised from ¥40,000 to ¥60,000 (income tax only).

## How it works

- Subtracted on the national taxable-income path and both residence paths **before** the home loan credit, so credit ordering and the furusato nōzei limit stay correct. All are 物的控除, so none affect the residence 調整控除.
- The Taxes tab shows them as a single **"Other Deductions"** row per section (income tax shows national amounts, residence shows residence amounts), with a per-item breakdown tooltip — the split is visible where it matters without a row per deduction.

## Notes for reviewers

- Brackets sourced from NTA ([1140](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1140.htm), [1145](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1145.htm), [1120](https://www.nta.go.jp/taxes/shiraberu/taxanswer/shotoku/1120.htm)) and Nerima City for residence amounts; linked in code and in the deduction tooltips.
- The life-insurance old+new combined rule is implemented cap-agnostically (`max(new-only, old-only, combined)`) rather than hardcoding NTA's national ¥60,000 threshold: that threshold is national-specific (the residence break-even is ¥42,000), so a hardcoded value would understate residence tax. Tests cover both.
- **Not supported (left as follow-ups):**
  - The **セルフメディケーション税制 (医療費控除の特例)** — the medical input computes the standard 医療費控除 only, and its tooltip says so.
  - The taxpayer's own 人的控除 (障害者・寡婦・ひとり親・勤労学生), and 配当控除 / 外国税額控除.
  - 寄付控除, including furusato nozei
  - 雑損控除
