### PR TITLE
Reflect modal deductions in the take-home-by-income chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -293,6 +293,10 @@ function App({ mode, toggleColorMode }: AppProps) {
             manualSocialInsuranceEntry={inputs.manualSocialInsuranceEntry}
             manualSocialInsuranceAmount={inputs.manualSocialInsuranceAmount}
             incomeStreams={inputs.incomeStreams}
+            lifeInsurance={inputs.lifeInsurance}
+            earthquakeInsurance={inputs.earthquakeInsurance}
+            medicalExpenses={inputs.medicalExpenses}
+            homeLoanTaxCredit={inputs.homeLoanTaxCredit}
           />
         </Suspense>
 

--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -26,8 +26,11 @@ import type {
   ChartRange,
   CustomEmployeesHealthInsuranceRates,
   IncomeStream,
+  LifeInsuranceInput,
+  EarthquakeInsuranceInput,
+  MedicalExpensesInput,
+  HomeLoanTaxCreditInput,
 } from '../../types/tax';
-import { EMPTY_ADDITIONAL_DEDUCTION_INPUTS } from '../../types/tax';
 import { formatJPY } from '../../utils/formatters';
 import {
   generateChartData,
@@ -142,6 +145,10 @@ interface TakeHomeChartProps {
   manualSocialInsuranceEntry?: boolean;
   manualSocialInsuranceAmount?: number;
   incomeStreams?: IncomeStream[];
+  lifeInsurance: LifeInsuranceInput;
+  earthquakeInsurance: EarthquakeInsuranceInput;
+  medicalExpenses: MedicalExpensesInput;
+  homeLoanTaxCredit?: HomeLoanTaxCreditInput | undefined;
 }
 
 // Define a type for the mark objects
@@ -226,6 +233,10 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
   manualSocialInsuranceEntry,
   manualSocialInsuranceAmount = 0,
   incomeStreams = [],
+  lifeInsurance,
+  earthquakeInsurance,
+  medicalExpenses,
+  homeLoanTaxCredit,
 }) => {
   const theme = useTheme();
 
@@ -285,9 +296,6 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
   const chartData = useMemo<ChartData<'bar' | 'line'>>(
     () =>
       generateChartData(chartRange, {
-        // The by-income projection does not yet apply the modal's additional deductions
-        // (生命保険料/地震保険料/医療費) or the home loan credit; hold them at zero for now (follow-up).
-        ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
         isEmploymentIncome,
         incomeYear,
         isSubjectToLongTermCarePremium,
@@ -299,6 +307,10 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
         manualSocialInsuranceEntry: manualSocialInsuranceEntry ?? false,
         manualSocialInsuranceAmount,
         incomeStreams,
+        lifeInsurance,
+        earthquakeInsurance,
+        medicalExpenses,
+        homeLoanTaxCredit,
       }),
     [
       chartRange,
@@ -313,6 +325,10 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
       manualSocialInsuranceEntry,
       manualSocialInsuranceAmount,
       incomeStreams,
+      lifeInsurance,
+      earthquakeInsurance,
+      medicalExpenses,
+      homeLoanTaxCredit,
     ],
   );
 
@@ -338,8 +354,6 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
 
                 // Calculate full tax results for this income level to get cap status
                 const taxInputs = {
-                  // See note in chartData: additional deductions / home loan credit not reflected here yet.
-                  ...EMPTY_ADDITIONAL_DEDUCTION_INPUTS,
                   annualIncome: income,
                   incomeYear,
                   isEmploymentIncome,
@@ -353,6 +367,10 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
                   manualSocialInsuranceAmount,
                   incomeMode: 'salary' as const,
                   incomeStreams: [],
+                  lifeInsurance,
+                  earthquakeInsurance,
+                  medicalExpenses,
+                  homeLoanTaxCredit,
                 };
 
                 const taxResults = calculateTaxes(taxInputs);
@@ -389,6 +407,10 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
     customEHIRates,
     manualSocialInsuranceEntry,
     manualSocialInsuranceAmount,
+    lifeInsurance,
+    earthquakeInsurance,
+    medicalExpenses,
+    homeLoanTaxCredit,
   ]);
 
   // Use media query to determine if we should show minor marks


### PR DESCRIPTION
## What

The Take-Home Pay Chart personalized its by-income curve with iDeCo, dependents, and health insurance, but **not** the modal-configured life insurance (生命保険料控除), earthquake insurance (地震保険料控除), medical expenses (医療費控除), or home loan tax credit (住宅ローン控除). Those were held at zero, so once a user entered any of them, the chart's curve and current-income marker disagreed with the headline take-home figure.

This threads the user's actual `lifeInsurance` / `earthquakeInsurance` / `medicalExpenses` (now required props on `TakeHomeInputs`, since #371) and `homeLoanTaxCredit` from `App.tsx` into `TakeHomeChart`, and passes them into both call sites:

- the `generateChartData(chartRange, {...})` call that builds the bars, and
- the tooltip's `taxInputs` object used for cap detection.

The income-dependent pieces — the medical-expense floor (`min(¥100k, 5% of net income)`) and the home-loan residence-tax spillover cap — recompute per chart point automatically, since each point runs through `calculateTaxes`.

## Why

So the by-income curve and the current-income marker reflect the same deductions as the headline take-home pay.

## Notes for reviewers

- Pure prop-threading; no calculation logic changed. `generateChartData` already spreads its inputs into `TakeHomeInputs` and calls `calculateTaxes`, which has applied these fields since #371.
- Verified manually in the running app: entering ¥500,000 of medical expenses lifted the Take-Home curve at every income point (e.g. ¥5M: ¥3,942,948 → ¥4,003,348), confirming the floor recomputes per point.
- **Out of scope (separate task):** while verifying, I found the chart tooltip's "🔒 Max reached" cap badge is dead — its `taxInputs` passes `incomeStreams: []`, which makes `calculateTaxes` short-circuit to zero-income defaults, so the badge never shows. Pre-existing, untouched here; this PR just adds the (equally-ignored) deduction fields to that object for consistency.
