### PR TITLE
Fix dead cap-detection path in Take-Home Chart tooltip

### DIFF
--- a/src/components/TakeHomeCalculator/TakeHomeChart.tsx
+++ b/src/components/TakeHomeCalculator/TakeHomeChart.tsx
@@ -35,6 +35,7 @@ import { formatJPY } from '../../utils/formatters';
 import {
   generateChartData,
   getChartOptions,
+  scaleIncomeStreamsToIncome,
   currentAndMedianIncomeChartPlugin,
 } from '../../utils/chartConfig';
 import type { HealthInsuranceProviderId } from '../../types/healthInsurance';
@@ -352,9 +353,10 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
                 const band = getPercentileBand(income);
                 let info = `~${estimatedPercentile.toFixed(1)} percentile (${band.label})`;
 
-                // Calculate full tax results for this income level to get cap status
+                // Calculate full tax results for this income level to get cap status.
+                // Scale the user's actual streams to the hovered income the same way
+                // generateChartData does, so the cap badge matches the bars exactly.
                 const taxInputs = {
-                  annualIncome: income,
                   incomeYear,
                   isEmploymentIncome,
                   isSubjectToLongTermCarePremium,
@@ -365,8 +367,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
                   customEHIRates,
                   manualSocialInsuranceEntry: manualSocialInsuranceEntry ?? false,
                   manualSocialInsuranceAmount,
-                  incomeMode: 'salary' as const,
-                  incomeStreams: [],
+                  incomeStreams: scaleIncomeStreamsToIncome(incomeStreams, income),
                   lifeInsurance,
                   earthquakeInsurance,
                   medicalExpenses,
@@ -411,6 +412,7 @@ const TakeHomeChart: React.FC<TakeHomeChartProps> = ({
     earthquakeInsurance,
     medicalExpenses,
     homeLoanTaxCredit,
+    incomeStreams,
   ]);
 
   // Use media query to determine if we should show minor marks

--- a/src/utils/chartConfig.ts
+++ b/src/utils/chartConfig.ts
@@ -77,6 +77,43 @@ export interface ChartCalculationContext extends TakeHomeInputs {
   isEmploymentIncome: boolean;
 }
 
+/**
+ * Scale a set of income streams so their annualized total matches `targetIncome`,
+ * preserving the original composition (salary/bonus/business mix). When the base
+ * streams sum to 0 (or none are provided), fall back to a single annual salary
+ * stream at `targetIncome` so downstream calculations still see income.
+ *
+ * Shared by the chart's per-income bars and the tooltip's cap-detection probe so
+ * the "🔒 Max reached" badge matches the bars exactly.
+ */
+export const scaleIncomeStreamsToIncome = (
+  streams: IncomeStream[],
+  targetIncome: number,
+): IncomeStream[] => {
+  const baseTotal = streams.reduce((sum, s) => {
+    if (s.type === 'salary' && s.frequency === 'monthly') return sum + s.amount * 12;
+    return sum + s.amount;
+  }, 0);
+
+  if (baseTotal > 0) {
+    const ratio = targetIncome / baseTotal;
+    return streams.map(s => ({
+      ...s,
+      amount: s.amount * ratio,
+    }));
+  }
+
+  // Fallback if base is 0
+  return [
+    {
+      id: 'chart-salary-fallback',
+      type: 'salary',
+      amount: targetIncome,
+      frequency: 'annual',
+    },
+  ];
+};
+
 export const generateChartData = (
   chartRange: ChartRange,
   currentInputs: ChartCalculationContext,
@@ -106,29 +143,7 @@ export const generateChartData = (
   // Precompute results and cap status for each income point
   const resultsAndCaps = incomePoints.map(income => {
     // Scale each income stream to match the 'income' for this chart point
-    let calcStreams: IncomeStream[];
-    const baseTotal = currentInputs.incomeStreams.reduce((sum, s) => {
-      if (s.type === 'salary' && s.frequency === 'monthly') return sum + s.amount * 12;
-      return sum + s.amount;
-    }, 0);
-
-    if (baseTotal > 0) {
-      const ratio = income / baseTotal;
-      calcStreams = currentInputs.incomeStreams.map(s => ({
-        ...s,
-        amount: s.amount * ratio,
-      }));
-    } else {
-      // Fallback if base is 0
-      calcStreams = [
-        {
-          id: 'chart-salary-fallback',
-          type: 'salary',
-          amount: income,
-          frequency: 'annual',
-        },
-      ];
-    }
+    const calcStreams = scaleIncomeStreamsToIncome(currentInputs.incomeStreams, income);
 
     // Prepare inputs
     const inputsForCalc: TakeHomeInputs = {


### PR DESCRIPTION
## What

The Take-Home Pay Chart's tooltip has a dead cap-detection path. In the `chartOptions` `afterTitle` callback, the code built a `taxInputs` object with `incomeStreams: []` and ran it through `calculateTaxes` to decide whether to show the "🔒 Max reached: Pension, Health Insurance" badge.

But `calculateTaxes` derives income solely from `incomeStreams` (ignoring `annualIncome`/`incomeMode`) and short-circuits to all-zero defaults when the stream total is `<= 0`. So with `incomeStreams: []`, every hovered income returned the zero-income defaults, `detectCaps` ran on zeros, and the badge **never appeared for any bar**.

## Origins of the regression

The cap badge isn't new — it was introduced in #16 ("Indicators when health insurance or pension is capped") and **worked correctly** then, because the tooltip passed `annualIncome: income` and `calculateTaxes` actually read `annualIncome`.

It broke in **#160 ("Advanced income input with multiple incomes", `4c47627`, 2026-02-10)**, which made three changes in a single commit that together formed the bug:

1. **`calculateTaxes`** switched to deriving income solely from `incomeStreams` (via `calculateIncomeBreakdown`), plus the `if (totalAnnualIncome <= 0) return DEFAULT_TAKE_HOME_RESULTS` short-circuit. `annualIncome`/`incomeMode` became dead inputs.
2. **The bars (`generateChartData`)** were *correctly* migrated to scaled streams, including the `chart-salary-fallback` path — so the bars' cap borders kept working.
3. **The tooltip** switched to `incomeStreams: []` (while leaving the now-ignored `annualIncome: income` in place) — the half that was overlooked.

So #160 migrated the bars to the new income model but missed the tooltip's parallel cap computation, leaving it pointed at an empty stream list that always short-circuits to zeros. The badge has been dead for every income on every bar since 2026-02-10.

Two later PRs touched these exact lines without noticing the latent bug, because both were focused on the deduction inputs rather than the `incomeStreams: []` that neutered the calculation: #371 (added the `EMPTY_ADDITIONAL_DEDUCTION_INPUTS` placeholder) and #374 (threaded the real deductions in).

## Fix

- Extracted the stream-scaling logic out of `generateChartData` into a shared, exported `scaleIncomeStreamsToIncome(streams, targetIncome)` helper in `chartConfig.ts`. It scales the user's actual income streams to the target income (preserving the salary/bonus/business composition), falling back to a single annual salary stream when the base total is 0 — identical to what the bars already did.
- The tooltip now uses that helper (`scaleIncomeStreamsToIncome(incomeStreams, income)`) instead of `[]`, so the cap badge matches the bars exactly.
- Dropped the dead `annualIncome`/`incomeMode` fields the tooltip passed — `calculateTaxes` ignores both.
- Added `incomeStreams` to the `chartOptions` `useMemo` dependency array (the callback now closes over it).
